### PR TITLE
CLUE-489 React 18 (3/6) — slate-editor 0.13.0-pre.0 + text-tile fallout

### DIFF
--- a/.github/workflows/ci-regression.yml
+++ b/.github/workflows/ci-regression.yml
@@ -72,6 +72,7 @@ jobs:
             package-lock.json
       - uses: cypress-io/github-action@v4
         with:
+          install-command: npm ci --legacy-peer-deps
           start: npm start
           wait-on: 'http://localhost:8080'
           wait-on-timeout: 600

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
           cache-dependency-path: |
             package-lock.json
       - name: Install Dependencies
-        run: npm ci
+        run: npm ci --legacy-peer-deps
       - uses: concord-consortium/s3-deploy-action/deploy-path@v1
         id: s3-deploy-path
       - name: Lint
@@ -45,7 +45,7 @@ jobs:
             package-lock.json
             authoring-api/package-lock.json
       - name: Install Dependencies
-        run: npm ci
+        run: npm ci --legacy-peer-deps
       - name: Install Authoring API Dependencies
         working-directory: ./authoring-api
         run: npm ci
@@ -94,6 +94,7 @@ jobs:
             package-lock.json
       - uses: cypress-io/github-action@v4
         with:
+          install-command: npm ci --legacy-peer-deps
           start: npm start
           wait-on: 'http://localhost:8080'
           wait-on-timeout: 600

--- a/.github/workflows/manual-regression.yml
+++ b/.github/workflows/manual-regression.yml
@@ -90,6 +90,7 @@ jobs:
           echo "Tests to run: ${{ github.event.inputs.test }}"
       - uses: cypress-io/github-action@v4
         with:
+          install-command: npm ci --legacy-peer-deps
           start: npm start
           wait-on: 'http://localhost:8080'
           wait-on-timeout: 600
@@ -141,6 +142,7 @@ jobs:
           echo "Tests to run: ${{ github.event.inputs.test }}"
       - uses: cypress-io/github-action@v4
         with:
+          install-command: npm ci --legacy-peer-deps
           start: npm start
           wait-on: 'http://localhost:8080'
           wait-on-timeout: 600

--- a/.github/workflows/regression-daily.yml
+++ b/.github/workflows/regression-daily.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Run Cypress Tests
         uses: cypress-io/github-action@v4
         with:
+          install-command: npm ci --legacy-peer-deps
           start: npm start
           wait-on: 'http://localhost:8080'
           wait-on-timeout: 600
@@ -91,6 +92,7 @@ jobs:
       - name: Cleanup Comments
         uses: cypress-io/github-action@v4
         with:
+          install-command: npm ci --legacy-peer-deps
           start: npm start
           wait-on: 'http://localhost:8080'
           wait-on-timeout: 600

--- a/cypress/support/elements/tile/TextToolTile.js
+++ b/cypress/support/elements/tile/TextToolTile.js
@@ -18,7 +18,11 @@ class TextToolTile {
 
         this.getTextTile().last().focus();
         this.getTextEditor().last().click();
-        this.getTextEditor().last().type(text);
+        // slate-react listens for native `beforeinput` events (via addEventListener, not React
+        // synthetic props), and `cy.type()` doesn't dispatch those, so typed characters never
+        // reach the editor. `cy.realType()` from cypress-real-events uses CDP to dispatch real
+        // keyboard input.
+        cy.realType(text);
         // This doesn't guarantee the text has been saved to firebase. It would be best
         // if there was a way to tell if it has been saved perhaps by some saving indicator
         // in the UI. Or reaching into app to find some saving state.
@@ -27,7 +31,10 @@ class TextToolTile {
     }
     enterAdditionalText(text){
         this.getTextTile().last().focus();
-        this.getTextEditor().last().type('{moveToEnd}'+text);
+        // `{moveToEnd}` is a Cypress meta-key, so it has to go through `type`. The text itself
+        // needs `realType` so slate-react's native `beforeinput` listener actually fires.
+        this.getTextEditor().last().type('{moveToEnd}');
+        cy.realType(text);
         cy.wait(300);
     }
 

--- a/cypress/support/elements/tile/TextToolTile.js
+++ b/cypress/support/elements/tile/TextToolTile.js
@@ -18,11 +18,7 @@ class TextToolTile {
 
         this.getTextTile().last().focus();
         this.getTextEditor().last().click();
-        // slate-react listens for native `beforeinput` events (via addEventListener, not React
-        // synthetic props), and `cy.type()` doesn't dispatch those, so typed characters never
-        // reach the editor. `cy.realType()` from cypress-real-events uses CDP to dispatch real
-        // keyboard input.
-        cy.realType(text);
+        this._dispatchKeystrokes(text);
         // This doesn't guarantee the text has been saved to firebase. It would be best
         // if there was a way to tell if it has been saved perhaps by some saving indicator
         // in the UI. Or reaching into app to find some saving state.
@@ -31,11 +27,40 @@ class TextToolTile {
     }
     enterAdditionalText(text){
         this.getTextTile().last().focus();
-        // `{moveToEnd}` is a Cypress meta-key, so it has to go through `type`. The text itself
-        // needs `realType` so slate-react's native `beforeinput` listener actually fires.
-        this.getTextEditor().last().type('{moveToEnd}');
-        cy.realType(text);
+        this._dispatchKeystrokes('{moveToEnd}' + text);
         cy.wait(300);
+    }
+    // slate-react listens for native `beforeinput` events (via addEventListener, not React
+    // synthetic props); `cy.type()` doesn't dispatch those, so typed characters never reach
+    // the editor. We split each input into literal-text chunks (dispatched with
+    // `cy.realType`, which uses CDP to fire real keyboard input) and `{metaKey}` chunks
+    // (dispatched with `cy.realPress`). Only the meta-keys actually used in our specs are
+    // mapped — adding more is a one-line edit.
+    _dispatchKeystrokes(text){
+        const META_KEY_MAP = {
+          movetostart: 'Home',
+          movetoend: 'End',
+          enter: 'Enter',
+          end: 'End',
+          home: 'Home',
+          esc: 'Escape',
+          escape: 'Escape',
+          backspace: 'Backspace',
+          del: 'Delete',
+          delete: 'Delete',
+          tab: 'Tab',
+        };
+        const re = /\{([a-zA-Z]+)\}/g;
+        let last = 0;
+        let m;
+        while ((m = re.exec(text)) !== null) {
+          if (m.index > last) cy.realType(text.slice(last, m.index));
+          const key = META_KEY_MAP[m[1].toLowerCase()];
+          if (!key) throw new Error(`Unknown meta-key {${m[1]}} in TextToolTile keystroke dispatcher`);
+          cy.realPress(key);
+          last = m.index + m[0].length;
+        }
+        if (last < text.length) cy.realType(text.slice(last));
     }
 
     deleteText(text){

--- a/cypress/support/elements/tile/TextToolTile.js
+++ b/cypress/support/elements/tile/TextToolTile.js
@@ -33,9 +33,10 @@ class TextToolTile {
     // slate-react listens for native `beforeinput` events (via addEventListener, not React
     // synthetic props); `cy.type()` doesn't dispatch those, so typed characters never reach
     // the editor. We split each input into literal-text chunks (dispatched with
-    // `cy.realType`, which uses CDP to fire real keyboard input) and `{metaKey}` chunks
-    // (dispatched with `cy.realPress`). Only the meta-keys actually used in our specs are
-    // mapped — adding more is a one-line edit.
+    // `cy.realType`, which uses CDP to fire real keyboard input) and Cypress-style `{key}`
+    // tokens — e.g. `{moveToEnd}`, `{backspace}` — dispatched as single key presses via
+    // `cy.realPress`. Modifier combos like `Cmd+Z` aren't handled; only the standalone
+    // keys in META_KEY_MAP are mapped, and adding more is a one-line edit.
     _dispatchKeystrokes(text){
         const META_KEY_MAP = {
           movetostart: 'Home',

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,18 +10,18 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@chakra-ui/react": "^1.8.9",
+        "@chakra-ui/react": "^2.10.5",
         "@codemirror/lang-json": "^6.0.2",
         "@concord-consortium/accessibility-tools": "0.0.1-pre.1",
-        "@concord-consortium/codap-formulas-react17": "^1.1.0",
+        "@concord-consortium/codap-formulas": "1.1.0-pre.2",
         "@concord-consortium/compute-engine": "^0.12.3-cc.2",
-        "@concord-consortium/diagram-view": "1.0.2",
+        "@concord-consortium/diagram-view": "2.0.0-pre.2",
         "@concord-consortium/lara-interactive-api": "^1.12.0",
         "@concord-consortium/log-monitor": "^1.0.0",
         "@concord-consortium/mobx-state-tree": "^6.0.0-cc.1",
         "@concord-consortium/react-components": "^1.0.0",
         "@concord-consortium/react-modal-hook": "^3.0.0-cc.1",
-        "@concord-consortium/slate-editor": "^0.10.1",
+        "@concord-consortium/slate-editor": "^0.12.0",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",
         "@dnd-kit/sortable": "^10.0.0",
@@ -34,7 +34,7 @@
         "@visx/scale": "3.5.0",
         "@visx/shape": "3.5.0",
         "@visx/text": "3.3.0",
-        "chart.js": "^2.9.4",
+        "chart.js": "^4.5.1",
         "classnames": "^2.3.1",
         "client-oauth2": "^4.3.3",
         "clsx": "^1.2.1",
@@ -63,23 +63,22 @@
         "nanoid": "^3.3.4",
         "object-hash": "^3.0.0",
         "pako": "^2.1.0",
-        "patch-package": "^6.4.7",
+        "patch-package": "^8.0.1",
         "promise-assist": "^2.0.1",
         "query-string": "7.1.1",
         "rc-slider": "^10.5.0",
-        "react": "^17.0.2",
-        "react-chartjs-2": "^2.11.2",
-        "react-data-grid": "7.0.0-canary.46",
-        "react-dom": "^17.0.2",
+        "react": "^18.3.1",
+        "react-chartjs-2": "^5.3.1",
+        "react-data-grid": "7.0.0-beta.44",
+        "react-dom": "^18.3.1",
         "react-dom-factories": "^1.0.2",
         "react-error-boundary": "^4.0.11",
         "react-hook-form": "^7.63.0",
         "react-modal": "^3.15.1",
         "react-query": "^3.39.2",
-        "react-resize-detector": "^8.0.4",
+        "react-resize-detector": "^12.3.0",
         "react-select": "^5.4.0",
-        "react-sizeme": "^3.0.2",
-        "react-tabs": "^3.2.3",
+        "react-tabs": "^6.1.1",
         "react-tippy": "^1.4.0",
         "resize-observer-polyfill": "^1.5.1",
         "rete": "^2.0.3",
@@ -115,11 +114,10 @@
         "@svgr/webpack": "^6.3.1",
         "@talabes/json5-jest": "^2.0.0",
         "@testing-library/cypress": "^10.0.1",
+        "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^12.1.5",
-        "@testing-library/react-hooks": "^8.0.1",
+        "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
-        "@types/chart.js": "^2.9.37",
         "@types/color-string": "^1.5.2",
         "@types/common-tags": "^1.8.1",
         "@types/d3": "^7.4.0",
@@ -133,10 +131,10 @@
         "@types/object-hash": "^2.2.1",
         "@types/pako": "^2.0.4",
         "@types/papaparse": "^5.3.16",
-        "@types/react": "^17.0.48",
-        "@types/react-dom": "^17.0.17",
+        "@types/react": "^18.3.12",
+        "@types/react-dom": "^18.3.1",
         "@types/react-modal": "^3.13.1",
-        "@types/react-tabs": "^2.3.4",
+        "@types/react-tabs": "^5.0.5",
         "@types/rtree": "^1.4.28",
         "@types/superagent": "^4.1.15",
         "@types/uuid": "^8.3.4",
@@ -188,7 +186,6 @@
         "sass": "^1.54.5",
         "sass-loader": "^13.0.2",
         "script-loader": "^0.7.2",
-        "slate-dom": "^0.117.4",
         "string-replace-loader": "^3.1.0",
         "style-loader": "^3.3.1",
         "terser": "^5.46.0",
@@ -255,7 +252,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
       "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -265,7 +262,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
@@ -296,12 +293,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@babel/core/node_modules/debug": {
       "version": "4.3.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.1.2"
@@ -319,7 +316,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -367,7 +364,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
       "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.28.6",
@@ -384,7 +381,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
@@ -394,7 +391,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -403,7 +400,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
@@ -561,7 +558,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
       "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.28.6",
@@ -683,7 +680,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
       "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -707,7 +704,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
       "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.28.6",
@@ -2033,780 +2030,586 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@chakra-ui/accordion": {
-      "version": "1.4.12",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/descendant": "2.1.4",
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/icon": "2.0.5",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/transition": "1.4.8",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "framer-motion": "3.x || 4.x || 5.x || 6.x",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/alert": {
-      "version": "1.3.7",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/icon": "2.0.5",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
     "node_modules/@chakra-ui/anatomy": {
-      "version": "1.3.0",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/anatomy/-/anatomy-2.3.6.tgz",
+      "integrity": "sha512-TjmjyQouIZzha/l8JxdBZN1pKZTj7sLpJ0YkFnQFyqHcbfWggW9jKWzY1E0VBnhtFz/xF3KC6UAVuZVSJx+y0g==",
+      "license": "MIT"
+    },
+    "node_modules/@chakra-ui/breakpoint-utils": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/breakpoint-utils/-/breakpoint-utils-2.0.8.tgz",
+      "integrity": "sha512-Pq32MlEX9fwb5j5xx8s18zJMARNHlQZH2VH1RZgfgRDpp7DcEgtRW5AInfN5CfqdHLO1dGxA7I3MqEuL5JnIsA==",
       "license": "MIT",
       "dependencies": {
-        "@chakra-ui/theme-tools": "^1.3.6"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0"
+        "@chakra-ui/shared-utils": "2.0.5"
       }
     },
-    "node_modules/@chakra-ui/avatar": {
-      "version": "1.3.11",
+    "node_modules/@chakra-ui/card": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/card/-/card-2.2.0.tgz",
+      "integrity": "sha512-xUB/k5MURj4CtPAhdSoXZidUbm8j3hci9vnc+eZJVDqhDOShNlD6QeniQNRPRys4lWAQLCbFcrwL29C8naDi6g==",
       "license": "MIT",
       "dependencies": {
-        "@chakra-ui/image": "1.1.10",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4"
+        "@chakra-ui/shared-utils": "2.0.5"
       },
       "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/breadcrumb": {
-      "version": "1.3.6",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/button": {
-      "version": "1.5.10",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/spinner": "1.2.6",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/checkbox": {
-      "version": "1.7.1",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/form-control": "1.6.0",
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4",
-        "@chakra-ui/visually-hidden": "1.1.6"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "framer-motion": "3.x || 4.x || 5.x || 6.x",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/clickable": {
-      "version": "1.2.6",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/close-button": {
-      "version": "1.2.7",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/icon": "2.0.5",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
       }
     },
     "node_modules/@chakra-ui/color-mode": {
-      "version": "1.4.8",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/color-mode/-/color-mode-2.2.0.tgz",
+      "integrity": "sha512-niTEA8PALtMWRI9wJ4LL0CSBDo8NBfLNp4GD6/0hstcm3IlbBHTVKxN6HwSaoNYfphDQLxCjT4yG+0BJA5tFpg==",
       "license": "MIT",
       "dependencies": {
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/react-env": "1.1.6",
-        "@chakra-ui/utils": "1.10.4"
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0"
       },
       "peerDependencies": {
-        "react": ">=16.8.6"
+        "react": ">=18"
       }
     },
-    "node_modules/@chakra-ui/control-box": {
-      "version": "1.1.6",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/counter": {
-      "version": "1.2.10",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/css-reset": {
-      "version": "1.1.3",
-      "license": "MIT",
-      "peerDependencies": {
-        "@emotion/react": ">=10.0.35",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/descendant": {
-      "version": "2.1.4",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/react-utils": "^1.2.3"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/editable": {
-      "version": "1.4.2",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/focus-lock": {
-      "version": "1.2.6",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/utils": "1.10.4",
-        "react-focus-lock": "2.5.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/form-control": {
-      "version": "1.6.0",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/icon": "2.0.5",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/hooks": {
-      "version": "1.9.1",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4",
-        "compute-scroll-into-view": "1.0.14",
-        "copy-to-clipboard": "3.3.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/hooks/node_modules/compute-scroll-into-view": {
-      "version": "1.0.14",
+    "node_modules/@chakra-ui/dom-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/dom-utils/-/dom-utils-2.1.0.tgz",
+      "integrity": "sha512-ZmF2qRa1QZ0CMLU8M1zCfmw29DmPNtfjR9iTo74U5FPr3i1aoAh7fbJ4qAlZ197Xw9eAW28tvzQuoVWeL5C7fQ==",
       "license": "MIT"
     },
-    "node_modules/@chakra-ui/icon": {
+    "node_modules/@chakra-ui/event-utils": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/event-utils/-/event-utils-2.0.8.tgz",
+      "integrity": "sha512-IGM/yGUHS+8TOQrZGpAKOJl/xGBrmRYJrmbHfUE7zrG3PpQyXvbLDP1M+RggkCFVgHlJi2wpYIf0QtQlU0XZfw==",
+      "license": "MIT"
+    },
+    "node_modules/@chakra-ui/hooks": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/hooks/-/hooks-2.4.5.tgz",
+      "integrity": "sha512-601fWfHE2i7UjaxK/9lDLlOni6vk/I+04YDbM0BrelJy+eqxdlOmoN8Z6MZ3PzFh7ofERUASor+vL+/HaCaZ7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/utils": "2.2.5",
+        "@zag-js/element-size": "0.31.1",
+        "copy-to-clipboard": "3.3.3",
+        "framesync": "6.1.2"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/icons": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/icons/-/icons-2.2.4.tgz",
+      "integrity": "sha512-l5QdBgwrAg3Sc2BRqtNkJpfuLw/pWRDwwT58J6c4PqQT6wzXxyNa8Q0PForu1ltB5qEiFb1kxr/F/HO1EwNa6g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@chakra-ui/react": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/lazy-utils": {
       "version": "2.0.5",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
+      "resolved": "https://registry.npmjs.org/@chakra-ui/lazy-utils/-/lazy-utils-2.0.5.tgz",
+      "integrity": "sha512-UULqw7FBvcckQk2n3iPO56TMJvDsNv0FKZI6PlUNJVaGsPbsYxK/8IQ60vZgaTVPtVcjY6BE+y6zg8u9HOqpyg==",
+      "license": "MIT"
     },
-    "node_modules/@chakra-ui/image": {
-      "version": "1.1.10",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
+    "node_modules/@chakra-ui/number-utils": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/number-utils/-/number-utils-2.0.7.tgz",
+      "integrity": "sha512-yOGxBjXNvLTBvQyhMDqGU0Oj26s91mbAlqKHiuw737AXHt0aPllOthVUqQMeaYLwLCjGMg0jtI7JReRzyi94Dg==",
+      "license": "MIT"
     },
-    "node_modules/@chakra-ui/input": {
-      "version": "1.4.6",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/form-control": "1.6.0",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/layout": {
-      "version": "1.8.0",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/icon": "2.0.5",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/live-region": {
-      "version": "1.1.6",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/media-query": {
-      "version": "2.0.4",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/react-env": "1.1.6",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "@chakra-ui/theme": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/menu": {
-      "version": "1.8.12",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/clickable": "1.2.6",
-        "@chakra-ui/descendant": "2.1.4",
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/popper": "2.4.3",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/transition": "1.4.8",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "framer-motion": "3.x || 4.x || 5.x || 6.x",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/modal": {
-      "version": "1.11.1",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/close-button": "1.2.7",
-        "@chakra-ui/focus-lock": "1.2.6",
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/portal": "1.3.10",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/transition": "1.4.8",
-        "@chakra-ui/utils": "1.10.4",
-        "aria-hidden": "^1.1.1",
-        "react-remove-scroll": "2.4.1"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "framer-motion": "3.x || 4.x || 5.x || 6.x",
-        "react": ">=16.8.6",
-        "react-dom": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/number-input": {
-      "version": "1.4.7",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/counter": "1.2.10",
-        "@chakra-ui/form-control": "1.6.0",
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/icon": "2.0.5",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/pin-input": {
-      "version": "1.7.11",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/descendant": "2.1.4",
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/popover": {
-      "version": "1.11.9",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/close-button": "1.2.7",
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/popper": "2.4.3",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "framer-motion": "3.x || 4.x || 5.x || 6.x",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/popper": {
-      "version": "2.4.3",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/react-utils": "1.2.3",
-        "@popperjs/core": "^2.9.3"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/portal": {
-      "version": "1.3.10",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.6",
-        "react-dom": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/progress": {
-      "version": "1.2.6",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/theme-tools": "1.3.6",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/provider": {
-      "version": "1.7.14",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/css-reset": "1.1.3",
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/portal": "1.3.10",
-        "@chakra-ui/react-env": "1.1.6",
-        "@chakra-ui/system": "1.12.1",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.0.0",
-        "@emotion/styled": "^11.0.0",
-        "react": ">=16.8.6",
-        "react-dom": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/radio": {
-      "version": "1.5.1",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/form-control": "1.6.0",
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4",
-        "@chakra-ui/visually-hidden": "1.1.6"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
+    "node_modules/@chakra-ui/object-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/object-utils/-/object-utils-2.1.0.tgz",
+      "integrity": "sha512-tgIZOgLHaoti5PYGPTwK3t/cqtcycW0owaiOXoZOcpwwX/vlVb+H1jFsQyWiiwQVPt9RkoSLtxzXamx+aHH+bQ==",
+      "license": "MIT"
     },
     "node_modules/@chakra-ui/react": {
-      "version": "1.8.9",
+      "version": "2.10.9",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react/-/react-2.10.9.tgz",
+      "integrity": "sha512-lhdcgoocOiURwBNR3L8OioCNIaGCZqRfuKioLyaQLjOanl4jr0PQclsGb+w0cmito252vEWpsz2xRqF7y+Flrw==",
       "license": "MIT",
       "dependencies": {
-        "@chakra-ui/accordion": "1.4.12",
-        "@chakra-ui/alert": "1.3.7",
-        "@chakra-ui/avatar": "1.3.11",
-        "@chakra-ui/breadcrumb": "1.3.6",
-        "@chakra-ui/button": "1.5.10",
-        "@chakra-ui/checkbox": "1.7.1",
-        "@chakra-ui/close-button": "1.2.7",
-        "@chakra-ui/control-box": "1.1.6",
-        "@chakra-ui/counter": "1.2.10",
-        "@chakra-ui/css-reset": "1.1.3",
-        "@chakra-ui/editable": "1.4.2",
-        "@chakra-ui/form-control": "1.6.0",
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/icon": "2.0.5",
-        "@chakra-ui/image": "1.1.10",
-        "@chakra-ui/input": "1.4.6",
-        "@chakra-ui/layout": "1.8.0",
-        "@chakra-ui/live-region": "1.1.6",
-        "@chakra-ui/media-query": "2.0.4",
-        "@chakra-ui/menu": "1.8.12",
-        "@chakra-ui/modal": "1.11.1",
-        "@chakra-ui/number-input": "1.4.7",
-        "@chakra-ui/pin-input": "1.7.11",
-        "@chakra-ui/popover": "1.11.9",
-        "@chakra-ui/popper": "2.4.3",
-        "@chakra-ui/portal": "1.3.10",
-        "@chakra-ui/progress": "1.2.6",
-        "@chakra-ui/provider": "1.7.14",
-        "@chakra-ui/radio": "1.5.1",
-        "@chakra-ui/react-env": "1.1.6",
-        "@chakra-ui/select": "1.2.11",
-        "@chakra-ui/skeleton": "1.2.14",
-        "@chakra-ui/slider": "1.5.11",
-        "@chakra-ui/spinner": "1.2.6",
-        "@chakra-ui/stat": "1.2.7",
-        "@chakra-ui/switch": "1.3.10",
-        "@chakra-ui/system": "1.12.1",
-        "@chakra-ui/table": "1.3.6",
-        "@chakra-ui/tabs": "1.6.11",
-        "@chakra-ui/tag": "1.2.7",
-        "@chakra-ui/textarea": "1.2.11",
-        "@chakra-ui/theme": "1.14.1",
-        "@chakra-ui/toast": "1.5.9",
-        "@chakra-ui/tooltip": "1.5.1",
-        "@chakra-ui/transition": "1.4.8",
-        "@chakra-ui/utils": "1.10.4",
-        "@chakra-ui/visually-hidden": "1.1.6"
+        "@chakra-ui/hooks": "2.4.5",
+        "@chakra-ui/styled-system": "2.12.4",
+        "@chakra-ui/theme": "3.4.9",
+        "@chakra-ui/utils": "2.2.5",
+        "@popperjs/core": "^2.11.8",
+        "@zag-js/focus-visible": "^0.31.1",
+        "aria-hidden": "^1.2.3",
+        "react-fast-compare": "3.2.2",
+        "react-focus-lock": "^2.9.6",
+        "react-remove-scroll": "^2.5.7"
       },
       "peerDependencies": {
-        "@emotion/react": "^11.0.0",
-        "@emotion/styled": "^11.0.0",
-        "framer-motion": "3.x || 4.x || 5.x || 6.x",
-        "react": ">=16.8.6",
-        "react-dom": ">=16.8.6"
+        "@emotion/react": ">=11",
+        "@emotion/styled": ">=11",
+        "framer-motion": ">=4.0.0",
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
-    "node_modules/@chakra-ui/react-env": {
-      "version": "1.1.6",
+    "node_modules/@chakra-ui/react-children-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-children-utils/-/react-children-utils-2.0.6.tgz",
+      "integrity": "sha512-QVR2RC7QsOsbWwEnq9YduhpqSFnZGvjjGREV8ygKi8ADhXh93C8azLECCUVgRJF2Wc+So1fgxmjLcbZfY2VmBA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-context": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-context/-/react-context-2.1.0.tgz",
+      "integrity": "sha512-iahyStvzQ4AOwKwdPReLGfDesGG+vWJfEsn0X/NoGph/SkN+HXtv2sCfYFFR9k7bb+Kvc6YfpLlSuLvKMHi2+w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-types/-/react-types-2.0.7.tgz",
+      "integrity": "sha512-12zv2qIZ8EHwiytggtGvo4iLT0APris7T0qaAWqzpUGS0cdUtR8W+V1BJ5Ocq+7tA6dzQ/7+w5hmXih61TuhWQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-animation-state": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-animation-state/-/react-use-animation-state-2.1.0.tgz",
+      "integrity": "sha512-CFZkQU3gmDBwhqy0vC1ryf90BVHxVN8cTLpSyCpdmExUEtSEInSCGMydj2fvn7QXsz/za8JNdO2xxgJwxpLMtg==",
       "license": "MIT",
       "dependencies": {
-        "@chakra-ui/utils": "1.10.4"
+        "@chakra-ui/dom-utils": "2.1.0",
+        "@chakra-ui/react-use-event-listener": "2.1.0"
       },
       "peerDependencies": {
-        "react": ">=16.8.6"
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-callback-ref": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-callback-ref/-/react-use-callback-ref-2.1.0.tgz",
+      "integrity": "sha512-efnJrBtGDa4YaxDzDE90EnKD3Vkh5a1t3w7PhnRQmsphLy3g2UieasoKTlT2Hn118TwDjIv5ZjHJW6HbzXA9wQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-controllable-state": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-controllable-state/-/react-use-controllable-state-2.1.0.tgz",
+      "integrity": "sha512-QR/8fKNokxZUs4PfxjXuwl0fj/d71WPrmLJvEpCTkHjnzu7LnYvzoe2wB867IdooQJL0G1zBxl0Dq+6W1P3jpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/react-use-callback-ref": "2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-disclosure": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-disclosure/-/react-use-disclosure-2.1.0.tgz",
+      "integrity": "sha512-Ax4pmxA9LBGMyEZJhhUZobg9C0t3qFE4jVF1tGBsrLDcdBeLR9fwOogIPY9Hf0/wqSlAryAimICbr5hkpa5GSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/react-use-callback-ref": "2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-event-listener": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-event-listener/-/react-use-event-listener-2.1.0.tgz",
+      "integrity": "sha512-U5greryDLS8ISP69DKDsYcsXRtAdnTQT+jjIlRYZ49K/XhUR/AqVZCK5BkR1spTDmO9H8SPhgeNKI70ODuDU/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/react-use-callback-ref": "2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-focus-effect": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-focus-effect/-/react-use-focus-effect-2.1.0.tgz",
+      "integrity": "sha512-xzVboNy7J64xveLcxTIJ3jv+lUJKDwRM7Szwn9tNzUIPD94O3qwjV7DDCUzN2490nSYDF4OBMt/wuDBtaR3kUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/dom-utils": "2.1.0",
+        "@chakra-ui/react-use-event-listener": "2.1.0",
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0",
+        "@chakra-ui/react-use-update-effect": "2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-focus-on-pointer-down": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-focus-on-pointer-down/-/react-use-focus-on-pointer-down-2.1.0.tgz",
+      "integrity": "sha512-2jzrUZ+aiCG/cfanrolsnSMDykCAbv9EK/4iUyZno6BYb3vziucmvgKuoXbMPAzWNtwUwtuMhkby8rc61Ue+Lg==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/react-use-event-listener": "2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-interval": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-interval/-/react-use-interval-2.1.0.tgz",
+      "integrity": "sha512-8iWj+I/+A0J08pgEXP1J1flcvhLBHkk0ln7ZvGIyXiEyM6XagOTJpwNhiu+Bmk59t3HoV/VyvyJTa+44sEApuw==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/react-use-callback-ref": "2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-latest-ref": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-latest-ref/-/react-use-latest-ref-2.1.0.tgz",
+      "integrity": "sha512-m0kxuIYqoYB0va9Z2aW4xP/5b7BzlDeWwyXCH6QpT2PpW3/281L3hLCm1G0eOUcdVlayqrQqOeD6Mglq+5/xoQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-merge-refs": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-merge-refs/-/react-use-merge-refs-2.1.0.tgz",
+      "integrity": "sha512-lERa6AWF1cjEtWSGjxWTaSMvneccnAVH4V4ozh8SYiN9fSPZLlSG3kNxfNzdFvMEhM7dnP60vynF7WjGdTgQbQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-outside-click": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-outside-click/-/react-use-outside-click-2.2.0.tgz",
+      "integrity": "sha512-PNX+s/JEaMneijbgAM4iFL+f3m1ga9+6QK0E5Yh4s8KZJQ/bLwZzdhMz8J/+mL+XEXQ5J0N8ivZN28B82N1kNw==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/react-use-callback-ref": "2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-pan-event": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-pan-event/-/react-use-pan-event-2.1.0.tgz",
+      "integrity": "sha512-xmL2qOHiXqfcj0q7ZK5s9UjTh4Gz0/gL9jcWPA6GVf+A0Od5imEDa/Vz+533yQKWiNSm1QGrIj0eJAokc7O4fg==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/event-utils": "2.0.8",
+        "@chakra-ui/react-use-latest-ref": "2.1.0",
+        "framesync": "6.1.2"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-previous": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-previous/-/react-use-previous-2.1.0.tgz",
+      "integrity": "sha512-pjxGwue1hX8AFcmjZ2XfrQtIJgqbTF3Qs1Dy3d1krC77dEsiCUbQ9GzOBfDc8pfd60DrB5N2tg5JyHbypqh0Sg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-safe-layout-effect": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-safe-layout-effect/-/react-use-safe-layout-effect-2.1.0.tgz",
+      "integrity": "sha512-Knbrrx/bcPwVS1TorFdzrK/zWA8yuU/eaXDkNj24IrKoRlQrSBFarcgAEzlCHtzuhufP3OULPkELTzz91b0tCw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-size": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-size/-/react-use-size-2.1.0.tgz",
+      "integrity": "sha512-tbLqrQhbnqOjzTaMlYytp7wY8BW1JpL78iG7Ru1DlV4EWGiAmXFGvtnEt9HftU0NJ0aJyjgymkxfVGI55/1Z4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/element-size": "0.10.5"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-size/node_modules/@zag-js/element-size": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@zag-js/element-size/-/element-size-0.10.5.tgz",
+      "integrity": "sha512-uQre5IidULANvVkNOBQ1tfgwTQcGl4hliPSe69Fct1VfYb2Fd0jdAcGzqQgPhfrXFpR62MxLPB7erxJ/ngtL8w==",
+      "license": "MIT"
+    },
+    "node_modules/@chakra-ui/react-use-timeout": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-timeout/-/react-use-timeout-2.1.0.tgz",
+      "integrity": "sha512-cFN0sobKMM9hXUhyCofx3/Mjlzah6ADaEl/AXl5Y+GawB5rgedgAcu2ErAgarEkwvsKdP6c68CKjQ9dmTQlJxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/react-use-callback-ref": "2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/react-use-update-effect": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-update-effect/-/react-use-update-effect-2.1.0.tgz",
+      "integrity": "sha512-ND4Q23tETaR2Qd3zwCKYOOS1dfssojPLJMLvUtUbW5M9uW1ejYWgGUobeAiOVfSplownG8QYMmHTP86p/v0lbA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18"
       }
     },
     "node_modules/@chakra-ui/react-utils": {
-      "version": "1.2.3",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-utils/-/react-utils-2.0.12.tgz",
+      "integrity": "sha512-GbSfVb283+YA3kA8w8xWmzbjNWk14uhNpntnipHCftBibl0lxtQ9YqMFQLwuFOO0U2gYVocszqqDWX+XNKq9hw==",
       "license": "MIT",
       "dependencies": {
-        "@chakra-ui/utils": "^1.10.4"
+        "@chakra-ui/utils": "2.0.15"
       },
       "peerDependencies": {
-        "react": ">=16.8.6"
+        "react": ">=18"
       }
     },
-    "node_modules/@chakra-ui/select": {
-      "version": "1.2.11",
+    "node_modules/@chakra-ui/react-utils/node_modules/@chakra-ui/utils": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-2.0.15.tgz",
+      "integrity": "sha512-El4+jL0WSaYYs+rJbuYFDbjmfCcfGDmRY95GO4xwzit6YAPZBLcR65rOEwLps+XWluZTy1xdMrusg/hW0c1aAA==",
       "license": "MIT",
       "dependencies": {
-        "@chakra-ui/form-control": "1.6.0",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/skeleton": {
-      "version": "1.2.14",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/media-query": "2.0.4",
-        "@chakra-ui/system": "1.12.1",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/theme": ">=1.0.0",
-        "@emotion/react": "^11.0.0",
-        "@emotion/styled": "^11.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/slider": {
-      "version": "1.5.11",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/spinner": {
-      "version": "1.2.6",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/utils": "1.10.4",
-        "@chakra-ui/visually-hidden": "1.1.6"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/stat": {
-      "version": "1.2.7",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/icon": "2.0.5",
-        "@chakra-ui/utils": "1.10.4",
-        "@chakra-ui/visually-hidden": "1.1.6"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/styled-system": {
-      "version": "1.19.0",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/utils": "1.10.4",
-        "csstype": "3.0.9"
-      }
-    },
-    "node_modules/@chakra-ui/switch": {
-      "version": "1.3.10",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/checkbox": "1.7.1",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "framer-motion": "3.x || 4.x || 5.x || 6.x",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/system": {
-      "version": "1.12.1",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/color-mode": "1.4.8",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/styled-system": "1.19.0",
-        "@chakra-ui/utils": "1.10.4",
-        "react-fast-compare": "3.2.0"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.0.0",
-        "@emotion/styled": "^11.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/table": {
-      "version": "1.3.6",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/tabs": {
-      "version": "1.6.11",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/clickable": "1.2.6",
-        "@chakra-ui/descendant": "2.1.4",
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/tag": {
-      "version": "1.2.7",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/icon": "2.0.5",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/textarea": {
-      "version": "1.2.11",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/form-control": "1.6.0",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/theme": {
-      "version": "1.14.1",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/anatomy": "1.3.0",
-        "@chakra-ui/theme-tools": "1.3.6",
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0"
-      }
-    },
-    "node_modules/@chakra-ui/theme-tools": {
-      "version": "1.3.6",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/utils": "1.10.4",
-        "@ctrl/tinycolor": "^3.4.0"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0"
-      }
-    },
-    "node_modules/@chakra-ui/toast": {
-      "version": "1.5.9",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/alert": "1.3.7",
-        "@chakra-ui/close-button": "1.2.7",
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/theme": "1.14.1",
-        "@chakra-ui/transition": "1.4.8",
-        "@chakra-ui/utils": "1.10.4",
-        "@reach/alert": "0.13.2"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "framer-motion": "3.x || 4.x || 5.x || 6.x",
-        "react": ">=16.8.6",
-        "react-dom": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/tooltip": {
-      "version": "1.5.1",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/popper": "2.4.3",
-        "@chakra-ui/portal": "1.3.10",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4",
-        "@chakra-ui/visually-hidden": "1.1.6"
-      },
-      "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "framer-motion": "3.x || 4.x || 5.x || 6.x",
-        "react": ">=16.8.6",
-        "react-dom": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/transition": {
-      "version": "1.4.8",
-      "license": "MIT",
-      "dependencies": {
-        "@chakra-ui/utils": "1.10.4"
-      },
-      "peerDependencies": {
-        "framer-motion": "3.x || 4.x || 5.x || 6.x",
-        "react": ">=16.8.6"
-      }
-    },
-    "node_modules/@chakra-ui/utils": {
-      "version": "1.10.4",
-      "license": "MIT",
-      "dependencies": {
-        "@types/lodash.mergewith": "4.6.6",
+        "@types/lodash.mergewith": "4.6.7",
         "css-box-model": "1.2.1",
-        "framesync": "5.3.0",
+        "framesync": "6.1.2",
         "lodash.mergewith": "4.6.2"
       }
     },
-    "node_modules/@chakra-ui/visually-hidden": {
-      "version": "1.1.6",
+    "node_modules/@chakra-ui/react-utils/node_modules/@types/lodash.mergewith": {
+      "version": "4.6.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.mergewith/-/lodash.mergewith-4.6.7.tgz",
+      "integrity": "sha512-3m+lkO5CLRRYU0fhGRp7zbsGi6+BZj0uTVSwvcKU+nSlhjA9/QRNfuSGnD2mX6hQA7ZbmcCkzk5h4ZYGOtk14A==",
       "license": "MIT",
       "dependencies": {
-        "@chakra-ui/utils": "1.10.4"
+        "@types/lodash": "*"
+      }
+    },
+    "node_modules/@chakra-ui/shared-utils": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/shared-utils/-/shared-utils-2.0.5.tgz",
+      "integrity": "sha512-4/Wur0FqDov7Y0nCXl7HbHzCg4aq86h+SXdoUeuCMD3dSj7dpsVnStLYhng1vxvlbUnLpdF4oz5Myt3i/a7N3Q==",
+      "license": "MIT"
+    },
+    "node_modules/@chakra-ui/skip-nav": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/skip-nav/-/skip-nav-2.1.0.tgz",
+      "integrity": "sha512-Hk+FG+vadBSH0/7hwp9LJnLjkO0RPGnx7gBJWI4/SpoJf3e4tZlWYtwGj0toYY4aGKl93jVghuwGbDBEMoHDug==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/stepper": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/stepper/-/stepper-2.3.1.tgz",
+      "integrity": "sha512-ky77lZbW60zYkSXhYz7kbItUpAQfEdycT0Q4bkHLxfqbuiGMf8OmgZOQkOB9uM4v0zPwy2HXhe0vq4Dd0xa55Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/icon": "3.2.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
       },
       "peerDependencies": {
-        "@chakra-ui/system": ">=1.0.0",
-        "react": ">=16.8.6"
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/stepper/node_modules/@chakra-ui/icon": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-3.2.0.tgz",
+      "integrity": "sha512-xxjGLvlX2Ys4H0iHrI16t74rG9EBcpFvJ3Y3B7KMQTrnW34Kf7Da/UC8J67Gtx85mTHW020ml85SVPKORWNNKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/styled-system": {
+      "version": "2.12.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/styled-system/-/styled-system-2.12.4.tgz",
+      "integrity": "sha512-oa07UG7Lic5hHSQtGRiMEnYjuhIa8lszyuVhZjZqR2Ap3VMF688y1MVPJ1pK+8OwY5uhXBgVd5c0+rI8aBZlwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/utils": "2.2.5",
+        "csstype": "^3.1.2"
+      }
+    },
+    "node_modules/@chakra-ui/system": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/system/-/system-2.6.2.tgz",
+      "integrity": "sha512-EGtpoEjLrUu4W1fHD+a62XR+hzC5YfsWm+6lO0Kybcga3yYEij9beegO0jZgug27V+Rf7vns95VPVP6mFd/DEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/color-mode": "2.2.0",
+        "@chakra-ui/object-utils": "2.1.0",
+        "@chakra-ui/react-utils": "2.0.12",
+        "@chakra-ui/styled-system": "2.9.2",
+        "@chakra-ui/theme-utils": "2.0.21",
+        "@chakra-ui/utils": "2.0.15",
+        "react-fast-compare": "3.2.2"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.0.0",
+        "@emotion/styled": "^11.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/system/node_modules/@chakra-ui/styled-system": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/styled-system/-/styled-system-2.9.2.tgz",
+      "integrity": "sha512-To/Z92oHpIE+4nk11uVMWqo2GGRS86coeMmjxtpnErmWRdLcp1WVCVRAvn+ZwpLiNR+reWFr2FFqJRsREuZdAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/shared-utils": "2.0.5",
+        "csstype": "^3.1.2",
+        "lodash.mergewith": "4.6.2"
+      }
+    },
+    "node_modules/@chakra-ui/system/node_modules/@chakra-ui/utils": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-2.0.15.tgz",
+      "integrity": "sha512-El4+jL0WSaYYs+rJbuYFDbjmfCcfGDmRY95GO4xwzit6YAPZBLcR65rOEwLps+XWluZTy1xdMrusg/hW0c1aAA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/lodash.mergewith": "4.6.7",
+        "css-box-model": "1.2.1",
+        "framesync": "6.1.2",
+        "lodash.mergewith": "4.6.2"
+      }
+    },
+    "node_modules/@chakra-ui/system/node_modules/@types/lodash.mergewith": {
+      "version": "4.6.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.mergewith/-/lodash.mergewith-4.6.7.tgz",
+      "integrity": "sha512-3m+lkO5CLRRYU0fhGRp7zbsGi6+BZj0uTVSwvcKU+nSlhjA9/QRNfuSGnD2mX6hQA7ZbmcCkzk5h4ZYGOtk14A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/lodash": "*"
+      }
+    },
+    "node_modules/@chakra-ui/theme": {
+      "version": "3.4.9",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/theme/-/theme-3.4.9.tgz",
+      "integrity": "sha512-GAom2SjSdRWTcX76/2yJOFJsOWHQeBgaynCUNBsHq62OafzvELrsSHDUw0bBqBb1c2ww0CclIvGilPup8kXBFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/anatomy": "2.3.6",
+        "@chakra-ui/theme-tools": "2.2.9",
+        "@chakra-ui/utils": "2.2.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/styled-system": ">=2.8.0"
+      }
+    },
+    "node_modules/@chakra-ui/theme-tools": {
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/theme-tools/-/theme-tools-2.2.9.tgz",
+      "integrity": "sha512-PcbYL19lrVvEc7Oydy//jsy/MO/rZz1DvLyO6AoI+bI/+Kwz9WfOKsspbulEhRg5COayE0R/IZPsskXZ7Mp4bA==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/anatomy": "2.3.6",
+        "@chakra-ui/utils": "2.2.5",
+        "color2k": "^2.0.2"
+      },
+      "peerDependencies": {
+        "@chakra-ui/styled-system": ">=2.0.0"
+      }
+    },
+    "node_modules/@chakra-ui/theme-utils": {
+      "version": "2.0.21",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/theme-utils/-/theme-utils-2.0.21.tgz",
+      "integrity": "sha512-FjH5LJbT794r0+VSCXB3lT4aubI24bLLRWB+CuRKHijRvsOg717bRdUN/N1fEmEpFnRVrbewttWh/OQs0EWpWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@chakra-ui/styled-system": "2.9.2",
+        "@chakra-ui/theme": "3.3.1",
+        "lodash.mergewith": "4.6.2"
+      }
+    },
+    "node_modules/@chakra-ui/theme-utils/node_modules/@chakra-ui/anatomy": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/anatomy/-/anatomy-2.2.2.tgz",
+      "integrity": "sha512-MV6D4VLRIHr4PkW4zMyqfrNS1mPlCTiCXwvYGtDFQYr+xHFfonhAuf9WjsSc0nyp2m0OdkSLnzmVKkZFLo25Tg==",
+      "license": "MIT"
+    },
+    "node_modules/@chakra-ui/theme-utils/node_modules/@chakra-ui/styled-system": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/styled-system/-/styled-system-2.9.2.tgz",
+      "integrity": "sha512-To/Z92oHpIE+4nk11uVMWqo2GGRS86coeMmjxtpnErmWRdLcp1WVCVRAvn+ZwpLiNR+reWFr2FFqJRsREuZdAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/shared-utils": "2.0.5",
+        "csstype": "^3.1.2",
+        "lodash.mergewith": "4.6.2"
+      }
+    },
+    "node_modules/@chakra-ui/theme-utils/node_modules/@chakra-ui/theme": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/theme/-/theme-3.3.1.tgz",
+      "integrity": "sha512-Hft/VaT8GYnItGCBbgWd75ICrIrIFrR7lVOhV/dQnqtfGqsVDlrztbSErvMkoPKt0UgAkd9/o44jmZ6X4U2nZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/anatomy": "2.2.2",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@chakra-ui/theme-tools": "2.1.2"
+      },
+      "peerDependencies": {
+        "@chakra-ui/styled-system": ">=2.8.0"
+      }
+    },
+    "node_modules/@chakra-ui/theme-utils/node_modules/@chakra-ui/theme-tools": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/theme-tools/-/theme-tools-2.1.2.tgz",
+      "integrity": "sha512-Qdj8ajF9kxY4gLrq7gA+Azp8CtFHGO9tWMN2wfF9aQNgG9AuMhPrUzMq9AMQ0MXiYcgNq/FD3eegB43nHVmXVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/anatomy": "2.2.2",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "color2k": "^2.0.2"
+      },
+      "peerDependencies": {
+        "@chakra-ui/styled-system": ">=2.0.0"
+      }
+    },
+    "node_modules/@chakra-ui/utils": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-2.2.5.tgz",
+      "integrity": "sha512-KTBCK+M5KtXH6p54XS39ImQUMVtAx65BoZDoEms3LuObyTo1+civ1sMm4h3nRT320U6H5H7D35WnABVQjqU/4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/lodash.mergewith": "4.6.9",
+        "lodash.mergewith": "4.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@codemirror/autocomplete": {
@@ -2947,12 +2750,14 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@concord-consortium/codap-formulas-react17": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/codap-formulas-react17/-/codap-formulas-react17-1.1.0.tgz",
-      "integrity": "sha512-t8bcMHiShdqR9qS8jJLyK1nZfjoUGLI9d35NJIRRhm115cFurrnMqc4o0SIjXEOC2X2uqIDbS+NVxwzfGwpMSg==",
+    "node_modules/@concord-consortium/codap-formulas": {
+      "version": "1.1.0-pre.2",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/codap-formulas/-/codap-formulas-1.1.0-pre.2.tgz",
+      "integrity": "sha512-jaRmOq9taiMxXvVnh5uzVIlFsOBcQ0+2IUy7kRvaGC/CXg5a3hB5g1zM3lImiGcnZLAjO68Wl9V0/8+RMg5cXg==",
+      "license": "MIT",
       "dependencies": {
-        "@chakra-ui/react": "^1.8.9",
+        "@chakra-ui/icons": "^2.2.4",
+        "@chakra-ui/react": "~2.8.2",
         "@codemirror/autocomplete": "^6.18.6",
         "@codemirror/commands": "^6.8.0",
         "@codemirror/language": "^6.11.0",
@@ -2965,20 +2770,941 @@
         "@uiw/react-codemirror": "^4.23.10",
         "colord": "^2.9.3",
         "escape-string-regexp": "^5.0.0",
-        "framer-motion": "^6.5.1",
+        "framer-motion": "^12.18.1",
         "lodash": "^4.17.21",
         "mathjs": "12.4.3",
         "mobx": "^6.13.6",
         "mobx-react-lite": "^4.1.0",
         "mobx-state-tree": "npm:@concord-consortium/mobx-state-tree@6.0.0-cc.1",
         "random": "^5.4.0",
-        "react": "^17.0.2",
-        "react-dom": "^17.0.2",
         "type-fest": "^4.41.0",
         "use-memo-one": "^1.1.3"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@concord-consortium/codap-formulas-react17/node_modules/mathjs": {
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/accordion": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/accordion/-/accordion-2.3.1.tgz",
+      "integrity": "sha512-FSXRm8iClFyU+gVaXisOSEw0/4Q+qZbFRiuhIAkVU6Boj0FxAMrlo9a8AV5TuF77rgaHytCdHk0Ng+cyUijrag==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/descendant": "3.1.0",
+        "@chakra-ui/icon": "3.2.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-controllable-state": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@chakra-ui/transition": "2.1.0"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "framer-motion": ">=4.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/alert": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/alert/-/alert-2.2.2.tgz",
+      "integrity": "sha512-jHg4LYMRNOJH830ViLuicjb3F+v6iriE/2G5T+Sd0Hna04nukNJ1MxUmBPE+vI22me2dIflfelu2v9wdB6Pojw==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/icon": "3.2.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@chakra-ui/spinner": "2.1.0"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/anatomy": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/anatomy/-/anatomy-2.2.2.tgz",
+      "integrity": "sha512-MV6D4VLRIHr4PkW4zMyqfrNS1mPlCTiCXwvYGtDFQYr+xHFfonhAuf9WjsSc0nyp2m0OdkSLnzmVKkZFLo25Tg==",
+      "license": "MIT"
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/avatar": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/avatar/-/avatar-2.3.0.tgz",
+      "integrity": "sha512-8gKSyLfygnaotbJbDMHDiJoF38OHXUYVme4gGxZ1fLnQEdPVEaIWfH+NndIjOM0z8S+YEFnT9KyGMUtvPrBk3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/image": "2.1.0",
+        "@chakra-ui/react-children-utils": "2.0.6",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/breadcrumb": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/breadcrumb/-/breadcrumb-2.2.0.tgz",
+      "integrity": "sha512-4cWCG24flYBxjruRi4RJREWTGF74L/KzI2CognAW/d/zWR0CjiScuJhf37Am3LFbCySP6WSoyBOtTIoTA4yLEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/react-children-utils": "2.0.6",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/button": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/button/-/button-2.1.0.tgz",
+      "integrity": "sha512-95CplwlRKmmUXkdEp/21VkEWgnwcx2TOBG6NfYlsuLBDHSLlo5FKIiE2oSi4zXc4TLcopGcWPNcm/NDaSC5pvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@chakra-ui/spinner": "2.1.0"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/checkbox": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/checkbox/-/checkbox-2.3.2.tgz",
+      "integrity": "sha512-85g38JIXMEv6M+AcyIGLh7igNtfpAN6KGQFYxY9tBj0eWvWk4NKQxvqqyVta0bSAyIl1rixNIIezNpNWk2iO4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/form-control": "2.2.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-types": "2.0.7",
+        "@chakra-ui/react-use-callback-ref": "2.1.0",
+        "@chakra-ui/react-use-controllable-state": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0",
+        "@chakra-ui/react-use-update-effect": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@chakra-ui/visually-hidden": "2.2.0",
+        "@zag-js/focus-visible": "0.16.0"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/clickable": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/clickable/-/clickable-2.1.0.tgz",
+      "integrity": "sha512-flRA/ClPUGPYabu+/GLREZVZr9j2uyyazCAUHAdrTUEdDYCr31SVGhgh7dgKdtq23bOvAQJpIJjw/0Bs0WvbXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/close-button": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/close-button/-/close-button-2.1.1.tgz",
+      "integrity": "sha512-gnpENKOanKexswSVpVz7ojZEALl2x5qjLYNqSQGbxz+aP9sOXPfUS56ebyBrre7T7exuWGiFeRwnM0oVeGPaiw==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/icon": "3.2.0"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/control-box": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/control-box/-/control-box-2.1.0.tgz",
+      "integrity": "sha512-gVrRDyXFdMd8E7rulL0SKeoljkLQiPITFnsyMO8EFHNZ+AHt5wK4LIguYVEq88APqAGZGfHFWXr79RYrNiE3Mg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/counter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/counter/-/counter-2.1.0.tgz",
+      "integrity": "sha512-s6hZAEcWT5zzjNz2JIWUBzRubo9la/oof1W7EKZVVfPYHERnl5e16FmBC79Yfq8p09LQ+aqFKm/etYoJMMgghw==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/number-utils": "2.0.7",
+        "@chakra-ui/react-use-callback-ref": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/css-reset": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/css-reset/-/css-reset-2.3.0.tgz",
+      "integrity": "sha512-cQwwBy5O0jzvl0K7PLTLgp8ijqLPKyuEMiDXwYzl95seD3AoeuoCLyzZcJtVqaUZ573PiBdAbY/IlZcwDOItWg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@emotion/react": ">=10.0.35",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/descendant": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/descendant/-/descendant-3.1.0.tgz",
+      "integrity": "sha512-VxCIAir08g5w27klLyi7PVo8BxhW4tgU/lxQyujkmi4zx7hT9ZdrcQLAted/dAa+aSIZ14S1oV0Q9lGjsAdxUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/editable": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/editable/-/editable-3.1.0.tgz",
+      "integrity": "sha512-j2JLrUL9wgg4YA6jLlbU88370eCRyor7DZQD9lzpY95tSOXpTljeg3uF9eOmDnCs6fxp3zDWIfkgMm/ExhcGTg==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-types": "2.0.7",
+        "@chakra-ui/react-use-callback-ref": "2.1.0",
+        "@chakra-ui/react-use-controllable-state": "2.1.0",
+        "@chakra-ui/react-use-focus-on-pointer-down": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0",
+        "@chakra-ui/react-use-update-effect": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/focus-lock": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/focus-lock/-/focus-lock-2.1.0.tgz",
+      "integrity": "sha512-EmGx4PhWGjm4dpjRqM4Aa+rCWBxP+Rq8Uc/nAVnD4YVqkEhBkrPTpui2lnjsuxqNaZ24fIAZ10cF1hlpemte/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/dom-utils": "2.1.0",
+        "react-focus-lock": "^2.9.4"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/form-control": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/form-control/-/form-control-2.2.0.tgz",
+      "integrity": "sha512-wehLC1t4fafCVJ2RvJQT2jyqsAwX7KymmiGqBu7nQoQz8ApTkGABWpo/QwDh3F/dBLrouHDoOvGmYTqft3Mirw==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/icon": "3.2.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-types": "2.0.7",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/hooks": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/hooks/-/hooks-2.2.1.tgz",
+      "integrity": "sha512-RQbTnzl6b1tBjbDPf9zGRo9rf/pQMholsOudTxjy4i9GfTfz6kgp5ValGjQm2z7ng6Z31N1cnjZ1AlSzQ//ZfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/react-utils": "2.0.12",
+        "@chakra-ui/utils": "2.0.15",
+        "compute-scroll-into-view": "3.0.3",
+        "copy-to-clipboard": "3.3.3"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/icon": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-3.2.0.tgz",
+      "integrity": "sha512-xxjGLvlX2Ys4H0iHrI16t74rG9EBcpFvJ3Y3B7KMQTrnW34Kf7Da/UC8J67Gtx85mTHW020ml85SVPKORWNNKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/image": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/image/-/image-2.1.0.tgz",
+      "integrity": "sha512-bskumBYKLiLMySIWDGcz0+D9Th0jPvmX6xnRMs4o92tT3Od/bW26lahmV2a2Op2ItXeCmRMY+XxJH5Gy1i46VA==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/input": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/input/-/input-2.1.2.tgz",
+      "integrity": "sha512-GiBbb3EqAA8Ph43yGa6Mc+kUPjh4Spmxp1Pkelr8qtudpc3p2PJOOebLpd90mcqw8UePPa+l6YhhPtp6o0irhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/form-control": "2.2.0",
+        "@chakra-ui/object-utils": "2.1.0",
+        "@chakra-ui/react-children-utils": "2.0.6",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/layout": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/layout/-/layout-2.3.1.tgz",
+      "integrity": "sha512-nXuZ6WRbq0WdgnRgLw+QuxWAHuhDtVX8ElWqcTK+cSMFg/52eVP47czYBE5F35YhnoW2XBwfNoNgZ7+e8Z01Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/breakpoint-utils": "2.0.8",
+        "@chakra-ui/icon": "3.2.0",
+        "@chakra-ui/object-utils": "2.1.0",
+        "@chakra-ui/react-children-utils": "2.0.6",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/live-region": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/live-region/-/live-region-2.1.0.tgz",
+      "integrity": "sha512-ZOxFXwtaLIsXjqnszYYrVuswBhnIHHP+XIgK1vC6DePKtyK590Wg+0J0slDwThUAd4MSSIUa/nNX84x1GMphWw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/media-query": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/media-query/-/media-query-3.3.0.tgz",
+      "integrity": "sha512-IsTGgFLoICVoPRp9ykOgqmdMotJG0CnPsKvGQeSFOB/dZfIujdVb14TYxDU4+MURXry1MhJ7LzZhv+Ml7cr8/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/breakpoint-utils": "2.0.8",
+        "@chakra-ui/react-env": "3.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/menu": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/menu/-/menu-2.2.1.tgz",
+      "integrity": "sha512-lJS7XEObzJxsOwWQh7yfG4H8FzFPRP5hVPN/CL+JzytEINCSBvsCDHrYPQGp7jzpCi8vnTqQQGQe0f8dwnXd2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/clickable": "2.1.0",
+        "@chakra-ui/descendant": "3.1.0",
+        "@chakra-ui/lazy-utils": "2.0.5",
+        "@chakra-ui/popper": "3.1.0",
+        "@chakra-ui/react-children-utils": "2.0.6",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-animation-state": "2.1.0",
+        "@chakra-ui/react-use-controllable-state": "2.1.0",
+        "@chakra-ui/react-use-disclosure": "2.1.0",
+        "@chakra-ui/react-use-focus-effect": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/react-use-outside-click": "2.2.0",
+        "@chakra-ui/react-use-update-effect": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@chakra-ui/transition": "2.1.0"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "framer-motion": ">=4.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/modal": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/modal/-/modal-2.3.1.tgz",
+      "integrity": "sha512-TQv1ZaiJMZN+rR9DK0snx/OPwmtaGH1HbZtlYt4W4s6CzyK541fxLRTjIXfEzIGpvNW+b6VFuFjbcR78p4DEoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/close-button": "2.1.1",
+        "@chakra-ui/focus-lock": "2.1.0",
+        "@chakra-ui/portal": "2.1.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-types": "2.0.7",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@chakra-ui/transition": "2.1.0",
+        "aria-hidden": "^1.2.3",
+        "react-remove-scroll": "^2.5.6"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "framer-motion": ">=4.0.0",
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/number-input": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/number-input/-/number-input-2.1.2.tgz",
+      "integrity": "sha512-pfOdX02sqUN0qC2ysuvgVDiws7xZ20XDIlcNhva55Jgm095xjm8eVdIBfNm3SFbSUNxyXvLTW/YQanX74tKmuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/counter": "2.1.0",
+        "@chakra-ui/form-control": "2.2.0",
+        "@chakra-ui/icon": "3.2.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-types": "2.0.7",
+        "@chakra-ui/react-use-callback-ref": "2.1.0",
+        "@chakra-ui/react-use-event-listener": "2.1.0",
+        "@chakra-ui/react-use-interval": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0",
+        "@chakra-ui/react-use-update-effect": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/pin-input": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/pin-input/-/pin-input-2.1.0.tgz",
+      "integrity": "sha512-x4vBqLStDxJFMt+jdAHHS8jbh294O53CPQJoL4g228P513rHylV/uPscYUHrVJXRxsHfRztQO9k45jjTYaPRMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/descendant": "3.1.0",
+        "@chakra-ui/react-children-utils": "2.0.6",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-controllable-state": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/popover": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/popover/-/popover-2.2.1.tgz",
+      "integrity": "sha512-K+2ai2dD0ljvJnlrzesCDT9mNzLifE3noGKZ3QwLqd/K34Ym1W/0aL1ERSynrcG78NKoXS54SdEzkhCZ4Gn/Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/close-button": "2.1.1",
+        "@chakra-ui/lazy-utils": "2.0.5",
+        "@chakra-ui/popper": "3.1.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-types": "2.0.7",
+        "@chakra-ui/react-use-animation-state": "2.1.0",
+        "@chakra-ui/react-use-disclosure": "2.1.0",
+        "@chakra-ui/react-use-focus-effect": "2.1.0",
+        "@chakra-ui/react-use-focus-on-pointer-down": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "framer-motion": ">=4.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/popper": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/popper/-/popper-3.1.0.tgz",
+      "integrity": "sha512-ciDdpdYbeFG7og6/6J8lkTFxsSvwTdMLFkpVylAF6VNC22jssiWfquj2eyD4rJnzkRFPvIWJq8hvbfhsm+AjSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/react-types": "2.0.7",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@popperjs/core": "^2.9.3"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/portal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/portal/-/portal-2.1.0.tgz",
+      "integrity": "sha512-9q9KWf6SArEcIq1gGofNcFPSWEyl+MfJjEUg/un1SMlQjaROOh3zYr+6JAwvcORiX7tyHosnmWC3d3wI2aPSQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/progress": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/progress/-/progress-2.2.0.tgz",
+      "integrity": "sha512-qUXuKbuhN60EzDD9mHR7B67D7p/ZqNS2Aze4Pbl1qGGZfulPW0PY8Rof32qDtttDQBkzQIzFGE8d9QpAemToIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/react-context": "2.1.0"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/provider": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/provider/-/provider-2.4.2.tgz",
+      "integrity": "sha512-w0Tef5ZCJK1mlJorcSjItCSbyvVuqpvyWdxZiVQmE6fvSJR83wZof42ux0+sfWD+I7rHSfj+f9nzhNaEWClysw==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/css-reset": "2.3.0",
+        "@chakra-ui/portal": "2.1.0",
+        "@chakra-ui/react-env": "3.1.0",
+        "@chakra-ui/system": "2.6.2",
+        "@chakra-ui/utils": "2.0.15"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.0.0",
+        "@emotion/styled": "^11.0.0",
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/radio": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/radio/-/radio-2.1.2.tgz",
+      "integrity": "sha512-n10M46wJrMGbonaghvSRnZ9ToTv/q76Szz284gv4QUWvyljQACcGrXIONUnQ3BIwbOfkRqSk7Xl/JgZtVfll+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/form-control": "2.2.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-types": "2.0.7",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@zag-js/focus-visible": "0.16.0"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/react": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react/-/react-2.8.2.tgz",
+      "integrity": "sha512-Hn0moyxxyCDKuR9ywYpqgX8dvjqwu9ArwpIb9wHNYjnODETjLwazgNIliCVBRcJvysGRiV51U2/JtJVrpeCjUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/accordion": "2.3.1",
+        "@chakra-ui/alert": "2.2.2",
+        "@chakra-ui/avatar": "2.3.0",
+        "@chakra-ui/breadcrumb": "2.2.0",
+        "@chakra-ui/button": "2.1.0",
+        "@chakra-ui/card": "2.2.0",
+        "@chakra-ui/checkbox": "2.3.2",
+        "@chakra-ui/close-button": "2.1.1",
+        "@chakra-ui/control-box": "2.1.0",
+        "@chakra-ui/counter": "2.1.0",
+        "@chakra-ui/css-reset": "2.3.0",
+        "@chakra-ui/editable": "3.1.0",
+        "@chakra-ui/focus-lock": "2.1.0",
+        "@chakra-ui/form-control": "2.2.0",
+        "@chakra-ui/hooks": "2.2.1",
+        "@chakra-ui/icon": "3.2.0",
+        "@chakra-ui/image": "2.1.0",
+        "@chakra-ui/input": "2.1.2",
+        "@chakra-ui/layout": "2.3.1",
+        "@chakra-ui/live-region": "2.1.0",
+        "@chakra-ui/media-query": "3.3.0",
+        "@chakra-ui/menu": "2.2.1",
+        "@chakra-ui/modal": "2.3.1",
+        "@chakra-ui/number-input": "2.1.2",
+        "@chakra-ui/pin-input": "2.1.0",
+        "@chakra-ui/popover": "2.2.1",
+        "@chakra-ui/popper": "3.1.0",
+        "@chakra-ui/portal": "2.1.0",
+        "@chakra-ui/progress": "2.2.0",
+        "@chakra-ui/provider": "2.4.2",
+        "@chakra-ui/radio": "2.1.2",
+        "@chakra-ui/react-env": "3.1.0",
+        "@chakra-ui/select": "2.1.2",
+        "@chakra-ui/skeleton": "2.1.0",
+        "@chakra-ui/skip-nav": "2.1.0",
+        "@chakra-ui/slider": "2.1.0",
+        "@chakra-ui/spinner": "2.1.0",
+        "@chakra-ui/stat": "2.1.1",
+        "@chakra-ui/stepper": "2.3.1",
+        "@chakra-ui/styled-system": "2.9.2",
+        "@chakra-ui/switch": "2.1.2",
+        "@chakra-ui/system": "2.6.2",
+        "@chakra-ui/table": "2.1.0",
+        "@chakra-ui/tabs": "3.0.0",
+        "@chakra-ui/tag": "3.1.1",
+        "@chakra-ui/textarea": "2.1.2",
+        "@chakra-ui/theme": "3.3.1",
+        "@chakra-ui/theme-utils": "2.0.21",
+        "@chakra-ui/toast": "7.0.2",
+        "@chakra-ui/tooltip": "2.3.1",
+        "@chakra-ui/transition": "2.1.0",
+        "@chakra-ui/utils": "2.0.15",
+        "@chakra-ui/visually-hidden": "2.2.0"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.0.0",
+        "@emotion/styled": "^11.0.0",
+        "framer-motion": ">=4.0.0",
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/react-env": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-env/-/react-env-3.1.0.tgz",
+      "integrity": "sha512-Vr96GV2LNBth3+IKzr/rq1IcnkXv+MLmwjQH6C8BRtn3sNskgDFD5vLkVXcEhagzZMCh8FR3V/bzZPojBOyNhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/select": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/select/-/select-2.1.2.tgz",
+      "integrity": "sha512-ZwCb7LqKCVLJhru3DXvKXpZ7Pbu1TDZ7N0PdQ0Zj1oyVLJyrpef1u9HR5u0amOpqcH++Ugt0f5JSmirjNlctjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/form-control": "2.2.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/skeleton": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/skeleton/-/skeleton-2.1.0.tgz",
+      "integrity": "sha512-JNRuMPpdZGd6zFVKjVQ0iusu3tXAdI29n4ZENYwAJEMf/fN0l12sVeirOxkJ7oEL0yOx2AgEYFSKdbcAgfUsAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/media-query": "3.3.0",
+        "@chakra-ui/react-use-previous": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/slider": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/slider/-/slider-2.1.0.tgz",
+      "integrity": "sha512-lUOBcLMCnFZiA/s2NONXhELJh6sY5WtbRykPtclGfynqqOo47lwWJx+VP7xaeuhDOPcWSSecWc9Y1BfPOCz9cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/number-utils": "2.0.7",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-types": "2.0.7",
+        "@chakra-ui/react-use-callback-ref": "2.1.0",
+        "@chakra-ui/react-use-controllable-state": "2.1.0",
+        "@chakra-ui/react-use-latest-ref": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/react-use-pan-event": "2.1.0",
+        "@chakra-ui/react-use-size": "2.1.0",
+        "@chakra-ui/react-use-update-effect": "2.1.0"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/spinner": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/spinner/-/spinner-2.1.0.tgz",
+      "integrity": "sha512-hczbnoXt+MMv/d3gE+hjQhmkzLiKuoTo42YhUG7Bs9OSv2lg1fZHW1fGNRFP3wTi6OIbD044U1P9HK+AOgFH3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/stat": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/stat/-/stat-2.1.1.tgz",
+      "integrity": "sha512-LDn0d/LXQNbAn2KaR3F1zivsZCewY4Jsy1qShmfBMKwn6rI8yVlbvu6SiA3OpHS0FhxbsZxQI6HefEoIgtqY6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/icon": "3.2.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/styled-system": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/styled-system/-/styled-system-2.9.2.tgz",
+      "integrity": "sha512-To/Z92oHpIE+4nk11uVMWqo2GGRS86coeMmjxtpnErmWRdLcp1WVCVRAvn+ZwpLiNR+reWFr2FFqJRsREuZdAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/shared-utils": "2.0.5",
+        "csstype": "^3.1.2",
+        "lodash.mergewith": "4.6.2"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/switch": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/switch/-/switch-2.1.2.tgz",
+      "integrity": "sha512-pgmi/CC+E1v31FcnQhsSGjJnOE2OcND4cKPyTE+0F+bmGm48Q/b5UmKD9Y+CmZsrt/7V3h8KNczowupfuBfIHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/checkbox": "2.3.2",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "framer-motion": ">=4.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/table": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/table/-/table-2.1.0.tgz",
+      "integrity": "sha512-o5OrjoHCh5uCLdiUb0Oc0vq9rIAeHSIRScc2ExTC9Qg/uVZl2ygLrjToCaKfaaKl1oQexIeAcZDKvPG8tVkHyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/tabs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/tabs/-/tabs-3.0.0.tgz",
+      "integrity": "sha512-6Mlclp8L9lqXmsGWF5q5gmemZXOiOYuh0SGT/7PgJVNPz3LXREXlXg2an4MBUD8W5oTkduCX+3KTMCwRrVrDYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/clickable": "2.1.0",
+        "@chakra-ui/descendant": "3.1.0",
+        "@chakra-ui/lazy-utils": "2.0.5",
+        "@chakra-ui/react-children-utils": "2.0.6",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-controllable-state": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/tag": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/tag/-/tag-3.1.1.tgz",
+      "integrity": "sha512-Bdel79Dv86Hnge2PKOU+t8H28nm/7Y3cKd4Kfk9k3lOpUh4+nkSGe58dhRzht59lEqa4N9waCgQiBdkydjvBXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/icon": "3.2.0",
+        "@chakra-ui/react-context": "2.1.0"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/textarea": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/textarea/-/textarea-2.1.2.tgz",
+      "integrity": "sha512-ip7tvklVCZUb2fOHDb23qPy/Fr2mzDOGdkrpbNi50hDCiV4hFX02jdQJdi3ydHZUyVgZVBKPOJ+lT9i7sKA2wA==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/form-control": "2.2.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/theme": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/theme/-/theme-3.3.1.tgz",
+      "integrity": "sha512-Hft/VaT8GYnItGCBbgWd75ICrIrIFrR7lVOhV/dQnqtfGqsVDlrztbSErvMkoPKt0UgAkd9/o44jmZ6X4U2nZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/anatomy": "2.2.2",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@chakra-ui/theme-tools": "2.1.2"
+      },
+      "peerDependencies": {
+        "@chakra-ui/styled-system": ">=2.8.0"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/theme-tools": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/theme-tools/-/theme-tools-2.1.2.tgz",
+      "integrity": "sha512-Qdj8ajF9kxY4gLrq7gA+Azp8CtFHGO9tWMN2wfF9aQNgG9AuMhPrUzMq9AMQ0MXiYcgNq/FD3eegB43nHVmXVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/anatomy": "2.2.2",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "color2k": "^2.0.2"
+      },
+      "peerDependencies": {
+        "@chakra-ui/styled-system": ">=2.0.0"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/toast": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/toast/-/toast-7.0.2.tgz",
+      "integrity": "sha512-yvRP8jFKRs/YnkuE41BVTq9nB2v/KDRmje9u6dgDmE5+1bFt3bwjdf9gVbif4u5Ve7F7BGk5E093ARRVtvLvXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/alert": "2.2.2",
+        "@chakra-ui/close-button": "2.1.1",
+        "@chakra-ui/portal": "2.1.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/react-use-timeout": "2.1.0",
+        "@chakra-ui/react-use-update-effect": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@chakra-ui/styled-system": "2.9.2",
+        "@chakra-ui/theme": "3.3.1"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": "2.6.2",
+        "framer-motion": ">=4.0.0",
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/tooltip": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/tooltip/-/tooltip-2.3.1.tgz",
+      "integrity": "sha512-Rh39GBn/bL4kZpuEMPPRwYNnccRCL+w9OqamWHIB3Qboxs6h8cOyXfIdGxjo72lvhu1QI/a4KFqkM3St+WfC0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/dom-utils": "2.1.0",
+        "@chakra-ui/popper": "3.1.0",
+        "@chakra-ui/portal": "2.1.0",
+        "@chakra-ui/react-types": "2.0.7",
+        "@chakra-ui/react-use-disclosure": "2.1.0",
+        "@chakra-ui/react-use-event-listener": "2.1.0",
+        "@chakra-ui/react-use-merge-refs": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "framer-motion": ">=4.0.0",
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/transition": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/transition/-/transition-2.1.0.tgz",
+      "integrity": "sha512-orkT6T/Dt+/+kVwJNy7zwJ+U2xAZ3EU7M3XCs45RBvUnZDr/u9vdmaM/3D/rOpmQJWgQBwKPJleUXrYWUagEDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "framer-motion": ">=4.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/utils": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-2.0.15.tgz",
+      "integrity": "sha512-El4+jL0WSaYYs+rJbuYFDbjmfCcfGDmRY95GO4xwzit6YAPZBLcR65rOEwLps+XWluZTy1xdMrusg/hW0c1aAA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/lodash.mergewith": "4.6.7",
+        "css-box-model": "1.2.1",
+        "framesync": "6.1.2",
+        "lodash.mergewith": "4.6.2"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@chakra-ui/visually-hidden": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/visually-hidden/-/visually-hidden-2.2.0.tgz",
+      "integrity": "sha512-KmKDg01SrQ7VbTD3+cPWf/UfpF5MSwm3v7MWi0n5t8HnnadT13MF0MJCDSXbBWnzLv1ZKJ6zlyAOeARWX+DpjQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@types/lodash.mergewith": {
+      "version": "4.6.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.mergewith/-/lodash.mergewith-4.6.7.tgz",
+      "integrity": "sha512-3m+lkO5CLRRYU0fhGRp7zbsGi6+BZj0uTVSwvcKU+nSlhjA9/QRNfuSGnD2mX6hQA7ZbmcCkzk5h4ZYGOtk14A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/lodash": "*"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@zag-js/dom-query": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-0.16.0.tgz",
+      "integrity": "sha512-Oqhd6+biWyKnhKwFFuZrrf6lxBz2tX2pRQe6grUnYwO6HJ8BcbqZomy2lpOdr+3itlaUqx+Ywj5E5ZZDr/LBfQ==",
+      "license": "MIT"
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/@zag-js/focus-visible": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/focus-visible/-/focus-visible-0.16.0.tgz",
+      "integrity": "sha512-a7U/HSopvQbrDU4GLerpqiMcHKEkQkNPeDZJWz38cw/6Upunh41GjHetq5TB84hxyCaDzJ6q2nEdNoBQfC0FKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/dom-query": "0.16.0"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/compute-scroll-into-view": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.0.3.tgz",
+      "integrity": "sha512-nadqwNxghAGTamwIqQSG433W6OADZx2vCo3UXHNrzTRHK/htu+7+L0zhjEoaeaQVNAi3YgqWDv8+tzf0hRfR+A==",
+      "license": "MIT"
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/mathjs": {
       "version": "12.4.3",
       "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-12.4.3.tgz",
       "integrity": "sha512-oHdGPDbp7gO873xxG90RLq36IuicuKvbpr/bBG5g9c8Obm/VsKVrK9uoRZZHUodohzlnmCEqfDzbR3LH6m+aAQ==",
@@ -3001,10 +3727,10 @@
         "node": ">= 18"
       }
     },
-    "node_modules/@concord-consortium/codap-formulas-react17/node_modules/mobx-react-lite": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-4.1.0.tgz",
-      "integrity": "sha512-QEP10dpHHBeQNv1pks3WnHRCem2Zp636lq54M2nKO2Sarr13pL4u6diQXf65yzXUn0mkk18SyIDCm9UOJYTi1w==",
+    "node_modules/@concord-consortium/codap-formulas/node_modules/mobx-react-lite": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-4.1.1.tgz",
+      "integrity": "sha512-iUxiMpsvNraCKXU+yPotsOncNNmyeS2B5DKL+TL6Tar/xm+wwNJAubJmtRSeAoYawdZqwv8Z/+5nPRHeQxTiXg==",
       "license": "MIT",
       "dependencies": {
         "use-sync-external-store": "^1.4.0"
@@ -3026,16 +3752,7 @@
         }
       }
     },
-    "node_modules/@concord-consortium/codap-formulas-react17/node_modules/mobx-react-lite/node_modules/use-sync-external-store": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
-      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@concord-consortium/codap-formulas-react17/node_modules/type-fest": {
+    "node_modules/@concord-consortium/codap-formulas/node_modules/type-fest": {
       "version": "4.41.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
       "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
@@ -3047,13 +3764,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@concord-consortium/codap-formulas-react17/node_modules/typed-function": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-4.2.1.tgz",
-      "integrity": "sha512-EGjWssW7Tsk4DGfE+5yluuljS1OGYWiI1J6e8puZz9nTMM51Oug8CD5Zo4gWMsOhq5BI+1bF+rWTm4Vbj3ivRA==",
+    "node_modules/@concord-consortium/codap-formulas/node_modules/typed-function": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-4.2.2.tgz",
+      "integrity": "sha512-VwaXim9Gp1bngi/q3do8hgttYn2uC3MoT/gfuMWylnj1IeZBUAyPddHZlo1K05BDoj8DYPpMdiHqH1dDYdJf2A==",
       "license": "MIT",
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/@concord-consortium/codap-formulas/node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@concord-consortium/codap-utilities": {
@@ -3163,30 +3889,255 @@
       }
     },
     "node_modules/@concord-consortium/diagram-view": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-1.0.2.tgz",
-      "integrity": "sha512-RlaTEc8U3v2sXpBicHi4Ka8jafWv9z5vZqGkYGOMiFA+O3yvJtFY7KnFKeIOdVcIVHvGwdvUEDg4Cot0NjBknA==",
+      "version": "2.0.0-pre.2",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-2.0.0-pre.2.tgz",
+      "integrity": "sha512-AiR5J/O2bAAE3pPBOA3d0cbUEu+rRNzOYsmUShOUqVXsyzq8M1ehDuRa4chGzsfMhgTZsRkiOzYD5xltlmaL7w==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@uiw/react-color-circle": "^2.10.1",
         "classnames": "^2.3.2",
         "iframe-phone": "^1.3.1",
         "mathjs": "^10.4.1",
         "patch-package": "^6.5.1",
         "pluralize": "^8.0.0",
-        "react-color": "^2.19.3",
         "react-textarea-autosize": "^8.3.4",
         "reactflow": "^11.7.2"
       },
       "peerDependencies": {
-        "@concord-consortium/mobx-state-tree": "^5.1.8-cc.1 || ^6.0.0-cc.1",
+        "@concord-consortium/mobx-state-tree": "^6.0.0-cc.1",
         "mobx": "^6.4.2",
         "mobx-react-lite": "^3.3.0",
         "nanoid": "^3.3.1",
         "rc-slider": "^10.2.1",
-        "react": "^17.0.2",
-        "react-dom": "^17.0.2",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0",
         "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@concord-consortium/diagram-view/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@concord-consortium/diagram-view/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@concord-consortium/diagram-view/node_modules/ci-info": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+      "license": "MIT"
+    },
+    "node_modules/@concord-consortium/diagram-view/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@concord-consortium/diagram-view/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/@concord-consortium/diagram-view/node_modules/cross-spawn": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
+      "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
+      "license": "MIT",
+      "dependencies": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      },
+      "engines": {
+        "node": ">=4.8"
+      }
+    },
+    "node_modules/@concord-consortium/diagram-view/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@concord-consortium/diagram-view/node_modules/is-ci": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+      "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+      "license": "MIT",
+      "dependencies": {
+        "ci-info": "^2.0.0"
+      },
+      "bin": {
+        "is-ci": "bin.js"
+      }
+    },
+    "node_modules/@concord-consortium/diagram-view/node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@concord-consortium/diagram-view/node_modules/patch-package": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-6.5.1.tgz",
+      "integrity": "sha512-I/4Zsalfhc6bphmJTlrLoOcAF87jcxko4q0qsv4bGcurbr8IskEOtdnt9iCmsQVGL1B+iUhSQqweyTLJfCF9rA==",
+      "license": "MIT",
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "cross-spawn": "^6.0.5",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^9.0.0",
+        "is-ci": "^2.0.0",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "rimraf": "^2.6.3",
+        "semver": "^5.6.0",
+        "slash": "^2.0.0",
+        "tmp": "^0.0.33",
+        "yaml": "^1.10.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">5"
+      }
+    },
+    "node_modules/@concord-consortium/diagram-view/node_modules/path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@concord-consortium/diagram-view/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/@concord-consortium/diagram-view/node_modules/shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@concord-consortium/diagram-view/node_modules/shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@concord-consortium/diagram-view/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@concord-consortium/diagram-view/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@concord-consortium/diagram-view/node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "license": "MIT",
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/@concord-consortium/diagram-view/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
       }
     },
     "node_modules/@concord-consortium/lara-interactive-api": {
@@ -3246,35 +4197,30 @@
       }
     },
     "node_modules/@concord-consortium/slate-editor": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/slate-editor/-/slate-editor-0.10.1.tgz",
-      "integrity": "sha512-RK86HWXAb6lg1ocbDC05C2Zfb2sxvZncvO0gjDNk6ToQK9M/R1k3cbas+Ft0xmsFBEDXG5Z9iG2bnymvHYI0zw==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/slate-editor/-/slate-editor-0.12.0.tgz",
+      "integrity": "sha512-NhYGV+3IMuIIoW23p/z4Fwdlw2P+Mt7LfbrIO88sGsChIJ1MZ/3yR2LSZrA9Asw1SthgNpRtJCsS0U/nHDNyiA==",
+      "license": "MIT",
       "dependencies": {
-        "@emotion/css": "^11.13.0",
+        "@emotion/css": "^11.13.5",
         "classnames": "^2.5.1",
-        "eventemitter3": "^5.0.1",
         "html-escaper": "^3.0.3",
         "is-hotkey": "^0.2.0",
         "lodash": "^4.17.21",
-        "react-select": "^5.8.0",
+        "react-select": "^5.10.2",
         "rgb-hex": "^3.0.0",
-        "slate": "^0.103.0",
-        "slate-history": "^0.100.0",
+        "slate": "^0.118.1",
+        "slate-history": "^0.113.1",
         "slate-hyperscript": "^0.100.0",
-        "slate-react": "~0.98.4",
-        "style-to-object": "^1.0.6",
-        "tslib": "^2.6.3",
+        "slate-react": "^0.117.4",
+        "style-to-object": "^1.0.9",
+        "tslib": "^2.8.1",
         "valid-url": "^1.0.9"
       },
       "peerDependencies": {
-        "react": ">=16.14",
-        "react-dom": ">=16.14"
+        "react": ">=18",
+        "react-dom": ">=18"
       }
-    },
-    "node_modules/@concord-consortium/slate-editor/node_modules/eventemitter3": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
     "node_modules/@concord-consortium/slate-editor/node_modules/html-escaper": {
       "version": "3.0.3",
@@ -3418,13 +4364,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@ctrl/tinycolor": {
-      "version": "3.6.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@cypress/code-coverage": {
@@ -4232,7 +5171,6 @@
     },
     "node_modules/@firebase/app-types": {
       "version": "0.7.0",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/app/node_modules/@firebase/app-types": {
@@ -5015,14 +5953,6 @@
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true,
       "license": "BSD-3-Clause"
-    },
-    "node_modules/@icons/material": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",
-      "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==",
-      "peerDependencies": {
-        "react": "*"
-      }
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -6508,7 +7438,7 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -6567,6 +7497,12 @@
       "version": "3.4.0",
       "license": "Apache-2.0"
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.4",
       "dev": true,
@@ -6611,58 +7547,6 @@
       "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
       "license": "MIT"
-    },
-    "node_modules/@motionone/animation": {
-      "version": "10.15.1",
-      "license": "MIT",
-      "dependencies": {
-        "@motionone/easing": "^10.15.1",
-        "@motionone/types": "^10.15.1",
-        "@motionone/utils": "^10.15.1",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@motionone/dom": {
-      "version": "10.12.0",
-      "license": "MIT",
-      "dependencies": {
-        "@motionone/animation": "^10.12.0",
-        "@motionone/generators": "^10.12.0",
-        "@motionone/types": "^10.12.0",
-        "@motionone/utils": "^10.12.0",
-        "hey-listen": "^1.0.8",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@motionone/easing": {
-      "version": "10.15.1",
-      "license": "MIT",
-      "dependencies": {
-        "@motionone/utils": "^10.15.1",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@motionone/generators": {
-      "version": "10.15.1",
-      "license": "MIT",
-      "dependencies": {
-        "@motionone/types": "^10.15.1",
-        "@motionone/utils": "^10.15.1",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@motionone/types": {
-      "version": "10.15.1",
-      "license": "MIT"
-    },
-    "node_modules/@motionone/utils": {
-      "version": "10.15.1",
-      "license": "MIT",
-      "dependencies": {
-        "@motionone/types": "^10.15.1",
-        "hey-listen": "^1.0.8",
-        "tslib": "^2.3.1"
-      }
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
@@ -6744,7 +7628,9 @@
       }
     },
     "node_modules/@popperjs/core": {
-      "version": "2.11.7",
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -6794,45 +7680,6 @@
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.0",
       "license": "BSD-3-Clause"
-    },
-    "node_modules/@reach/alert": {
-      "version": "0.13.2",
-      "license": "MIT",
-      "dependencies": {
-        "@reach/utils": "0.13.2",
-        "@reach/visually-hidden": "0.13.2",
-        "prop-types": "^15.7.2",
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || 17.x",
-        "react-dom": "^16.8.0 || 17.x"
-      }
-    },
-    "node_modules/@reach/utils": {
-      "version": "0.13.2",
-      "license": "MIT",
-      "dependencies": {
-        "@types/warning": "^3.0.0",
-        "tslib": "^2.1.0",
-        "warning": "^4.0.3"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || 17.x",
-        "react-dom": "^16.8.0 || 17.x"
-      }
-    },
-    "node_modules/@reach/visually-hidden": {
-      "version": "0.13.2",
-      "license": "MIT",
-      "dependencies": {
-        "prop-types": "^15.7.2",
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || 17.x",
-        "react-dom": "^16.8.0 || 17.x"
-      }
     },
     "node_modules/@reactflow/background": {
       "version": "11.2.2",
@@ -7630,12 +8477,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/@testing-library/cypress/node_modules/@types/aria-query": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.3.tgz",
-      "integrity": "sha512-0Z6Tr7wjKJIk4OUEjVUQMtyunLDy339vcMaj38Kpj6jM2OE1p3S4kXExKZ7a3uXQAPCoy3sbrP1wibDKaf39oA==",
-      "dev": true
-    },
     "node_modules/@testing-library/cypress/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -7707,85 +8548,33 @@
       }
     },
     "node_modules/@testing-library/dom": {
-      "version": "8.10.1",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^4.2.0",
-        "aria-query": "^5.0.0",
-        "chalk": "^4.1.0",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
         "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.4.4",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
         "pretty-format": "^27.0.2"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
-    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
-      "version": "4.3.0",
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
-      "license": "MIT",
+      "license": "Apache-2.0",
       "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/chalk": {
-      "version": "4.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/color-convert": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/color-name": {
-      "version": "1.1.4",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@testing-library/dom/node_modules/has-flag": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/supports-color": {
-      "version": "7.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
+        "dequal": "^2.0.3"
       }
     },
     "node_modules/@testing-library/jest-dom": {
@@ -7871,65 +8660,31 @@
       }
     },
     "node_modules/@testing-library/react": {
-      "version": "12.1.5",
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "@testing-library/dom": "^8.0.0",
-        "@types/react-dom": "<18.0.0"
+        "@babel/runtime": "^7.12.5"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "react": "<18.0.0",
-        "react-dom": "<18.0.0"
-      }
-    },
-    "node_modules/@testing-library/react-hooks": {
-      "version": "8.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "react-error-boundary": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.9.0 || ^17.0.0",
-        "react": "^16.9.0 || ^17.0.0",
-        "react-dom": "^16.9.0 || ^17.0.0",
-        "react-test-renderer": "^16.9.0 || ^17.0.0"
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
           "optional": true
         },
-        "react-dom": {
-          "optional": true
-        },
-        "react-test-renderer": {
+        "@types/react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@testing-library/react-hooks/node_modules/react-error-boundary": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
-      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.12.5"
-      },
-      "engines": {
-        "node": ">=10",
-        "npm": ">=6"
-      },
-      "peerDependencies": {
-        "react": ">=16.13.1"
       }
     },
     "node_modules/@testing-library/user-event": {
@@ -7995,7 +8750,9 @@
       }
     },
     "node_modules/@types/aria-query": {
-      "version": "4.2.2",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
       "license": "MIT"
     },
@@ -8053,14 +8810,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
-      }
-    },
-    "node_modules/@types/chart.js": {
-      "version": "2.9.37",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "moment": "^2.10.2"
       }
     },
     "node_modules/@types/color-string": {
@@ -8386,6 +9135,7 @@
     },
     "node_modules/@types/is-hotkey": {
       "version": "0.1.7",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
@@ -8503,7 +9253,9 @@
       "license": "MIT"
     },
     "node_modules/@types/lodash.mergewith": {
-      "version": "4.6.6",
+      "version": "4.6.9",
+      "resolved": "https://registry.npmjs.org/@types/lodash.mergewith/-/lodash.mergewith-4.6.9.tgz",
+      "integrity": "sha512-fgkoCAOF47K7sxrQ7Mlud2TH023itugZs2bUg8h/KzT+BnZNrR2jAOmaokbLunHNnobXVWOezAeNn/lZqwxkcw==",
       "license": "MIT",
       "dependencies": {
         "@types/lodash": "*"
@@ -8596,20 +9348,23 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "17.0.48",
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
-        "@types/scheduler": "*",
-        "csstype": "^3.0.2"
+        "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "17.0.17",
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@types/react": "^17"
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
       }
     },
     "node_modules/@types/react-modal": {
@@ -8621,11 +9376,14 @@
       }
     },
     "node_modules/@types/react-tabs": {
-      "version": "2.3.4",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@types/react-tabs/-/react-tabs-5.0.5.tgz",
+      "integrity": "sha512-3CZTmjR7nNrZnYbnxp/DtK5e82mhM22dN47aYObmYLcp9fC1XjIEF0mLzGKFl1fR6/R8X7DyGh9hO6lON6LVkQ==",
+      "deprecated": "This is a stub types definition. react-tabs provides its own type definitions, so you do not need this installed.",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/react": "*"
+        "react-tabs": "*"
       }
     },
     "node_modules/@types/react-transition-group": {
@@ -8643,10 +9401,6 @@
     "node_modules/@types/rtree": {
       "version": "1.4.28",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/scheduler": {
-      "version": "0.16.2",
       "license": "MIT"
     },
     "node_modules/@types/seedrandom": {
@@ -8731,10 +9485,6 @@
     "node_modules/@types/w3c-web-serial": {
       "version": "1.0.2",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/warning": {
-      "version": "3.0.0",
       "license": "MIT"
     },
     "node_modules/@types/ws": {
@@ -9191,6 +9941,18 @@
         "@codemirror/view": ">=6.0.0"
       }
     },
+    "node_modules/@uiw/color-convert": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@uiw/color-convert/-/color-convert-2.10.1.tgz",
+      "integrity": "sha512-/Z3YfBiX+SErRM59yQH88Id+Xy/k10nnkfTuqhX6RB2yYUcG57DoFqb6FudhiQ5fwzKvKf1k4xq9lfT1UTFUKQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0"
+      }
+    },
     "node_modules/@uiw/react-codemirror": {
       "version": "4.23.13",
       "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.23.13.tgz",
@@ -9215,6 +9977,41 @@
         "codemirror": ">=6.0.0",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@uiw/react-color-circle": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-circle/-/react-color-circle-2.10.1.tgz",
+      "integrity": "sha512-f7/RPnpOGOktmuX1pdPBvXNRoq4irddKG3LU+6vETB7DI0aJiYZH+NXPSrdtNM9j5msdPVH6aGZmfOVJMfbx/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@uiw/color-convert": "2.10.1",
+        "@uiw/react-color-swatch": "2.10.1"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@uiw/react-color-swatch": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-swatch/-/react-color-swatch-2.10.1.tgz",
+      "integrity": "sha512-DuGlaIszNcvtsY8BfW+RiUkEK1yVmnAamkzc/S5cQZwaAA5bCKhwwyaKPqh1/XWs7pR4pysjSNlMaeqaSOO34A==",
+      "license": "MIT",
+      "dependencies": {
+        "@uiw/color-convert": "2.10.1"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
       }
     },
     "node_modules/@ungap/structured-clone": {
@@ -9904,6 +10701,27 @@
       "version": "1.1.0",
       "license": "BSD-2-Clause"
     },
+    "node_modules/@zag-js/dom-query": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-0.31.1.tgz",
+      "integrity": "sha512-oiuohEXAXhBxpzzNm9k2VHGEOLC1SXlXSbRPcfBZ9so5NRQUA++zCE7cyQJqGLTZR0t3itFLlZqDbYEXRrefwg==",
+      "license": "MIT"
+    },
+    "node_modules/@zag-js/element-size": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@zag-js/element-size/-/element-size-0.31.1.tgz",
+      "integrity": "sha512-4T3yvn5NqqAjhlP326Fv+w9RqMIBbNN9H72g5q2ohwzhSgSfZzrKtjL4rs9axY/cw9UfMfXjRjEE98e5CMq7WQ==",
+      "license": "MIT"
+    },
+    "node_modules/@zag-js/focus-visible": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@zag-js/focus-visible/-/focus-visible-0.31.1.tgz",
+      "integrity": "sha512-dbLksz7FEwyFoANbpIlNnd3bVm0clQSUsnP8yUVQucStZPsuWjCrhL2jlAbGNrTrahX96ntUMXHb/sM68TibFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/dom-query": "0.31.1"
+      }
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "dev": true,
@@ -10180,7 +10998,9 @@
       }
     },
     "node_modules/aria-hidden": {
-      "version": "1.2.3",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.0"
@@ -10686,7 +11506,7 @@
       "version": "2.9.19",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
       "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
@@ -10695,10 +11515,6 @@
     "node_modules/batch": {
       "version": "0.6.1",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/batch-processor": {
-      "version": "1.0.0",
       "license": "MIT"
     },
     "node_modules/bcrypt-pbkdf": {
@@ -10871,7 +11687,7 @@
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
       "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -10998,11 +11814,18 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.2",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
       "license": "MIT",
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -11019,6 +11842,22 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -11057,7 +11896,7 @@
       "version": "1.0.30001767",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001767.tgz",
       "integrity": "sha512-34+zUAMhSH+r+9eKmYG+k2Rpt8XttfE4yXAjoZvkAPs15xcYQhyBYdalJ65BzivAvGRMViEjy6oKr/S91loekQ==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -11112,26 +11951,15 @@
       }
     },
     "node_modules/chart.js": {
-      "version": "2.9.4",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
+      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
       "license": "MIT",
       "dependencies": {
-        "chartjs-color": "^2.1.0",
-        "moment": "^2.10.2"
-      }
-    },
-    "node_modules/chartjs-color": {
-      "version": "2.4.1",
-      "license": "MIT",
-      "dependencies": {
-        "chartjs-color-string": "^0.6.0",
-        "color-convert": "^1.9.3"
-      }
-    },
-    "node_modules/chartjs-color-string": {
-      "version": "0.6.0",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "^1.0.0"
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/check-more-types": {
@@ -11177,9 +12005,19 @@
       }
     },
     "node_modules/ci-info": {
-      "version": "3.2.0",
-      "dev": true,
-      "license": "MIT"
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/cjs-module-lexer": {
       "version": "2.2.0",
@@ -11328,6 +12166,7 @@
     },
     "node_modules/color-convert": {
       "version": "1.9.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
@@ -11344,6 +12183,12 @@
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
       }
+    },
+    "node_modules/color2k": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
+      "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog==",
+      "license": "MIT"
     },
     "node_modules/colord": {
       "version": "2.9.3",
@@ -11459,9 +12304,10 @@
       "license": "MIT"
     },
     "node_modules/compute-scroll-into-view": {
-      "version": "1.0.20",
-      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.20.tgz",
-      "integrity": "sha512-UCB0ioiyj8CRjtrvaceBLqqhZCVP+1B8+NWQhmdsm0VXOJtobBCf1dBQmebCCo34qZmUwZfIH2MZLqNHazrfjg=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
+      "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==",
+      "license": "MIT"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -11533,7 +12379,9 @@
       "license": "MIT"
     },
     "node_modules/copy-to-clipboard": {
-      "version": "3.3.1",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
+      "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
       "license": "MIT",
       "dependencies": {
         "toggle-selection": "^1.0.6"
@@ -11793,7 +12641,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -11806,6 +12653,8 @@
     },
     "node_modules/css-box-model": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz",
+      "integrity": "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==",
       "license": "MIT",
       "dependencies": {
         "tiny-invariant": "^1.0.6"
@@ -11964,7 +12813,9 @@
       }
     },
     "node_modules/csstype": {
-      "version": "3.0.9",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
     "node_modules/cypress": {
@@ -12853,17 +13704,20 @@
       }
     },
     "node_modules/define-data-property": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
-      "integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
-      "dev": true,
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
       "dependencies": {
-        "get-intrinsic": "^1.2.1",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.0"
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/define-lazy-prop": {
@@ -12913,6 +13767,16 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/destroy": {
       "version": "1.2.0",
       "dev": true,
@@ -12938,6 +13802,8 @@
     },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
     },
     "node_modules/dezalgo": {
@@ -13208,15 +14074,8 @@
       "version": "1.5.286",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
       "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
-    },
-    "node_modules/element-resize-detector": {
-      "version": "1.2.3",
-      "license": "MIT",
-      "dependencies": {
-        "batch-processor": "1.0.0"
-      }
     },
     "node_modules/emittery": {
       "version": "0.13.1",
@@ -13467,6 +14326,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
+      "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/es6-error": {
       "version": "4.1.1",
@@ -14835,7 +15704,9 @@
       "license": "ISC"
     },
     "node_modules/focus-lock": {
-      "version": "0.9.2",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-1.3.6.tgz",
+      "integrity": "sha512-Ik/6OCk9RQQ0T5Xw+hKNLWrjSMtv51dD4GRmJjbD5a58TIEpI5a5iXagKVl3Z5UuyslMCA8Xwnu76jQob62Yhg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.3"
@@ -14966,50 +15837,46 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "6.5.1",
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
+      "integrity": "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==",
       "license": "MIT",
       "dependencies": {
-        "@motionone/dom": "10.12.0",
-        "framesync": "6.0.1",
-        "hey-listen": "^1.0.8",
-        "popmotion": "11.0.3",
-        "style-value-types": "5.0.0",
-        "tslib": "^2.1.0"
-      },
-      "optionalDependencies": {
-        "@emotion/is-prop-valid": "^0.8.2"
+        "motion-dom": "^12.38.0",
+        "motion-utils": "^12.36.0",
+        "tslib": "^2.4.0"
       },
       "peerDependencies": {
-        "react": ">=16.8 || ^17.0.0 || ^18.0.0",
-        "react-dom": ">=16.8 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/framer-motion/node_modules/@emotion/is-prop-valid": {
-      "version": "0.8.8",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emotion/memoize": "0.7.4"
-      }
-    },
-    "node_modules/framer-motion/node_modules/@emotion/memoize": {
-      "version": "0.7.4",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/framer-motion/node_modules/framesync": {
-      "version": "6.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.1.0"
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/framesync": {
-      "version": "5.3.0",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/framesync/-/framesync-6.1.2.tgz",
+      "integrity": "sha512-jBTqhX6KaQVDyus8muwZbBeGGP0XgujBRbQ7gM7BRdS3CadCZIHiawyzYLnafYcvZIh5j8WE7cxZKFn7dXhu9g==",
       "license": "MIT",
       "dependencies": {
-        "tslib": "^2.1.0"
+        "tslib": "2.4.0"
       }
+    },
+    "node_modules/framesync/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "license": "0BSD"
     },
     "node_modules/fresh": {
       "version": "0.5.2",
@@ -15184,7 +16051,7 @@
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -15223,6 +16090,8 @@
     },
     "node_modules/get-nonce": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -15831,11 +16700,12 @@
       }
     },
     "node_modules/has-property-descriptors": {
-      "version": "1.0.0",
-      "dev": true,
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "license": "MIT",
       "dependencies": {
-        "get-intrinsic": "^1.1.1"
+        "es-define-property": "^1.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -15920,10 +16790,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/hey-listen": {
-      "version": "1.0.8",
-      "license": "MIT"
     },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
@@ -16353,9 +17219,10 @@
       "license": "MIT"
     },
     "node_modules/inline-style-parser": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.4.tgz",
-      "integrity": "sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q=="
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
     },
     "node_modules/internal-slot": {
       "version": "1.0.5",
@@ -16383,13 +17250,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/invariant": {
-      "version": "2.2.4",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/ipaddr.js": {
@@ -20179,9 +21039,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "license": "MIT"
     },
     "node_modules/json-stringify-pretty-compact": {
@@ -20196,7 +21081,7 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -20258,6 +21143,15 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/jsonwebtoken": {
@@ -20653,11 +21547,6 @@
       "version": "4.17.21",
       "license": "MIT"
     },
-    "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
-    },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "license": "MIT"
@@ -20713,6 +21602,8 @@
     },
     "node_modules/lodash.mergewith": {
       "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
       "license": "MIT"
     },
     "node_modules/lodash.once": {
@@ -20996,11 +21887,6 @@
         "@babel/runtime": "^7.12.5",
         "remove-accents": "0.4.2"
       }
-    },
-    "node_modules/material-colors": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz",
-      "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "node_modules/math-expression-evaluator": {
       "version": "1.4.0",
@@ -21371,13 +22257,6 @@
         "mobx": "^6.3.0"
       }
     },
-    "node_modules/moment": {
-      "version": "2.29.4",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/moo-color": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/moo-color/-/moo-color-1.0.3.tgz",
@@ -21393,6 +22272,21 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/motion-dom": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
+      "integrity": "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.36.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.36.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
+      "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
       "license": "MIT"
     },
     "node_modules/ms": {
@@ -21577,7 +22471,7 @@
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/normalize-path": {
@@ -21829,7 +22723,6 @@
     },
     "node_modules/object-keys": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -22000,6 +22893,8 @@
     },
     "node_modules/os-tmpdir": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -22178,30 +23073,31 @@
       }
     },
     "node_modules/patch-package": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-6.5.1.tgz",
-      "integrity": "sha512-I/4Zsalfhc6bphmJTlrLoOcAF87jcxko4q0qsv4bGcurbr8IskEOtdnt9iCmsQVGL1B+iUhSQqweyTLJfCF9rA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
+      "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
+      "license": "MIT",
       "dependencies": {
         "@yarnpkg/lockfile": "^1.1.0",
         "chalk": "^4.1.2",
-        "cross-spawn": "^6.0.5",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
         "find-yarn-workspace-root": "^2.0.0",
-        "fs-extra": "^9.0.0",
-        "is-ci": "^2.0.0",
+        "fs-extra": "^10.0.0",
+        "json-stable-stringify": "^1.0.2",
         "klaw-sync": "^6.0.0",
         "minimist": "^1.2.6",
         "open": "^7.4.2",
-        "rimraf": "^2.6.3",
-        "semver": "^5.6.0",
+        "semver": "^7.5.3",
         "slash": "^2.0.0",
-        "tmp": "^0.0.33",
-        "yaml": "^1.10.2"
+        "tmp": "^0.2.4",
+        "yaml": "^2.2.2"
       },
       "bin": {
         "patch-package": "index.js"
       },
       "engines": {
-        "node": ">=10",
+        "node": ">=14",
         "npm": ">5"
       }
     },
@@ -22234,10 +23130,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/patch-package/node_modules/ci-info": {
-      "version": "2.0.0",
-      "license": "MIT"
-    },
     "node_modules/patch-package/node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -22254,18 +23146,18 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
-    "node_modules/patch-package/node_modules/cross-spawn": {
-      "version": "6.0.5",
+    "node_modules/patch-package/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
       "license": "MIT",
       "dependencies": {
-        "nice-try": "^1.0.4",
-        "path-key": "^2.0.1",
-        "semver": "^5.5.0",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
       },
       "engines": {
-        "node": ">=4.8"
+        "node": ">=12"
       }
     },
     "node_modules/patch-package/node_modules/has-flag": {
@@ -22274,16 +23166,6 @@
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/patch-package/node_modules/is-ci": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "ci-info": "^2.0.0"
-      },
-      "bin": {
-        "is-ci": "bin.js"
       }
     },
     "node_modules/patch-package/node_modules/open": {
@@ -22300,38 +23182,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/patch-package/node_modules/path-key": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/patch-package/node_modules/rimraf": {
-      "version": "2.7.1",
+    "node_modules/patch-package/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
       "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/patch-package/node_modules/shebang-command": {
-      "version": "1.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "shebang-regex": "^1.0.0"
+        "semver": "bin/semver.js"
       },
       "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/patch-package/node_modules/shebang-regex": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
+        "node": ">=10"
       }
     },
     "node_modules/patch-package/node_modules/slash": {
@@ -22353,23 +23213,27 @@
       }
     },
     "node_modules/patch-package/node_modules/tmp": {
-      "version": "0.0.33",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
       "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
       "engines": {
-        "node": ">=0.6.0"
+        "node": ">=14.14"
       }
     },
-    "node_modules/patch-package/node_modules/which": {
-      "version": "1.3.1",
+    "node_modules/patch-package/node_modules/yaml": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+      "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
       "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
       "bin": {
-        "which": "bin/which"
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/path-exists": {
@@ -22389,7 +23253,6 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -22508,23 +23371,6 @@
       "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/popmotion": {
-      "version": "11.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "framesync": "6.0.1",
-        "hey-listen": "^1.0.8",
-        "style-value-types": "5.0.0",
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/popmotion/node_modules/framesync": {
-      "version": "6.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.1.0"
       }
     },
     "node_modules/popper.js": {
@@ -23129,77 +23975,72 @@
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
     },
     "node_modules/react": {
-      "version": "17.0.2",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-chartjs-2": {
-      "version": "2.11.2",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.1.tgz",
+      "integrity": "sha512-h5IPXKg9EXpjoBzUfyWJvllMjG2mQ4EiuHQFhms/AjUm0XSZHhyRy2xVmLXHKrtcdrPO4mnGqRtYoD0vp95A0A==",
       "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.7.2"
-      },
       "peerDependencies": {
-        "chart.js": "^2.3",
-        "react": "^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0",
-        "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-clientside-effect": {
-      "version": "1.2.6",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.8.tgz",
+      "integrity": "sha512-ma2FePH0z3px2+WOu6h+YycZcEvFmmxIlAb62cF52bG86eMySciO/EQZeQMXd07kPCYB0a1dWDT5J+KE9mCDUw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.13"
       },
       "peerDependencies": {
-        "react": "^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/react-color": {
-      "version": "2.19.3",
-      "resolved": "https://registry.npmjs.org/react-color/-/react-color-2.19.3.tgz",
-      "integrity": "sha512-LEeGE/ZzNLIsFWa1TMe8y5VYqr7bibneWmvJwm1pCn/eNmrabWDh659JSPn9BuaMpEfU83WTOJfnCcjDZwNQTA==",
-      "dependencies": {
-        "@icons/material": "^0.2.4",
-        "lodash": "^4.17.15",
-        "lodash-es": "^4.17.15",
-        "material-colors": "^1.2.1",
-        "prop-types": "^15.5.10",
-        "reactcss": "^1.2.0",
-        "tinycolor2": "^1.4.1"
-      },
-      "peerDependencies": {
-        "react": "*"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/react-data-grid": {
-      "version": "7.0.0-canary.46",
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/react-data-grid/-/react-data-grid-7.0.0-beta.44.tgz",
+      "integrity": "sha512-VTql8VPBJEf7E+zkrqYW+jaQT1/m47dxigWzPq59QESJ8LhU59kHyzIx06BUpjdZKdK/tzbWaw2yyJpKoNnt5g==",
       "license": "MIT",
       "dependencies": {
-        "clsx": "^1.1.1"
+        "clsx": "^2.0.0"
       },
       "peerDependencies": {
-        "react": "^16.14 || ^17.0",
-        "react-dom": "^16.14 || ^17.0"
+        "react": "^18.0",
+        "react-dom": "^18.0"
+      }
+    },
+    "node_modules/react-data-grid/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/react-dom": {
-      "version": "17.0.2",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "scheduler": "^0.20.2"
+        "scheduler": "^0.23.2"
       },
       "peerDependencies": {
-        "react": "17.0.2"
+        "react": "^18.3.1"
       }
     },
     "node_modules/react-dom-factories": {
@@ -23218,22 +24059,32 @@
       }
     },
     "node_modules/react-fast-compare": {
-      "version": "3.2.0",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
       "license": "MIT"
     },
     "node_modules/react-focus-lock": {
-      "version": "2.5.2",
+      "version": "2.13.7",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.13.7.tgz",
+      "integrity": "sha512-20lpZHEQrXPb+pp1tzd4ULL6DyO5D2KnR0G69tTDdydrmNhU7pdFmbQUYVyHUgp+xN29IuFR0PVuhOmvaZL9Og==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
-        "focus-lock": "^0.9.1",
+        "focus-lock": "^1.3.6",
         "prop-types": "^15.6.2",
-        "react-clientside-effect": "^1.2.5",
-        "use-callback-ref": "^1.2.5",
-        "use-sidecar": "^1.0.5"
+        "react-clientside-effect": "^1.2.7",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0"
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-hook-form": {
@@ -23301,21 +24152,23 @@
       }
     },
     "node_modules/react-remove-scroll": {
-      "version": "2.4.1",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
       "license": "MIT",
       "dependencies": {
-        "react-remove-scroll-bar": "^2.1.0",
-        "react-style-singleton": "^2.1.0",
-        "tslib": "^1.0.0",
-        "use-callback-ref": "^1.2.3",
-        "use-sidecar": "^1.0.1"
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
       },
       "engines": {
-        "node": ">=8.5.0"
+        "node": ">=10"
       },
       "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0",
-        "react": "^16.8.0 || ^17.0.0"
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -23324,18 +24177,20 @@
       }
     },
     "node_modules/react-remove-scroll-bar": {
-      "version": "2.3.4",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
       "license": "MIT",
       "dependencies": {
-        "react-style-singleton": "^2.2.1",
+        "react-style-singleton": "^2.2.2",
         "tslib": "^2.0.0"
       },
       "engines": {
         "node": ">=10"
       },
       "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -23343,25 +24198,23 @@
         }
       }
     },
-    "node_modules/react-remove-scroll/node_modules/tslib": {
-      "version": "1.14.1",
-      "license": "0BSD"
-    },
     "node_modules/react-resize-detector": {
-      "version": "8.1.0",
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-12.3.0.tgz",
+      "integrity": "sha512-mIDOVrTHKGnKe6qEUWi8dFdfHM5CPyTOpqoHctdMQf89Ljm/0qqDIzkP3vTRZZJi9/raaMiRxDEOqO4you5x+A==",
       "license": "MIT",
       "dependencies": {
-        "lodash": "^4.17.21"
+        "es-toolkit": "^1.39.6"
       },
       "peerDependencies": {
-        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
+        "react": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-select": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.10.1.tgz",
-      "integrity": "sha512-roPEZUL4aRZDx6DcsD+ZNreVl+fM8VsKn0Wtex1v4IazH60ILp5xhdlp464IsEAlJdXeD+BhDAFsBVMfvLQueA==",
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.10.2.tgz",
+      "integrity": "sha512-Z33nHdEFWq9tfnfVXaiM12rbJmk+QjFEztWLtmXqQhz6Al4UZZ9xc0wiatmGtUOCCnHN0WizL3tCMYRENX4rVQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.0",
         "@emotion/cache": "^11.4.0",
@@ -23378,30 +24231,21 @@
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/react-sizeme": {
-      "version": "3.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "element-resize-detector": "^1.2.2",
-        "invariant": "^2.2.4",
-        "shallowequal": "^1.1.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
     "node_modules/react-style-singleton": {
-      "version": "2.2.1",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
       "license": "MIT",
       "dependencies": {
         "get-nonce": "^1.0.0",
-        "invariant": "^2.2.4",
         "tslib": "^2.0.0"
       },
       "engines": {
         "node": ">=10"
       },
       "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -23410,14 +24254,25 @@
       }
     },
     "node_modules/react-tabs": {
-      "version": "3.2.3",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/react-tabs/-/react-tabs-6.1.1.tgz",
+      "integrity": "sha512-CPiuKoMFf89B7QlbFfdBD9XmUWiE3qudQputMVZB8GQvPJZRX/gqjDaDWOPDwGinEfpJKEuBCkGt83Tt4efeyA==",
       "license": "MIT",
       "dependencies": {
-        "clsx": "^1.1.0",
+        "clsx": "^2.0.0",
         "prop-types": "^15.5.0"
       },
       "peerDependencies": {
-        "react": "^16.3.0 || ^17.0.0-0"
+        "react": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-tabs/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/react-textarea-autosize": {
@@ -23455,14 +24310,6 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
-      }
-    },
-    "node_modules/reactcss": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/reactcss/-/reactcss-1.2.3.tgz",
-      "integrity": "sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==",
-      "dependencies": {
-        "lodash": "^4.0.1"
       }
     },
     "node_modules/reactflow": {
@@ -24114,11 +24961,12 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.20.2",
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/schema-utils": {
@@ -24147,11 +24995,12 @@
       }
     },
     "node_modules/scroll-into-view-if-needed": {
-      "version": "2.2.31",
-      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-2.2.31.tgz",
-      "integrity": "sha512-dGCXy99wZQivjmjIqihaBQNjryrz5rueJY7eHfTdyWEiR4ttYpsajb14rn9s5d4DY4EcY6+4+U/maARBXJedkA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-3.1.0.tgz",
+      "integrity": "sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==",
+      "license": "MIT",
       "dependencies": {
-        "compute-scroll-into-view": "^1.0.20"
+        "compute-scroll-into-view": "^3.0.2"
       }
     },
     "node_modules/seedrandom": {
@@ -24367,6 +25216,23 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/set-function-name": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.1.tgz",
@@ -24398,7 +25264,6 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -24409,7 +25274,6 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -24464,12 +25328,12 @@
       }
     },
     "node_modules/slate": {
-      "version": "0.103.0",
-      "resolved": "https://registry.npmjs.org/slate/-/slate-0.103.0.tgz",
-      "integrity": "sha512-eCUOVqUpADYMZ59O37QQvUdnFG+8rin0OGQAXNHvHbQeVJ67Bu0spQbcy621vtf8GQUXTEQBlk6OP9atwwob4w==",
+      "version": "0.118.1",
+      "resolved": "https://registry.npmjs.org/slate/-/slate-0.118.1.tgz",
+      "integrity": "sha512-6H1DNgnSwAFhq/pIgf+tLvjNzH912M5XrKKhP9Frmbds2zFXdSJ6L/uFNyVKxQIkPzGWPD0m+wdDfmEuGFH5Tg==",
+      "license": "MIT",
       "dependencies": {
         "immer": "^10.0.3",
-        "is-plain-object": "^5.0.0",
         "tiny-warning": "^1.0.3"
       }
     },
@@ -24477,8 +25341,8 @@
       "version": "0.117.4",
       "resolved": "https://registry.npmjs.org/slate-dom/-/slate-dom-0.117.4.tgz",
       "integrity": "sha512-eu5MMpphkCnr22R6hgFoQt/tEaHBjSdSy7uJjPOm++hCxstoLefp04EY50A4rXBovjkYoAncb9j8QoijZd0ENA==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@juggle/resize-observer": "^3.4.0",
         "direction": "^1.0.4",
@@ -24496,16 +25360,17 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
       "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/slate-history": {
-      "version": "0.100.0",
-      "resolved": "https://registry.npmjs.org/slate-history/-/slate-history-0.100.0.tgz",
-      "integrity": "sha512-x5rUuWLNtH97hs9PrFovGgt3Qc5zkTm/5mcUB+0NR/TK923eLax4HsL6xACLHMs245nI6aJElyM1y6hN0y5W/Q==",
+      "version": "0.113.1",
+      "resolved": "https://registry.npmjs.org/slate-history/-/slate-history-0.113.1.tgz",
+      "integrity": "sha512-J9NSJ+UG2GxoW0lw5mloaKcN0JI0x2IA5M5FxyGiInpn+QEutxT1WK7S/JneZCMFJBoHs1uu7S7e6pxQjubHmQ==",
+      "license": "MIT",
       "dependencies": {
         "is-plain-object": "^5.0.0"
       },
@@ -24517,6 +25382,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
       "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -24541,45 +25407,23 @@
       }
     },
     "node_modules/slate-react": {
-      "version": "0.98.4",
-      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.98.4.tgz",
-      "integrity": "sha512-8Of3v9hFuX8rIRc86LuuBhU9t8ps+9ARKL4yyhCrKQYZ93Ep/LFA3GvPGvtf3zYuVadZ8tkhRH8tbHOGNAndLw==",
+      "version": "0.117.4",
+      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.117.4.tgz",
+      "integrity": "sha512-9ckilyUzQS1VHJnstIpgInhcWnTDgv2Cd7m1HOQVl3zasChoapPSMftzT/wl/48grZaZYZIi4xVuzGTcFRUWFg==",
+      "license": "MIT",
       "dependencies": {
         "@juggle/resize-observer": "^3.4.0",
-        "@types/is-hotkey": "^0.1.1",
-        "@types/lodash": "^4.14.149",
-        "direction": "^1.0.3",
-        "is-hotkey": "^0.1.6",
-        "is-plain-object": "^5.0.0",
-        "lodash": "^4.17.4",
-        "scroll-into-view-if-needed": "^2.2.20",
-        "tiny-invariant": "1.0.6"
+        "direction": "^1.0.4",
+        "is-hotkey": "^0.2.0",
+        "lodash": "^4.17.21",
+        "scroll-into-view-if-needed": "^3.1.0",
+        "tiny-invariant": "1.3.1"
       },
       "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0",
-        "slate": ">=0.65.3"
-      }
-    },
-    "node_modules/slate-react/node_modules/is-hotkey": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/is-hotkey/-/is-hotkey-0.1.8.tgz",
-      "integrity": "sha512-qs3NZ1INIS+H+yeo7cD9pDfwYV/jqRh1JG9S9zYrNudkoUQg7OL7ziXqRKu+InFjUIDoP2o6HIkLYMh1pcWgyQ=="
-    },
-    "node_modules/slate-react/node_modules/is-plain-object": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/slate/node_modules/is-plain-object": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-      "engines": {
-        "node": ">=0.10.0"
+        "react": ">=18.2.0",
+        "react-dom": ">=18.2.0",
+        "slate": ">=0.114.0",
+        "slate-dom": ">=0.116.0"
       }
     },
     "node_modules/slice-ansi": {
@@ -25137,19 +25981,12 @@
       "license": "MIT"
     },
     "node_modules/style-to-object": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.8.tgz",
-      "integrity": "sha512-xT47I/Eo0rwJmaXC4oilDGDWLohVhR6o/xAQcPQN8q6QBuZVL8qMYL85kLmST5cPjAorwvqIA4qXTRQoYHaL6g==",
-      "dependencies": {
-        "inline-style-parser": "0.2.4"
-      }
-    },
-    "node_modules/style-value-types": {
-      "version": "5.0.0",
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
       "license": "MIT",
       "dependencies": {
-        "hey-listen": "^1.0.8",
-        "tslib": "^2.1.0"
+        "inline-style-parser": "0.2.7"
       }
     },
     "node_modules/styled-components": {
@@ -25570,13 +26407,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/throttle-debounce": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/throttleit": {
       "version": "1.0.0",
       "dev": true,
@@ -25602,18 +26432,16 @@
       "license": "MIT"
     },
     "node_modules/tiny-invariant": {
-      "version": "1.0.6",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
+      "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==",
       "license": "MIT"
     },
     "node_modules/tiny-warning": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
-    },
-    "node_modules/tinycolor2": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
-      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
@@ -25713,6 +26541,8 @@
     },
     "node_modules/toggle-selection": {
       "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==",
       "license": "MIT"
     },
     "node_modules/toidentifier": {
@@ -27762,7 +28592,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -27832,7 +28662,9 @@
       "license": "MIT"
     },
     "node_modules/use-callback-ref": {
-      "version": "1.3.0",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.0"
@@ -27841,8 +28673,8 @@
         "node": ">=10"
       },
       "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -27915,7 +28747,9 @@
       }
     },
     "node_modules/use-sidecar": {
-      "version": "1.1.2",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
       "license": "MIT",
       "dependencies": {
         "detect-node-es": "^1.1.0",
@@ -27925,8 +28759,8 @@
         "node": ">=10"
       },
       "peerDependencies": {
-        "@types/react": "^16.9.0 || ^17.0.0 || ^18.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -28612,7 +29446,6 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -29018,13 +29851,13 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
       "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
-      "dev": true
+      "devOptional": true
     },
     "@babel/core": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -29047,11 +29880,11 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
           "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-          "dev": true
+          "devOptional": true
         },
         "debug": {
           "version": "4.3.2",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "ms": "2.1.2"
           }
@@ -29060,7 +29893,7 @@
           "version": "6.3.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
           "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-          "dev": true
+          "devOptional": true
         }
       }
     },
@@ -29095,7 +29928,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
       "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/compat-data": "^7.28.6",
         "@babel/helper-validator-option": "^7.27.1",
@@ -29108,7 +29941,7 @@
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
           "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "yallist": "^3.0.2"
           }
@@ -29117,13 +29950,13 @@
           "version": "6.3.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
           "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-          "dev": true
+          "devOptional": true
         },
         "yallist": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
           "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-          "dev": true
+          "devOptional": true
         }
       }
     },
@@ -29226,7 +30059,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
       "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-module-imports": "^7.28.6",
         "@babel/helper-validator-identifier": "^7.28.5",
@@ -29302,7 +30135,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
       "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
-      "dev": true
+      "devOptional": true
     },
     "@babel/helper-wrap-function": {
       "version": "7.18.11",
@@ -29318,7 +30151,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
       "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/template": "^7.28.6",
         "@babel/types": "^7.28.6"
@@ -30097,502 +30930,438 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
-    "@chakra-ui/accordion": {
-      "version": "1.4.12",
-      "requires": {
-        "@chakra-ui/descendant": "2.1.4",
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/icon": "2.0.5",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/transition": "1.4.8",
-        "@chakra-ui/utils": "1.10.4"
-      }
-    },
-    "@chakra-ui/alert": {
-      "version": "1.3.7",
-      "requires": {
-        "@chakra-ui/icon": "2.0.5",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4"
-      }
-    },
     "@chakra-ui/anatomy": {
-      "version": "1.3.0",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/anatomy/-/anatomy-2.3.6.tgz",
+      "integrity": "sha512-TjmjyQouIZzha/l8JxdBZN1pKZTj7sLpJ0YkFnQFyqHcbfWggW9jKWzY1E0VBnhtFz/xF3KC6UAVuZVSJx+y0g=="
+    },
+    "@chakra-ui/breakpoint-utils": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/breakpoint-utils/-/breakpoint-utils-2.0.8.tgz",
+      "integrity": "sha512-Pq32MlEX9fwb5j5xx8s18zJMARNHlQZH2VH1RZgfgRDpp7DcEgtRW5AInfN5CfqdHLO1dGxA7I3MqEuL5JnIsA==",
       "requires": {
-        "@chakra-ui/theme-tools": "^1.3.6"
+        "@chakra-ui/shared-utils": "2.0.5"
       }
     },
-    "@chakra-ui/avatar": {
-      "version": "1.3.11",
+    "@chakra-ui/card": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/card/-/card-2.2.0.tgz",
+      "integrity": "sha512-xUB/k5MURj4CtPAhdSoXZidUbm8j3hci9vnc+eZJVDqhDOShNlD6QeniQNRPRys4lWAQLCbFcrwL29C8naDi6g==",
       "requires": {
-        "@chakra-ui/image": "1.1.10",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4"
-      }
-    },
-    "@chakra-ui/breadcrumb": {
-      "version": "1.3.6",
-      "requires": {
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4"
-      }
-    },
-    "@chakra-ui/button": {
-      "version": "1.5.10",
-      "requires": {
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/spinner": "1.2.6",
-        "@chakra-ui/utils": "1.10.4"
-      }
-    },
-    "@chakra-ui/checkbox": {
-      "version": "1.7.1",
-      "requires": {
-        "@chakra-ui/form-control": "1.6.0",
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4",
-        "@chakra-ui/visually-hidden": "1.1.6"
-      }
-    },
-    "@chakra-ui/clickable": {
-      "version": "1.2.6",
-      "requires": {
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4"
-      }
-    },
-    "@chakra-ui/close-button": {
-      "version": "1.2.7",
-      "requires": {
-        "@chakra-ui/icon": "2.0.5",
-        "@chakra-ui/utils": "1.10.4"
+        "@chakra-ui/shared-utils": "2.0.5"
       }
     },
     "@chakra-ui/color-mode": {
-      "version": "1.4.8",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/color-mode/-/color-mode-2.2.0.tgz",
+      "integrity": "sha512-niTEA8PALtMWRI9wJ4LL0CSBDo8NBfLNp4GD6/0hstcm3IlbBHTVKxN6HwSaoNYfphDQLxCjT4yG+0BJA5tFpg==",
       "requires": {
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/react-env": "1.1.6",
-        "@chakra-ui/utils": "1.10.4"
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0"
       }
     },
-    "@chakra-ui/control-box": {
-      "version": "1.1.6",
-      "requires": {
-        "@chakra-ui/utils": "1.10.4"
-      }
+    "@chakra-ui/dom-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/dom-utils/-/dom-utils-2.1.0.tgz",
+      "integrity": "sha512-ZmF2qRa1QZ0CMLU8M1zCfmw29DmPNtfjR9iTo74U5FPr3i1aoAh7fbJ4qAlZ197Xw9eAW28tvzQuoVWeL5C7fQ=="
     },
-    "@chakra-ui/counter": {
-      "version": "1.2.10",
-      "requires": {
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/utils": "1.10.4"
-      }
-    },
-    "@chakra-ui/css-reset": {
-      "version": "1.1.3"
-    },
-    "@chakra-ui/descendant": {
-      "version": "2.1.4",
-      "requires": {
-        "@chakra-ui/react-utils": "^1.2.3"
-      }
-    },
-    "@chakra-ui/editable": {
-      "version": "1.4.2",
-      "requires": {
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4"
-      }
-    },
-    "@chakra-ui/focus-lock": {
-      "version": "1.2.6",
-      "requires": {
-        "@chakra-ui/utils": "1.10.4",
-        "react-focus-lock": "2.5.2"
-      }
-    },
-    "@chakra-ui/form-control": {
-      "version": "1.6.0",
-      "requires": {
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/icon": "2.0.5",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4"
-      }
+    "@chakra-ui/event-utils": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/event-utils/-/event-utils-2.0.8.tgz",
+      "integrity": "sha512-IGM/yGUHS+8TOQrZGpAKOJl/xGBrmRYJrmbHfUE7zrG3PpQyXvbLDP1M+RggkCFVgHlJi2wpYIf0QtQlU0XZfw=="
     },
     "@chakra-ui/hooks": {
-      "version": "1.9.1",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/hooks/-/hooks-2.4.5.tgz",
+      "integrity": "sha512-601fWfHE2i7UjaxK/9lDLlOni6vk/I+04YDbM0BrelJy+eqxdlOmoN8Z6MZ3PzFh7ofERUASor+vL+/HaCaZ7w==",
       "requires": {
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4",
-        "compute-scroll-into-view": "1.0.14",
-        "copy-to-clipboard": "3.3.1"
+        "@chakra-ui/utils": "2.2.5",
+        "@zag-js/element-size": "0.31.1",
+        "copy-to-clipboard": "3.3.3",
+        "framesync": "6.1.2"
+      }
+    },
+    "@chakra-ui/icons": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/icons/-/icons-2.2.4.tgz",
+      "integrity": "sha512-l5QdBgwrAg3Sc2BRqtNkJpfuLw/pWRDwwT58J6c4PqQT6wzXxyNa8Q0PForu1ltB5qEiFb1kxr/F/HO1EwNa6g==",
+      "requires": {}
+    },
+    "@chakra-ui/lazy-utils": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/lazy-utils/-/lazy-utils-2.0.5.tgz",
+      "integrity": "sha512-UULqw7FBvcckQk2n3iPO56TMJvDsNv0FKZI6PlUNJVaGsPbsYxK/8IQ60vZgaTVPtVcjY6BE+y6zg8u9HOqpyg=="
+    },
+    "@chakra-ui/number-utils": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/number-utils/-/number-utils-2.0.7.tgz",
+      "integrity": "sha512-yOGxBjXNvLTBvQyhMDqGU0Oj26s91mbAlqKHiuw737AXHt0aPllOthVUqQMeaYLwLCjGMg0jtI7JReRzyi94Dg=="
+    },
+    "@chakra-ui/object-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/object-utils/-/object-utils-2.1.0.tgz",
+      "integrity": "sha512-tgIZOgLHaoti5PYGPTwK3t/cqtcycW0owaiOXoZOcpwwX/vlVb+H1jFsQyWiiwQVPt9RkoSLtxzXamx+aHH+bQ=="
+    },
+    "@chakra-ui/react": {
+      "version": "2.10.9",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react/-/react-2.10.9.tgz",
+      "integrity": "sha512-lhdcgoocOiURwBNR3L8OioCNIaGCZqRfuKioLyaQLjOanl4jr0PQclsGb+w0cmito252vEWpsz2xRqF7y+Flrw==",
+      "requires": {
+        "@chakra-ui/hooks": "2.4.5",
+        "@chakra-ui/styled-system": "2.12.4",
+        "@chakra-ui/theme": "3.4.9",
+        "@chakra-ui/utils": "2.2.5",
+        "@popperjs/core": "^2.11.8",
+        "@zag-js/focus-visible": "^0.31.1",
+        "aria-hidden": "^1.2.3",
+        "react-fast-compare": "3.2.2",
+        "react-focus-lock": "^2.9.6",
+        "react-remove-scroll": "^2.5.7"
+      }
+    },
+    "@chakra-ui/react-children-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-children-utils/-/react-children-utils-2.0.6.tgz",
+      "integrity": "sha512-QVR2RC7QsOsbWwEnq9YduhpqSFnZGvjjGREV8ygKi8ADhXh93C8azLECCUVgRJF2Wc+So1fgxmjLcbZfY2VmBA==",
+      "requires": {}
+    },
+    "@chakra-ui/react-context": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-context/-/react-context-2.1.0.tgz",
+      "integrity": "sha512-iahyStvzQ4AOwKwdPReLGfDesGG+vWJfEsn0X/NoGph/SkN+HXtv2sCfYFFR9k7bb+Kvc6YfpLlSuLvKMHi2+w==",
+      "requires": {}
+    },
+    "@chakra-ui/react-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-types/-/react-types-2.0.7.tgz",
+      "integrity": "sha512-12zv2qIZ8EHwiytggtGvo4iLT0APris7T0qaAWqzpUGS0cdUtR8W+V1BJ5Ocq+7tA6dzQ/7+w5hmXih61TuhWQ==",
+      "requires": {}
+    },
+    "@chakra-ui/react-use-animation-state": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-animation-state/-/react-use-animation-state-2.1.0.tgz",
+      "integrity": "sha512-CFZkQU3gmDBwhqy0vC1ryf90BVHxVN8cTLpSyCpdmExUEtSEInSCGMydj2fvn7QXsz/za8JNdO2xxgJwxpLMtg==",
+      "requires": {
+        "@chakra-ui/dom-utils": "2.1.0",
+        "@chakra-ui/react-use-event-listener": "2.1.0"
+      }
+    },
+    "@chakra-ui/react-use-callback-ref": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-callback-ref/-/react-use-callback-ref-2.1.0.tgz",
+      "integrity": "sha512-efnJrBtGDa4YaxDzDE90EnKD3Vkh5a1t3w7PhnRQmsphLy3g2UieasoKTlT2Hn118TwDjIv5ZjHJW6HbzXA9wQ==",
+      "requires": {}
+    },
+    "@chakra-ui/react-use-controllable-state": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-controllable-state/-/react-use-controllable-state-2.1.0.tgz",
+      "integrity": "sha512-QR/8fKNokxZUs4PfxjXuwl0fj/d71WPrmLJvEpCTkHjnzu7LnYvzoe2wB867IdooQJL0G1zBxl0Dq+6W1P3jpg==",
+      "requires": {
+        "@chakra-ui/react-use-callback-ref": "2.1.0"
+      }
+    },
+    "@chakra-ui/react-use-disclosure": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-disclosure/-/react-use-disclosure-2.1.0.tgz",
+      "integrity": "sha512-Ax4pmxA9LBGMyEZJhhUZobg9C0t3qFE4jVF1tGBsrLDcdBeLR9fwOogIPY9Hf0/wqSlAryAimICbr5hkpa5GSw==",
+      "requires": {
+        "@chakra-ui/react-use-callback-ref": "2.1.0"
+      }
+    },
+    "@chakra-ui/react-use-event-listener": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-event-listener/-/react-use-event-listener-2.1.0.tgz",
+      "integrity": "sha512-U5greryDLS8ISP69DKDsYcsXRtAdnTQT+jjIlRYZ49K/XhUR/AqVZCK5BkR1spTDmO9H8SPhgeNKI70ODuDU/Q==",
+      "requires": {
+        "@chakra-ui/react-use-callback-ref": "2.1.0"
+      }
+    },
+    "@chakra-ui/react-use-focus-effect": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-focus-effect/-/react-use-focus-effect-2.1.0.tgz",
+      "integrity": "sha512-xzVboNy7J64xveLcxTIJ3jv+lUJKDwRM7Szwn9tNzUIPD94O3qwjV7DDCUzN2490nSYDF4OBMt/wuDBtaR3kUQ==",
+      "requires": {
+        "@chakra-ui/dom-utils": "2.1.0",
+        "@chakra-ui/react-use-event-listener": "2.1.0",
+        "@chakra-ui/react-use-safe-layout-effect": "2.1.0",
+        "@chakra-ui/react-use-update-effect": "2.1.0"
+      }
+    },
+    "@chakra-ui/react-use-focus-on-pointer-down": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-focus-on-pointer-down/-/react-use-focus-on-pointer-down-2.1.0.tgz",
+      "integrity": "sha512-2jzrUZ+aiCG/cfanrolsnSMDykCAbv9EK/4iUyZno6BYb3vziucmvgKuoXbMPAzWNtwUwtuMhkby8rc61Ue+Lg==",
+      "requires": {
+        "@chakra-ui/react-use-event-listener": "2.1.0"
+      }
+    },
+    "@chakra-ui/react-use-interval": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-interval/-/react-use-interval-2.1.0.tgz",
+      "integrity": "sha512-8iWj+I/+A0J08pgEXP1J1flcvhLBHkk0ln7ZvGIyXiEyM6XagOTJpwNhiu+Bmk59t3HoV/VyvyJTa+44sEApuw==",
+      "requires": {
+        "@chakra-ui/react-use-callback-ref": "2.1.0"
+      }
+    },
+    "@chakra-ui/react-use-latest-ref": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-latest-ref/-/react-use-latest-ref-2.1.0.tgz",
+      "integrity": "sha512-m0kxuIYqoYB0va9Z2aW4xP/5b7BzlDeWwyXCH6QpT2PpW3/281L3hLCm1G0eOUcdVlayqrQqOeD6Mglq+5/xoQ==",
+      "requires": {}
+    },
+    "@chakra-ui/react-use-merge-refs": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-merge-refs/-/react-use-merge-refs-2.1.0.tgz",
+      "integrity": "sha512-lERa6AWF1cjEtWSGjxWTaSMvneccnAVH4V4ozh8SYiN9fSPZLlSG3kNxfNzdFvMEhM7dnP60vynF7WjGdTgQbQ==",
+      "requires": {}
+    },
+    "@chakra-ui/react-use-outside-click": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-outside-click/-/react-use-outside-click-2.2.0.tgz",
+      "integrity": "sha512-PNX+s/JEaMneijbgAM4iFL+f3m1ga9+6QK0E5Yh4s8KZJQ/bLwZzdhMz8J/+mL+XEXQ5J0N8ivZN28B82N1kNw==",
+      "requires": {
+        "@chakra-ui/react-use-callback-ref": "2.1.0"
+      }
+    },
+    "@chakra-ui/react-use-pan-event": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-pan-event/-/react-use-pan-event-2.1.0.tgz",
+      "integrity": "sha512-xmL2qOHiXqfcj0q7ZK5s9UjTh4Gz0/gL9jcWPA6GVf+A0Od5imEDa/Vz+533yQKWiNSm1QGrIj0eJAokc7O4fg==",
+      "requires": {
+        "@chakra-ui/event-utils": "2.0.8",
+        "@chakra-ui/react-use-latest-ref": "2.1.0",
+        "framesync": "6.1.2"
+      }
+    },
+    "@chakra-ui/react-use-previous": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-previous/-/react-use-previous-2.1.0.tgz",
+      "integrity": "sha512-pjxGwue1hX8AFcmjZ2XfrQtIJgqbTF3Qs1Dy3d1krC77dEsiCUbQ9GzOBfDc8pfd60DrB5N2tg5JyHbypqh0Sg==",
+      "requires": {}
+    },
+    "@chakra-ui/react-use-safe-layout-effect": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-safe-layout-effect/-/react-use-safe-layout-effect-2.1.0.tgz",
+      "integrity": "sha512-Knbrrx/bcPwVS1TorFdzrK/zWA8yuU/eaXDkNj24IrKoRlQrSBFarcgAEzlCHtzuhufP3OULPkELTzz91b0tCw==",
+      "requires": {}
+    },
+    "@chakra-ui/react-use-size": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-size/-/react-use-size-2.1.0.tgz",
+      "integrity": "sha512-tbLqrQhbnqOjzTaMlYytp7wY8BW1JpL78iG7Ru1DlV4EWGiAmXFGvtnEt9HftU0NJ0aJyjgymkxfVGI55/1Z4A==",
+      "requires": {
+        "@zag-js/element-size": "0.10.5"
       },
       "dependencies": {
-        "compute-scroll-into-view": {
-          "version": "1.0.14"
+        "@zag-js/element-size": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/@zag-js/element-size/-/element-size-0.10.5.tgz",
+          "integrity": "sha512-uQre5IidULANvVkNOBQ1tfgwTQcGl4hliPSe69Fct1VfYb2Fd0jdAcGzqQgPhfrXFpR62MxLPB7erxJ/ngtL8w=="
         }
       }
     },
-    "@chakra-ui/icon": {
-      "version": "2.0.5",
+    "@chakra-ui/react-use-timeout": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-timeout/-/react-use-timeout-2.1.0.tgz",
+      "integrity": "sha512-cFN0sobKMM9hXUhyCofx3/Mjlzah6ADaEl/AXl5Y+GawB5rgedgAcu2ErAgarEkwvsKdP6c68CKjQ9dmTQlJxQ==",
       "requires": {
-        "@chakra-ui/utils": "1.10.4"
+        "@chakra-ui/react-use-callback-ref": "2.1.0"
       }
     },
-    "@chakra-ui/image": {
-      "version": "1.1.10",
-      "requires": {
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/utils": "1.10.4"
-      }
-    },
-    "@chakra-ui/input": {
-      "version": "1.4.6",
-      "requires": {
-        "@chakra-ui/form-control": "1.6.0",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4"
-      }
-    },
-    "@chakra-ui/layout": {
-      "version": "1.8.0",
-      "requires": {
-        "@chakra-ui/icon": "2.0.5",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4"
-      }
-    },
-    "@chakra-ui/live-region": {
-      "version": "1.1.6",
-      "requires": {
-        "@chakra-ui/utils": "1.10.4"
-      }
-    },
-    "@chakra-ui/media-query": {
-      "version": "2.0.4",
-      "requires": {
-        "@chakra-ui/react-env": "1.1.6",
-        "@chakra-ui/utils": "1.10.4"
-      }
-    },
-    "@chakra-ui/menu": {
-      "version": "1.8.12",
-      "requires": {
-        "@chakra-ui/clickable": "1.2.6",
-        "@chakra-ui/descendant": "2.1.4",
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/popper": "2.4.3",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/transition": "1.4.8",
-        "@chakra-ui/utils": "1.10.4"
-      }
-    },
-    "@chakra-ui/modal": {
-      "version": "1.11.1",
-      "requires": {
-        "@chakra-ui/close-button": "1.2.7",
-        "@chakra-ui/focus-lock": "1.2.6",
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/portal": "1.3.10",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/transition": "1.4.8",
-        "@chakra-ui/utils": "1.10.4",
-        "aria-hidden": "^1.1.1",
-        "react-remove-scroll": "2.4.1"
-      }
-    },
-    "@chakra-ui/number-input": {
-      "version": "1.4.7",
-      "requires": {
-        "@chakra-ui/counter": "1.2.10",
-        "@chakra-ui/form-control": "1.6.0",
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/icon": "2.0.5",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4"
-      }
-    },
-    "@chakra-ui/pin-input": {
-      "version": "1.7.11",
-      "requires": {
-        "@chakra-ui/descendant": "2.1.4",
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4"
-      }
-    },
-    "@chakra-ui/popover": {
-      "version": "1.11.9",
-      "requires": {
-        "@chakra-ui/close-button": "1.2.7",
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/popper": "2.4.3",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4"
-      }
-    },
-    "@chakra-ui/popper": {
-      "version": "2.4.3",
-      "requires": {
-        "@chakra-ui/react-utils": "1.2.3",
-        "@popperjs/core": "^2.9.3"
-      }
-    },
-    "@chakra-ui/portal": {
-      "version": "1.3.10",
-      "requires": {
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4"
-      }
-    },
-    "@chakra-ui/progress": {
-      "version": "1.2.6",
-      "requires": {
-        "@chakra-ui/theme-tools": "1.3.6",
-        "@chakra-ui/utils": "1.10.4"
-      }
-    },
-    "@chakra-ui/provider": {
-      "version": "1.7.14",
-      "requires": {
-        "@chakra-ui/css-reset": "1.1.3",
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/portal": "1.3.10",
-        "@chakra-ui/react-env": "1.1.6",
-        "@chakra-ui/system": "1.12.1",
-        "@chakra-ui/utils": "1.10.4"
-      }
-    },
-    "@chakra-ui/radio": {
-      "version": "1.5.1",
-      "requires": {
-        "@chakra-ui/form-control": "1.6.0",
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4",
-        "@chakra-ui/visually-hidden": "1.1.6"
-      }
-    },
-    "@chakra-ui/react": {
-      "version": "1.8.9",
-      "requires": {
-        "@chakra-ui/accordion": "1.4.12",
-        "@chakra-ui/alert": "1.3.7",
-        "@chakra-ui/avatar": "1.3.11",
-        "@chakra-ui/breadcrumb": "1.3.6",
-        "@chakra-ui/button": "1.5.10",
-        "@chakra-ui/checkbox": "1.7.1",
-        "@chakra-ui/close-button": "1.2.7",
-        "@chakra-ui/control-box": "1.1.6",
-        "@chakra-ui/counter": "1.2.10",
-        "@chakra-ui/css-reset": "1.1.3",
-        "@chakra-ui/editable": "1.4.2",
-        "@chakra-ui/form-control": "1.6.0",
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/icon": "2.0.5",
-        "@chakra-ui/image": "1.1.10",
-        "@chakra-ui/input": "1.4.6",
-        "@chakra-ui/layout": "1.8.0",
-        "@chakra-ui/live-region": "1.1.6",
-        "@chakra-ui/media-query": "2.0.4",
-        "@chakra-ui/menu": "1.8.12",
-        "@chakra-ui/modal": "1.11.1",
-        "@chakra-ui/number-input": "1.4.7",
-        "@chakra-ui/pin-input": "1.7.11",
-        "@chakra-ui/popover": "1.11.9",
-        "@chakra-ui/popper": "2.4.3",
-        "@chakra-ui/portal": "1.3.10",
-        "@chakra-ui/progress": "1.2.6",
-        "@chakra-ui/provider": "1.7.14",
-        "@chakra-ui/radio": "1.5.1",
-        "@chakra-ui/react-env": "1.1.6",
-        "@chakra-ui/select": "1.2.11",
-        "@chakra-ui/skeleton": "1.2.14",
-        "@chakra-ui/slider": "1.5.11",
-        "@chakra-ui/spinner": "1.2.6",
-        "@chakra-ui/stat": "1.2.7",
-        "@chakra-ui/switch": "1.3.10",
-        "@chakra-ui/system": "1.12.1",
-        "@chakra-ui/table": "1.3.6",
-        "@chakra-ui/tabs": "1.6.11",
-        "@chakra-ui/tag": "1.2.7",
-        "@chakra-ui/textarea": "1.2.11",
-        "@chakra-ui/theme": "1.14.1",
-        "@chakra-ui/toast": "1.5.9",
-        "@chakra-ui/tooltip": "1.5.1",
-        "@chakra-ui/transition": "1.4.8",
-        "@chakra-ui/utils": "1.10.4",
-        "@chakra-ui/visually-hidden": "1.1.6"
-      }
-    },
-    "@chakra-ui/react-env": {
-      "version": "1.1.6",
-      "requires": {
-        "@chakra-ui/utils": "1.10.4"
-      }
+    "@chakra-ui/react-use-update-effect": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-update-effect/-/react-use-update-effect-2.1.0.tgz",
+      "integrity": "sha512-ND4Q23tETaR2Qd3zwCKYOOS1dfssojPLJMLvUtUbW5M9uW1ejYWgGUobeAiOVfSplownG8QYMmHTP86p/v0lbA==",
+      "requires": {}
     },
     "@chakra-ui/react-utils": {
-      "version": "1.2.3",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react-utils/-/react-utils-2.0.12.tgz",
+      "integrity": "sha512-GbSfVb283+YA3kA8w8xWmzbjNWk14uhNpntnipHCftBibl0lxtQ9YqMFQLwuFOO0U2gYVocszqqDWX+XNKq9hw==",
       "requires": {
-        "@chakra-ui/utils": "^1.10.4"
+        "@chakra-ui/utils": "2.0.15"
+      },
+      "dependencies": {
+        "@chakra-ui/utils": {
+          "version": "2.0.15",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-2.0.15.tgz",
+          "integrity": "sha512-El4+jL0WSaYYs+rJbuYFDbjmfCcfGDmRY95GO4xwzit6YAPZBLcR65rOEwLps+XWluZTy1xdMrusg/hW0c1aAA==",
+          "requires": {
+            "@types/lodash.mergewith": "4.6.7",
+            "css-box-model": "1.2.1",
+            "framesync": "6.1.2",
+            "lodash.mergewith": "4.6.2"
+          }
+        },
+        "@types/lodash.mergewith": {
+          "version": "4.6.7",
+          "resolved": "https://registry.npmjs.org/@types/lodash.mergewith/-/lodash.mergewith-4.6.7.tgz",
+          "integrity": "sha512-3m+lkO5CLRRYU0fhGRp7zbsGi6+BZj0uTVSwvcKU+nSlhjA9/QRNfuSGnD2mX6hQA7ZbmcCkzk5h4ZYGOtk14A==",
+          "requires": {
+            "@types/lodash": "*"
+          }
+        }
       }
     },
-    "@chakra-ui/select": {
-      "version": "1.2.11",
-      "requires": {
-        "@chakra-ui/form-control": "1.6.0",
-        "@chakra-ui/utils": "1.10.4"
-      }
+    "@chakra-ui/shared-utils": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/shared-utils/-/shared-utils-2.0.5.tgz",
+      "integrity": "sha512-4/Wur0FqDov7Y0nCXl7HbHzCg4aq86h+SXdoUeuCMD3dSj7dpsVnStLYhng1vxvlbUnLpdF4oz5Myt3i/a7N3Q=="
     },
-    "@chakra-ui/skeleton": {
-      "version": "1.2.14",
-      "requires": {
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/media-query": "2.0.4",
-        "@chakra-ui/system": "1.12.1",
-        "@chakra-ui/utils": "1.10.4"
-      }
+    "@chakra-ui/skip-nav": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/skip-nav/-/skip-nav-2.1.0.tgz",
+      "integrity": "sha512-Hk+FG+vadBSH0/7hwp9LJnLjkO0RPGnx7gBJWI4/SpoJf3e4tZlWYtwGj0toYY4aGKl93jVghuwGbDBEMoHDug==",
+      "requires": {}
     },
-    "@chakra-ui/slider": {
-      "version": "1.5.11",
+    "@chakra-ui/stepper": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/stepper/-/stepper-2.3.1.tgz",
+      "integrity": "sha512-ky77lZbW60zYkSXhYz7kbItUpAQfEdycT0Q4bkHLxfqbuiGMf8OmgZOQkOB9uM4v0zPwy2HXhe0vq4Dd0xa55Q==",
       "requires": {
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4"
-      }
-    },
-    "@chakra-ui/spinner": {
-      "version": "1.2.6",
-      "requires": {
-        "@chakra-ui/utils": "1.10.4",
-        "@chakra-ui/visually-hidden": "1.1.6"
-      }
-    },
-    "@chakra-ui/stat": {
-      "version": "1.2.7",
-      "requires": {
-        "@chakra-ui/icon": "2.0.5",
-        "@chakra-ui/utils": "1.10.4",
-        "@chakra-ui/visually-hidden": "1.1.6"
+        "@chakra-ui/icon": "3.2.0",
+        "@chakra-ui/react-context": "2.1.0",
+        "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "dependencies": {
+        "@chakra-ui/icon": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-3.2.0.tgz",
+          "integrity": "sha512-xxjGLvlX2Ys4H0iHrI16t74rG9EBcpFvJ3Y3B7KMQTrnW34Kf7Da/UC8J67Gtx85mTHW020ml85SVPKORWNNKQ==",
+          "requires": {
+            "@chakra-ui/shared-utils": "2.0.5"
+          }
+        }
       }
     },
     "@chakra-ui/styled-system": {
-      "version": "1.19.0",
+      "version": "2.12.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/styled-system/-/styled-system-2.12.4.tgz",
+      "integrity": "sha512-oa07UG7Lic5hHSQtGRiMEnYjuhIa8lszyuVhZjZqR2Ap3VMF688y1MVPJ1pK+8OwY5uhXBgVd5c0+rI8aBZlwg==",
       "requires": {
-        "@chakra-ui/utils": "1.10.4",
-        "csstype": "3.0.9"
-      }
-    },
-    "@chakra-ui/switch": {
-      "version": "1.3.10",
-      "requires": {
-        "@chakra-ui/checkbox": "1.7.1",
-        "@chakra-ui/utils": "1.10.4"
+        "@chakra-ui/utils": "2.2.5",
+        "csstype": "^3.1.2"
       }
     },
     "@chakra-ui/system": {
-      "version": "1.12.1",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/system/-/system-2.6.2.tgz",
+      "integrity": "sha512-EGtpoEjLrUu4W1fHD+a62XR+hzC5YfsWm+6lO0Kybcga3yYEij9beegO0jZgug27V+Rf7vns95VPVP6mFd/DEQ==",
       "requires": {
-        "@chakra-ui/color-mode": "1.4.8",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/styled-system": "1.19.0",
-        "@chakra-ui/utils": "1.10.4",
-        "react-fast-compare": "3.2.0"
-      }
-    },
-    "@chakra-ui/table": {
-      "version": "1.3.6",
-      "requires": {
-        "@chakra-ui/utils": "1.10.4"
-      }
-    },
-    "@chakra-ui/tabs": {
-      "version": "1.6.11",
-      "requires": {
-        "@chakra-ui/clickable": "1.2.6",
-        "@chakra-ui/descendant": "2.1.4",
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4"
-      }
-    },
-    "@chakra-ui/tag": {
-      "version": "1.2.7",
-      "requires": {
-        "@chakra-ui/icon": "2.0.5",
-        "@chakra-ui/utils": "1.10.4"
-      }
-    },
-    "@chakra-ui/textarea": {
-      "version": "1.2.11",
-      "requires": {
-        "@chakra-ui/form-control": "1.6.0",
-        "@chakra-ui/utils": "1.10.4"
+        "@chakra-ui/color-mode": "2.2.0",
+        "@chakra-ui/object-utils": "2.1.0",
+        "@chakra-ui/react-utils": "2.0.12",
+        "@chakra-ui/styled-system": "2.9.2",
+        "@chakra-ui/theme-utils": "2.0.21",
+        "@chakra-ui/utils": "2.0.15",
+        "react-fast-compare": "3.2.2"
+      },
+      "dependencies": {
+        "@chakra-ui/styled-system": {
+          "version": "2.9.2",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/styled-system/-/styled-system-2.9.2.tgz",
+          "integrity": "sha512-To/Z92oHpIE+4nk11uVMWqo2GGRS86coeMmjxtpnErmWRdLcp1WVCVRAvn+ZwpLiNR+reWFr2FFqJRsREuZdAg==",
+          "requires": {
+            "@chakra-ui/shared-utils": "2.0.5",
+            "csstype": "^3.1.2",
+            "lodash.mergewith": "4.6.2"
+          }
+        },
+        "@chakra-ui/utils": {
+          "version": "2.0.15",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-2.0.15.tgz",
+          "integrity": "sha512-El4+jL0WSaYYs+rJbuYFDbjmfCcfGDmRY95GO4xwzit6YAPZBLcR65rOEwLps+XWluZTy1xdMrusg/hW0c1aAA==",
+          "requires": {
+            "@types/lodash.mergewith": "4.6.7",
+            "css-box-model": "1.2.1",
+            "framesync": "6.1.2",
+            "lodash.mergewith": "4.6.2"
+          }
+        },
+        "@types/lodash.mergewith": {
+          "version": "4.6.7",
+          "resolved": "https://registry.npmjs.org/@types/lodash.mergewith/-/lodash.mergewith-4.6.7.tgz",
+          "integrity": "sha512-3m+lkO5CLRRYU0fhGRp7zbsGi6+BZj0uTVSwvcKU+nSlhjA9/QRNfuSGnD2mX6hQA7ZbmcCkzk5h4ZYGOtk14A==",
+          "requires": {
+            "@types/lodash": "*"
+          }
+        }
       }
     },
     "@chakra-ui/theme": {
-      "version": "1.14.1",
+      "version": "3.4.9",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/theme/-/theme-3.4.9.tgz",
+      "integrity": "sha512-GAom2SjSdRWTcX76/2yJOFJsOWHQeBgaynCUNBsHq62OafzvELrsSHDUw0bBqBb1c2ww0CclIvGilPup8kXBFA==",
       "requires": {
-        "@chakra-ui/anatomy": "1.3.0",
-        "@chakra-ui/theme-tools": "1.3.6",
-        "@chakra-ui/utils": "1.10.4"
+        "@chakra-ui/anatomy": "2.3.6",
+        "@chakra-ui/theme-tools": "2.2.9",
+        "@chakra-ui/utils": "2.2.5"
       }
     },
     "@chakra-ui/theme-tools": {
-      "version": "1.3.6",
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/theme-tools/-/theme-tools-2.2.9.tgz",
+      "integrity": "sha512-PcbYL19lrVvEc7Oydy//jsy/MO/rZz1DvLyO6AoI+bI/+Kwz9WfOKsspbulEhRg5COayE0R/IZPsskXZ7Mp4bA==",
       "requires": {
-        "@chakra-ui/utils": "1.10.4",
-        "@ctrl/tinycolor": "^3.4.0"
+        "@chakra-ui/anatomy": "2.3.6",
+        "@chakra-ui/utils": "2.2.5",
+        "color2k": "^2.0.2"
       }
     },
-    "@chakra-ui/toast": {
-      "version": "1.5.9",
+    "@chakra-ui/theme-utils": {
+      "version": "2.0.21",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/theme-utils/-/theme-utils-2.0.21.tgz",
+      "integrity": "sha512-FjH5LJbT794r0+VSCXB3lT4aubI24bLLRWB+CuRKHijRvsOg717bRdUN/N1fEmEpFnRVrbewttWh/OQs0EWpWw==",
       "requires": {
-        "@chakra-ui/alert": "1.3.7",
-        "@chakra-ui/close-button": "1.2.7",
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/theme": "1.14.1",
-        "@chakra-ui/transition": "1.4.8",
-        "@chakra-ui/utils": "1.10.4",
-        "@reach/alert": "0.13.2"
-      }
-    },
-    "@chakra-ui/tooltip": {
-      "version": "1.5.1",
-      "requires": {
-        "@chakra-ui/hooks": "1.9.1",
-        "@chakra-ui/popper": "2.4.3",
-        "@chakra-ui/portal": "1.3.10",
-        "@chakra-ui/react-utils": "1.2.3",
-        "@chakra-ui/utils": "1.10.4",
-        "@chakra-ui/visually-hidden": "1.1.6"
-      }
-    },
-    "@chakra-ui/transition": {
-      "version": "1.4.8",
-      "requires": {
-        "@chakra-ui/utils": "1.10.4"
+        "@chakra-ui/shared-utils": "2.0.5",
+        "@chakra-ui/styled-system": "2.9.2",
+        "@chakra-ui/theme": "3.3.1",
+        "lodash.mergewith": "4.6.2"
+      },
+      "dependencies": {
+        "@chakra-ui/anatomy": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/anatomy/-/anatomy-2.2.2.tgz",
+          "integrity": "sha512-MV6D4VLRIHr4PkW4zMyqfrNS1mPlCTiCXwvYGtDFQYr+xHFfonhAuf9WjsSc0nyp2m0OdkSLnzmVKkZFLo25Tg=="
+        },
+        "@chakra-ui/styled-system": {
+          "version": "2.9.2",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/styled-system/-/styled-system-2.9.2.tgz",
+          "integrity": "sha512-To/Z92oHpIE+4nk11uVMWqo2GGRS86coeMmjxtpnErmWRdLcp1WVCVRAvn+ZwpLiNR+reWFr2FFqJRsREuZdAg==",
+          "requires": {
+            "@chakra-ui/shared-utils": "2.0.5",
+            "csstype": "^3.1.2",
+            "lodash.mergewith": "4.6.2"
+          }
+        },
+        "@chakra-ui/theme": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/theme/-/theme-3.3.1.tgz",
+          "integrity": "sha512-Hft/VaT8GYnItGCBbgWd75ICrIrIFrR7lVOhV/dQnqtfGqsVDlrztbSErvMkoPKt0UgAkd9/o44jmZ6X4U2nZQ==",
+          "requires": {
+            "@chakra-ui/anatomy": "2.2.2",
+            "@chakra-ui/shared-utils": "2.0.5",
+            "@chakra-ui/theme-tools": "2.1.2"
+          }
+        },
+        "@chakra-ui/theme-tools": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/theme-tools/-/theme-tools-2.1.2.tgz",
+          "integrity": "sha512-Qdj8ajF9kxY4gLrq7gA+Azp8CtFHGO9tWMN2wfF9aQNgG9AuMhPrUzMq9AMQ0MXiYcgNq/FD3eegB43nHVmXVA==",
+          "requires": {
+            "@chakra-ui/anatomy": "2.2.2",
+            "@chakra-ui/shared-utils": "2.0.5",
+            "color2k": "^2.0.2"
+          }
+        }
       }
     },
     "@chakra-ui/utils": {
-      "version": "1.10.4",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-2.2.5.tgz",
+      "integrity": "sha512-KTBCK+M5KtXH6p54XS39ImQUMVtAx65BoZDoEms3LuObyTo1+civ1sMm4h3nRT320U6H5H7D35WnABVQjqU/4g==",
       "requires": {
-        "@types/lodash.mergewith": "4.6.6",
-        "css-box-model": "1.2.1",
-        "framesync": "5.3.0",
+        "@types/lodash.mergewith": "4.6.9",
         "lodash.mergewith": "4.6.2"
-      }
-    },
-    "@chakra-ui/visually-hidden": {
-      "version": "1.1.6",
-      "requires": {
-        "@chakra-ui/utils": "1.10.4"
       }
     },
     "@codemirror/autocomplete": {
@@ -30712,12 +31481,13 @@
         }
       }
     },
-    "@concord-consortium/codap-formulas-react17": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/codap-formulas-react17/-/codap-formulas-react17-1.1.0.tgz",
-      "integrity": "sha512-t8bcMHiShdqR9qS8jJLyK1nZfjoUGLI9d35NJIRRhm115cFurrnMqc4o0SIjXEOC2X2uqIDbS+NVxwzfGwpMSg==",
+    "@concord-consortium/codap-formulas": {
+      "version": "1.1.0-pre.2",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/codap-formulas/-/codap-formulas-1.1.0-pre.2.tgz",
+      "integrity": "sha512-jaRmOq9taiMxXvVnh5uzVIlFsOBcQ0+2IUy7kRvaGC/CXg5a3hB5g1zM3lImiGcnZLAjO68Wl9V0/8+RMg5cXg==",
       "requires": {
-        "@chakra-ui/react": "^1.8.9",
+        "@chakra-ui/icons": "^2.2.4",
+        "@chakra-ui/react": "~2.8.2",
         "@codemirror/autocomplete": "^6.18.6",
         "@codemirror/commands": "^6.8.0",
         "@codemirror/language": "^6.11.0",
@@ -30730,19 +31500,678 @@
         "@uiw/react-codemirror": "^4.23.10",
         "colord": "^2.9.3",
         "escape-string-regexp": "^5.0.0",
-        "framer-motion": "^6.5.1",
+        "framer-motion": "^12.18.1",
         "lodash": "^4.17.21",
         "mathjs": "12.4.3",
         "mobx": "^6.13.6",
         "mobx-react-lite": "^4.1.0",
         "mobx-state-tree": "npm:@concord-consortium/mobx-state-tree@6.0.0-cc.1",
         "random": "^5.4.0",
-        "react": "^17.0.2",
-        "react-dom": "^17.0.2",
         "type-fest": "^4.41.0",
         "use-memo-one": "^1.1.3"
       },
       "dependencies": {
+        "@chakra-ui/accordion": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/accordion/-/accordion-2.3.1.tgz",
+          "integrity": "sha512-FSXRm8iClFyU+gVaXisOSEw0/4Q+qZbFRiuhIAkVU6Boj0FxAMrlo9a8AV5TuF77rgaHytCdHk0Ng+cyUijrag==",
+          "requires": {
+            "@chakra-ui/descendant": "3.1.0",
+            "@chakra-ui/icon": "3.2.0",
+            "@chakra-ui/react-context": "2.1.0",
+            "@chakra-ui/react-use-controllable-state": "2.1.0",
+            "@chakra-ui/react-use-merge-refs": "2.1.0",
+            "@chakra-ui/shared-utils": "2.0.5",
+            "@chakra-ui/transition": "2.1.0"
+          }
+        },
+        "@chakra-ui/alert": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/alert/-/alert-2.2.2.tgz",
+          "integrity": "sha512-jHg4LYMRNOJH830ViLuicjb3F+v6iriE/2G5T+Sd0Hna04nukNJ1MxUmBPE+vI22me2dIflfelu2v9wdB6Pojw==",
+          "requires": {
+            "@chakra-ui/icon": "3.2.0",
+            "@chakra-ui/react-context": "2.1.0",
+            "@chakra-ui/shared-utils": "2.0.5",
+            "@chakra-ui/spinner": "2.1.0"
+          }
+        },
+        "@chakra-ui/anatomy": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/anatomy/-/anatomy-2.2.2.tgz",
+          "integrity": "sha512-MV6D4VLRIHr4PkW4zMyqfrNS1mPlCTiCXwvYGtDFQYr+xHFfonhAuf9WjsSc0nyp2m0OdkSLnzmVKkZFLo25Tg=="
+        },
+        "@chakra-ui/avatar": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/avatar/-/avatar-2.3.0.tgz",
+          "integrity": "sha512-8gKSyLfygnaotbJbDMHDiJoF38OHXUYVme4gGxZ1fLnQEdPVEaIWfH+NndIjOM0z8S+YEFnT9KyGMUtvPrBk3g==",
+          "requires": {
+            "@chakra-ui/image": "2.1.0",
+            "@chakra-ui/react-children-utils": "2.0.6",
+            "@chakra-ui/react-context": "2.1.0",
+            "@chakra-ui/shared-utils": "2.0.5"
+          }
+        },
+        "@chakra-ui/breadcrumb": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/breadcrumb/-/breadcrumb-2.2.0.tgz",
+          "integrity": "sha512-4cWCG24flYBxjruRi4RJREWTGF74L/KzI2CognAW/d/zWR0CjiScuJhf37Am3LFbCySP6WSoyBOtTIoTA4yLEA==",
+          "requires": {
+            "@chakra-ui/react-children-utils": "2.0.6",
+            "@chakra-ui/react-context": "2.1.0",
+            "@chakra-ui/shared-utils": "2.0.5"
+          }
+        },
+        "@chakra-ui/button": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/button/-/button-2.1.0.tgz",
+          "integrity": "sha512-95CplwlRKmmUXkdEp/21VkEWgnwcx2TOBG6NfYlsuLBDHSLlo5FKIiE2oSi4zXc4TLcopGcWPNcm/NDaSC5pvA==",
+          "requires": {
+            "@chakra-ui/react-context": "2.1.0",
+            "@chakra-ui/react-use-merge-refs": "2.1.0",
+            "@chakra-ui/shared-utils": "2.0.5",
+            "@chakra-ui/spinner": "2.1.0"
+          }
+        },
+        "@chakra-ui/checkbox": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/checkbox/-/checkbox-2.3.2.tgz",
+          "integrity": "sha512-85g38JIXMEv6M+AcyIGLh7igNtfpAN6KGQFYxY9tBj0eWvWk4NKQxvqqyVta0bSAyIl1rixNIIezNpNWk2iO4g==",
+          "requires": {
+            "@chakra-ui/form-control": "2.2.0",
+            "@chakra-ui/react-context": "2.1.0",
+            "@chakra-ui/react-types": "2.0.7",
+            "@chakra-ui/react-use-callback-ref": "2.1.0",
+            "@chakra-ui/react-use-controllable-state": "2.1.0",
+            "@chakra-ui/react-use-merge-refs": "2.1.0",
+            "@chakra-ui/react-use-safe-layout-effect": "2.1.0",
+            "@chakra-ui/react-use-update-effect": "2.1.0",
+            "@chakra-ui/shared-utils": "2.0.5",
+            "@chakra-ui/visually-hidden": "2.2.0",
+            "@zag-js/focus-visible": "0.16.0"
+          }
+        },
+        "@chakra-ui/clickable": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/clickable/-/clickable-2.1.0.tgz",
+          "integrity": "sha512-flRA/ClPUGPYabu+/GLREZVZr9j2uyyazCAUHAdrTUEdDYCr31SVGhgh7dgKdtq23bOvAQJpIJjw/0Bs0WvbXw==",
+          "requires": {
+            "@chakra-ui/react-use-merge-refs": "2.1.0",
+            "@chakra-ui/shared-utils": "2.0.5"
+          }
+        },
+        "@chakra-ui/close-button": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/close-button/-/close-button-2.1.1.tgz",
+          "integrity": "sha512-gnpENKOanKexswSVpVz7ojZEALl2x5qjLYNqSQGbxz+aP9sOXPfUS56ebyBrre7T7exuWGiFeRwnM0oVeGPaiw==",
+          "requires": {
+            "@chakra-ui/icon": "3.2.0"
+          }
+        },
+        "@chakra-ui/control-box": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/control-box/-/control-box-2.1.0.tgz",
+          "integrity": "sha512-gVrRDyXFdMd8E7rulL0SKeoljkLQiPITFnsyMO8EFHNZ+AHt5wK4LIguYVEq88APqAGZGfHFWXr79RYrNiE3Mg==",
+          "requires": {}
+        },
+        "@chakra-ui/counter": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/counter/-/counter-2.1.0.tgz",
+          "integrity": "sha512-s6hZAEcWT5zzjNz2JIWUBzRubo9la/oof1W7EKZVVfPYHERnl5e16FmBC79Yfq8p09LQ+aqFKm/etYoJMMgghw==",
+          "requires": {
+            "@chakra-ui/number-utils": "2.0.7",
+            "@chakra-ui/react-use-callback-ref": "2.1.0",
+            "@chakra-ui/shared-utils": "2.0.5"
+          }
+        },
+        "@chakra-ui/css-reset": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/css-reset/-/css-reset-2.3.0.tgz",
+          "integrity": "sha512-cQwwBy5O0jzvl0K7PLTLgp8ijqLPKyuEMiDXwYzl95seD3AoeuoCLyzZcJtVqaUZ573PiBdAbY/IlZcwDOItWg==",
+          "requires": {}
+        },
+        "@chakra-ui/descendant": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/descendant/-/descendant-3.1.0.tgz",
+          "integrity": "sha512-VxCIAir08g5w27klLyi7PVo8BxhW4tgU/lxQyujkmi4zx7hT9ZdrcQLAted/dAa+aSIZ14S1oV0Q9lGjsAdxUQ==",
+          "requires": {
+            "@chakra-ui/react-context": "2.1.0",
+            "@chakra-ui/react-use-merge-refs": "2.1.0"
+          }
+        },
+        "@chakra-ui/editable": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/editable/-/editable-3.1.0.tgz",
+          "integrity": "sha512-j2JLrUL9wgg4YA6jLlbU88370eCRyor7DZQD9lzpY95tSOXpTljeg3uF9eOmDnCs6fxp3zDWIfkgMm/ExhcGTg==",
+          "requires": {
+            "@chakra-ui/react-context": "2.1.0",
+            "@chakra-ui/react-types": "2.0.7",
+            "@chakra-ui/react-use-callback-ref": "2.1.0",
+            "@chakra-ui/react-use-controllable-state": "2.1.0",
+            "@chakra-ui/react-use-focus-on-pointer-down": "2.1.0",
+            "@chakra-ui/react-use-merge-refs": "2.1.0",
+            "@chakra-ui/react-use-safe-layout-effect": "2.1.0",
+            "@chakra-ui/react-use-update-effect": "2.1.0",
+            "@chakra-ui/shared-utils": "2.0.5"
+          }
+        },
+        "@chakra-ui/focus-lock": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/focus-lock/-/focus-lock-2.1.0.tgz",
+          "integrity": "sha512-EmGx4PhWGjm4dpjRqM4Aa+rCWBxP+Rq8Uc/nAVnD4YVqkEhBkrPTpui2lnjsuxqNaZ24fIAZ10cF1hlpemte/w==",
+          "requires": {
+            "@chakra-ui/dom-utils": "2.1.0",
+            "react-focus-lock": "^2.9.4"
+          }
+        },
+        "@chakra-ui/form-control": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/form-control/-/form-control-2.2.0.tgz",
+          "integrity": "sha512-wehLC1t4fafCVJ2RvJQT2jyqsAwX7KymmiGqBu7nQoQz8ApTkGABWpo/QwDh3F/dBLrouHDoOvGmYTqft3Mirw==",
+          "requires": {
+            "@chakra-ui/icon": "3.2.0",
+            "@chakra-ui/react-context": "2.1.0",
+            "@chakra-ui/react-types": "2.0.7",
+            "@chakra-ui/react-use-merge-refs": "2.1.0",
+            "@chakra-ui/shared-utils": "2.0.5"
+          }
+        },
+        "@chakra-ui/hooks": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/hooks/-/hooks-2.2.1.tgz",
+          "integrity": "sha512-RQbTnzl6b1tBjbDPf9zGRo9rf/pQMholsOudTxjy4i9GfTfz6kgp5ValGjQm2z7ng6Z31N1cnjZ1AlSzQ//ZfQ==",
+          "requires": {
+            "@chakra-ui/react-utils": "2.0.12",
+            "@chakra-ui/utils": "2.0.15",
+            "compute-scroll-into-view": "3.0.3",
+            "copy-to-clipboard": "3.3.3"
+          }
+        },
+        "@chakra-ui/icon": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/icon/-/icon-3.2.0.tgz",
+          "integrity": "sha512-xxjGLvlX2Ys4H0iHrI16t74rG9EBcpFvJ3Y3B7KMQTrnW34Kf7Da/UC8J67Gtx85mTHW020ml85SVPKORWNNKQ==",
+          "requires": {
+            "@chakra-ui/shared-utils": "2.0.5"
+          }
+        },
+        "@chakra-ui/image": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/image/-/image-2.1.0.tgz",
+          "integrity": "sha512-bskumBYKLiLMySIWDGcz0+D9Th0jPvmX6xnRMs4o92tT3Od/bW26lahmV2a2Op2ItXeCmRMY+XxJH5Gy1i46VA==",
+          "requires": {
+            "@chakra-ui/react-use-safe-layout-effect": "2.1.0",
+            "@chakra-ui/shared-utils": "2.0.5"
+          }
+        },
+        "@chakra-ui/input": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/input/-/input-2.1.2.tgz",
+          "integrity": "sha512-GiBbb3EqAA8Ph43yGa6Mc+kUPjh4Spmxp1Pkelr8qtudpc3p2PJOOebLpd90mcqw8UePPa+l6YhhPtp6o0irhw==",
+          "requires": {
+            "@chakra-ui/form-control": "2.2.0",
+            "@chakra-ui/object-utils": "2.1.0",
+            "@chakra-ui/react-children-utils": "2.0.6",
+            "@chakra-ui/react-context": "2.1.0",
+            "@chakra-ui/shared-utils": "2.0.5"
+          }
+        },
+        "@chakra-ui/layout": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/layout/-/layout-2.3.1.tgz",
+          "integrity": "sha512-nXuZ6WRbq0WdgnRgLw+QuxWAHuhDtVX8ElWqcTK+cSMFg/52eVP47czYBE5F35YhnoW2XBwfNoNgZ7+e8Z01Rg==",
+          "requires": {
+            "@chakra-ui/breakpoint-utils": "2.0.8",
+            "@chakra-ui/icon": "3.2.0",
+            "@chakra-ui/object-utils": "2.1.0",
+            "@chakra-ui/react-children-utils": "2.0.6",
+            "@chakra-ui/react-context": "2.1.0",
+            "@chakra-ui/shared-utils": "2.0.5"
+          }
+        },
+        "@chakra-ui/live-region": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/live-region/-/live-region-2.1.0.tgz",
+          "integrity": "sha512-ZOxFXwtaLIsXjqnszYYrVuswBhnIHHP+XIgK1vC6DePKtyK590Wg+0J0slDwThUAd4MSSIUa/nNX84x1GMphWw==",
+          "requires": {}
+        },
+        "@chakra-ui/media-query": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/media-query/-/media-query-3.3.0.tgz",
+          "integrity": "sha512-IsTGgFLoICVoPRp9ykOgqmdMotJG0CnPsKvGQeSFOB/dZfIujdVb14TYxDU4+MURXry1MhJ7LzZhv+Ml7cr8/g==",
+          "requires": {
+            "@chakra-ui/breakpoint-utils": "2.0.8",
+            "@chakra-ui/react-env": "3.1.0",
+            "@chakra-ui/shared-utils": "2.0.5"
+          }
+        },
+        "@chakra-ui/menu": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/menu/-/menu-2.2.1.tgz",
+          "integrity": "sha512-lJS7XEObzJxsOwWQh7yfG4H8FzFPRP5hVPN/CL+JzytEINCSBvsCDHrYPQGp7jzpCi8vnTqQQGQe0f8dwnXd2g==",
+          "requires": {
+            "@chakra-ui/clickable": "2.1.0",
+            "@chakra-ui/descendant": "3.1.0",
+            "@chakra-ui/lazy-utils": "2.0.5",
+            "@chakra-ui/popper": "3.1.0",
+            "@chakra-ui/react-children-utils": "2.0.6",
+            "@chakra-ui/react-context": "2.1.0",
+            "@chakra-ui/react-use-animation-state": "2.1.0",
+            "@chakra-ui/react-use-controllable-state": "2.1.0",
+            "@chakra-ui/react-use-disclosure": "2.1.0",
+            "@chakra-ui/react-use-focus-effect": "2.1.0",
+            "@chakra-ui/react-use-merge-refs": "2.1.0",
+            "@chakra-ui/react-use-outside-click": "2.2.0",
+            "@chakra-ui/react-use-update-effect": "2.1.0",
+            "@chakra-ui/shared-utils": "2.0.5",
+            "@chakra-ui/transition": "2.1.0"
+          }
+        },
+        "@chakra-ui/modal": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/modal/-/modal-2.3.1.tgz",
+          "integrity": "sha512-TQv1ZaiJMZN+rR9DK0snx/OPwmtaGH1HbZtlYt4W4s6CzyK541fxLRTjIXfEzIGpvNW+b6VFuFjbcR78p4DEoQ==",
+          "requires": {
+            "@chakra-ui/close-button": "2.1.1",
+            "@chakra-ui/focus-lock": "2.1.0",
+            "@chakra-ui/portal": "2.1.0",
+            "@chakra-ui/react-context": "2.1.0",
+            "@chakra-ui/react-types": "2.0.7",
+            "@chakra-ui/react-use-merge-refs": "2.1.0",
+            "@chakra-ui/shared-utils": "2.0.5",
+            "@chakra-ui/transition": "2.1.0",
+            "aria-hidden": "^1.2.3",
+            "react-remove-scroll": "^2.5.6"
+          }
+        },
+        "@chakra-ui/number-input": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/number-input/-/number-input-2.1.2.tgz",
+          "integrity": "sha512-pfOdX02sqUN0qC2ysuvgVDiws7xZ20XDIlcNhva55Jgm095xjm8eVdIBfNm3SFbSUNxyXvLTW/YQanX74tKmuA==",
+          "requires": {
+            "@chakra-ui/counter": "2.1.0",
+            "@chakra-ui/form-control": "2.2.0",
+            "@chakra-ui/icon": "3.2.0",
+            "@chakra-ui/react-context": "2.1.0",
+            "@chakra-ui/react-types": "2.0.7",
+            "@chakra-ui/react-use-callback-ref": "2.1.0",
+            "@chakra-ui/react-use-event-listener": "2.1.0",
+            "@chakra-ui/react-use-interval": "2.1.0",
+            "@chakra-ui/react-use-merge-refs": "2.1.0",
+            "@chakra-ui/react-use-safe-layout-effect": "2.1.0",
+            "@chakra-ui/react-use-update-effect": "2.1.0",
+            "@chakra-ui/shared-utils": "2.0.5"
+          }
+        },
+        "@chakra-ui/pin-input": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/pin-input/-/pin-input-2.1.0.tgz",
+          "integrity": "sha512-x4vBqLStDxJFMt+jdAHHS8jbh294O53CPQJoL4g228P513rHylV/uPscYUHrVJXRxsHfRztQO9k45jjTYaPRMw==",
+          "requires": {
+            "@chakra-ui/descendant": "3.1.0",
+            "@chakra-ui/react-children-utils": "2.0.6",
+            "@chakra-ui/react-context": "2.1.0",
+            "@chakra-ui/react-use-controllable-state": "2.1.0",
+            "@chakra-ui/react-use-merge-refs": "2.1.0",
+            "@chakra-ui/shared-utils": "2.0.5"
+          }
+        },
+        "@chakra-ui/popover": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/popover/-/popover-2.2.1.tgz",
+          "integrity": "sha512-K+2ai2dD0ljvJnlrzesCDT9mNzLifE3noGKZ3QwLqd/K34Ym1W/0aL1ERSynrcG78NKoXS54SdEzkhCZ4Gn/Zg==",
+          "requires": {
+            "@chakra-ui/close-button": "2.1.1",
+            "@chakra-ui/lazy-utils": "2.0.5",
+            "@chakra-ui/popper": "3.1.0",
+            "@chakra-ui/react-context": "2.1.0",
+            "@chakra-ui/react-types": "2.0.7",
+            "@chakra-ui/react-use-animation-state": "2.1.0",
+            "@chakra-ui/react-use-disclosure": "2.1.0",
+            "@chakra-ui/react-use-focus-effect": "2.1.0",
+            "@chakra-ui/react-use-focus-on-pointer-down": "2.1.0",
+            "@chakra-ui/react-use-merge-refs": "2.1.0",
+            "@chakra-ui/shared-utils": "2.0.5"
+          }
+        },
+        "@chakra-ui/popper": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/popper/-/popper-3.1.0.tgz",
+          "integrity": "sha512-ciDdpdYbeFG7og6/6J8lkTFxsSvwTdMLFkpVylAF6VNC22jssiWfquj2eyD4rJnzkRFPvIWJq8hvbfhsm+AjSg==",
+          "requires": {
+            "@chakra-ui/react-types": "2.0.7",
+            "@chakra-ui/react-use-merge-refs": "2.1.0",
+            "@popperjs/core": "^2.9.3"
+          }
+        },
+        "@chakra-ui/portal": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/portal/-/portal-2.1.0.tgz",
+          "integrity": "sha512-9q9KWf6SArEcIq1gGofNcFPSWEyl+MfJjEUg/un1SMlQjaROOh3zYr+6JAwvcORiX7tyHosnmWC3d3wI2aPSQg==",
+          "requires": {
+            "@chakra-ui/react-context": "2.1.0",
+            "@chakra-ui/react-use-safe-layout-effect": "2.1.0"
+          }
+        },
+        "@chakra-ui/progress": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/progress/-/progress-2.2.0.tgz",
+          "integrity": "sha512-qUXuKbuhN60EzDD9mHR7B67D7p/ZqNS2Aze4Pbl1qGGZfulPW0PY8Rof32qDtttDQBkzQIzFGE8d9QpAemToIQ==",
+          "requires": {
+            "@chakra-ui/react-context": "2.1.0"
+          }
+        },
+        "@chakra-ui/provider": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/provider/-/provider-2.4.2.tgz",
+          "integrity": "sha512-w0Tef5ZCJK1mlJorcSjItCSbyvVuqpvyWdxZiVQmE6fvSJR83wZof42ux0+sfWD+I7rHSfj+f9nzhNaEWClysw==",
+          "requires": {
+            "@chakra-ui/css-reset": "2.3.0",
+            "@chakra-ui/portal": "2.1.0",
+            "@chakra-ui/react-env": "3.1.0",
+            "@chakra-ui/system": "2.6.2",
+            "@chakra-ui/utils": "2.0.15"
+          }
+        },
+        "@chakra-ui/radio": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/radio/-/radio-2.1.2.tgz",
+          "integrity": "sha512-n10M46wJrMGbonaghvSRnZ9ToTv/q76Szz284gv4QUWvyljQACcGrXIONUnQ3BIwbOfkRqSk7Xl/JgZtVfll+w==",
+          "requires": {
+            "@chakra-ui/form-control": "2.2.0",
+            "@chakra-ui/react-context": "2.1.0",
+            "@chakra-ui/react-types": "2.0.7",
+            "@chakra-ui/react-use-merge-refs": "2.1.0",
+            "@chakra-ui/shared-utils": "2.0.5",
+            "@zag-js/focus-visible": "0.16.0"
+          }
+        },
+        "@chakra-ui/react": {
+          "version": "2.8.2",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/react/-/react-2.8.2.tgz",
+          "integrity": "sha512-Hn0moyxxyCDKuR9ywYpqgX8dvjqwu9ArwpIb9wHNYjnODETjLwazgNIliCVBRcJvysGRiV51U2/JtJVrpeCjUQ==",
+          "requires": {
+            "@chakra-ui/accordion": "2.3.1",
+            "@chakra-ui/alert": "2.2.2",
+            "@chakra-ui/avatar": "2.3.0",
+            "@chakra-ui/breadcrumb": "2.2.0",
+            "@chakra-ui/button": "2.1.0",
+            "@chakra-ui/card": "2.2.0",
+            "@chakra-ui/checkbox": "2.3.2",
+            "@chakra-ui/close-button": "2.1.1",
+            "@chakra-ui/control-box": "2.1.0",
+            "@chakra-ui/counter": "2.1.0",
+            "@chakra-ui/css-reset": "2.3.0",
+            "@chakra-ui/editable": "3.1.0",
+            "@chakra-ui/focus-lock": "2.1.0",
+            "@chakra-ui/form-control": "2.2.0",
+            "@chakra-ui/hooks": "2.2.1",
+            "@chakra-ui/icon": "3.2.0",
+            "@chakra-ui/image": "2.1.0",
+            "@chakra-ui/input": "2.1.2",
+            "@chakra-ui/layout": "2.3.1",
+            "@chakra-ui/live-region": "2.1.0",
+            "@chakra-ui/media-query": "3.3.0",
+            "@chakra-ui/menu": "2.2.1",
+            "@chakra-ui/modal": "2.3.1",
+            "@chakra-ui/number-input": "2.1.2",
+            "@chakra-ui/pin-input": "2.1.0",
+            "@chakra-ui/popover": "2.2.1",
+            "@chakra-ui/popper": "3.1.0",
+            "@chakra-ui/portal": "2.1.0",
+            "@chakra-ui/progress": "2.2.0",
+            "@chakra-ui/provider": "2.4.2",
+            "@chakra-ui/radio": "2.1.2",
+            "@chakra-ui/react-env": "3.1.0",
+            "@chakra-ui/select": "2.1.2",
+            "@chakra-ui/skeleton": "2.1.0",
+            "@chakra-ui/skip-nav": "2.1.0",
+            "@chakra-ui/slider": "2.1.0",
+            "@chakra-ui/spinner": "2.1.0",
+            "@chakra-ui/stat": "2.1.1",
+            "@chakra-ui/stepper": "2.3.1",
+            "@chakra-ui/styled-system": "2.9.2",
+            "@chakra-ui/switch": "2.1.2",
+            "@chakra-ui/system": "2.6.2",
+            "@chakra-ui/table": "2.1.0",
+            "@chakra-ui/tabs": "3.0.0",
+            "@chakra-ui/tag": "3.1.1",
+            "@chakra-ui/textarea": "2.1.2",
+            "@chakra-ui/theme": "3.3.1",
+            "@chakra-ui/theme-utils": "2.0.21",
+            "@chakra-ui/toast": "7.0.2",
+            "@chakra-ui/tooltip": "2.3.1",
+            "@chakra-ui/transition": "2.1.0",
+            "@chakra-ui/utils": "2.0.15",
+            "@chakra-ui/visually-hidden": "2.2.0"
+          }
+        },
+        "@chakra-ui/react-env": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/react-env/-/react-env-3.1.0.tgz",
+          "integrity": "sha512-Vr96GV2LNBth3+IKzr/rq1IcnkXv+MLmwjQH6C8BRtn3sNskgDFD5vLkVXcEhagzZMCh8FR3V/bzZPojBOyNhw==",
+          "requires": {
+            "@chakra-ui/react-use-safe-layout-effect": "2.1.0"
+          }
+        },
+        "@chakra-ui/select": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/select/-/select-2.1.2.tgz",
+          "integrity": "sha512-ZwCb7LqKCVLJhru3DXvKXpZ7Pbu1TDZ7N0PdQ0Zj1oyVLJyrpef1u9HR5u0amOpqcH++Ugt0f5JSmirjNlctjA==",
+          "requires": {
+            "@chakra-ui/form-control": "2.2.0",
+            "@chakra-ui/shared-utils": "2.0.5"
+          }
+        },
+        "@chakra-ui/skeleton": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/skeleton/-/skeleton-2.1.0.tgz",
+          "integrity": "sha512-JNRuMPpdZGd6zFVKjVQ0iusu3tXAdI29n4ZENYwAJEMf/fN0l12sVeirOxkJ7oEL0yOx2AgEYFSKdbcAgfUsAQ==",
+          "requires": {
+            "@chakra-ui/media-query": "3.3.0",
+            "@chakra-ui/react-use-previous": "2.1.0",
+            "@chakra-ui/shared-utils": "2.0.5"
+          }
+        },
+        "@chakra-ui/slider": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/slider/-/slider-2.1.0.tgz",
+          "integrity": "sha512-lUOBcLMCnFZiA/s2NONXhELJh6sY5WtbRykPtclGfynqqOo47lwWJx+VP7xaeuhDOPcWSSecWc9Y1BfPOCz9cQ==",
+          "requires": {
+            "@chakra-ui/number-utils": "2.0.7",
+            "@chakra-ui/react-context": "2.1.0",
+            "@chakra-ui/react-types": "2.0.7",
+            "@chakra-ui/react-use-callback-ref": "2.1.0",
+            "@chakra-ui/react-use-controllable-state": "2.1.0",
+            "@chakra-ui/react-use-latest-ref": "2.1.0",
+            "@chakra-ui/react-use-merge-refs": "2.1.0",
+            "@chakra-ui/react-use-pan-event": "2.1.0",
+            "@chakra-ui/react-use-size": "2.1.0",
+            "@chakra-ui/react-use-update-effect": "2.1.0"
+          }
+        },
+        "@chakra-ui/spinner": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/spinner/-/spinner-2.1.0.tgz",
+          "integrity": "sha512-hczbnoXt+MMv/d3gE+hjQhmkzLiKuoTo42YhUG7Bs9OSv2lg1fZHW1fGNRFP3wTi6OIbD044U1P9HK+AOgFH3g==",
+          "requires": {
+            "@chakra-ui/shared-utils": "2.0.5"
+          }
+        },
+        "@chakra-ui/stat": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/stat/-/stat-2.1.1.tgz",
+          "integrity": "sha512-LDn0d/LXQNbAn2KaR3F1zivsZCewY4Jsy1qShmfBMKwn6rI8yVlbvu6SiA3OpHS0FhxbsZxQI6HefEoIgtqY6Q==",
+          "requires": {
+            "@chakra-ui/icon": "3.2.0",
+            "@chakra-ui/react-context": "2.1.0",
+            "@chakra-ui/shared-utils": "2.0.5"
+          }
+        },
+        "@chakra-ui/styled-system": {
+          "version": "2.9.2",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/styled-system/-/styled-system-2.9.2.tgz",
+          "integrity": "sha512-To/Z92oHpIE+4nk11uVMWqo2GGRS86coeMmjxtpnErmWRdLcp1WVCVRAvn+ZwpLiNR+reWFr2FFqJRsREuZdAg==",
+          "requires": {
+            "@chakra-ui/shared-utils": "2.0.5",
+            "csstype": "^3.1.2",
+            "lodash.mergewith": "4.6.2"
+          }
+        },
+        "@chakra-ui/switch": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/switch/-/switch-2.1.2.tgz",
+          "integrity": "sha512-pgmi/CC+E1v31FcnQhsSGjJnOE2OcND4cKPyTE+0F+bmGm48Q/b5UmKD9Y+CmZsrt/7V3h8KNczowupfuBfIHA==",
+          "requires": {
+            "@chakra-ui/checkbox": "2.3.2",
+            "@chakra-ui/shared-utils": "2.0.5"
+          }
+        },
+        "@chakra-ui/table": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/table/-/table-2.1.0.tgz",
+          "integrity": "sha512-o5OrjoHCh5uCLdiUb0Oc0vq9rIAeHSIRScc2ExTC9Qg/uVZl2ygLrjToCaKfaaKl1oQexIeAcZDKvPG8tVkHyQ==",
+          "requires": {
+            "@chakra-ui/react-context": "2.1.0",
+            "@chakra-ui/shared-utils": "2.0.5"
+          }
+        },
+        "@chakra-ui/tabs": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/tabs/-/tabs-3.0.0.tgz",
+          "integrity": "sha512-6Mlclp8L9lqXmsGWF5q5gmemZXOiOYuh0SGT/7PgJVNPz3LXREXlXg2an4MBUD8W5oTkduCX+3KTMCwRrVrDYw==",
+          "requires": {
+            "@chakra-ui/clickable": "2.1.0",
+            "@chakra-ui/descendant": "3.1.0",
+            "@chakra-ui/lazy-utils": "2.0.5",
+            "@chakra-ui/react-children-utils": "2.0.6",
+            "@chakra-ui/react-context": "2.1.0",
+            "@chakra-ui/react-use-controllable-state": "2.1.0",
+            "@chakra-ui/react-use-merge-refs": "2.1.0",
+            "@chakra-ui/react-use-safe-layout-effect": "2.1.0",
+            "@chakra-ui/shared-utils": "2.0.5"
+          }
+        },
+        "@chakra-ui/tag": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/tag/-/tag-3.1.1.tgz",
+          "integrity": "sha512-Bdel79Dv86Hnge2PKOU+t8H28nm/7Y3cKd4Kfk9k3lOpUh4+nkSGe58dhRzht59lEqa4N9waCgQiBdkydjvBXQ==",
+          "requires": {
+            "@chakra-ui/icon": "3.2.0",
+            "@chakra-ui/react-context": "2.1.0"
+          }
+        },
+        "@chakra-ui/textarea": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/textarea/-/textarea-2.1.2.tgz",
+          "integrity": "sha512-ip7tvklVCZUb2fOHDb23qPy/Fr2mzDOGdkrpbNi50hDCiV4hFX02jdQJdi3ydHZUyVgZVBKPOJ+lT9i7sKA2wA==",
+          "requires": {
+            "@chakra-ui/form-control": "2.2.0",
+            "@chakra-ui/shared-utils": "2.0.5"
+          }
+        },
+        "@chakra-ui/theme": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/theme/-/theme-3.3.1.tgz",
+          "integrity": "sha512-Hft/VaT8GYnItGCBbgWd75ICrIrIFrR7lVOhV/dQnqtfGqsVDlrztbSErvMkoPKt0UgAkd9/o44jmZ6X4U2nZQ==",
+          "requires": {
+            "@chakra-ui/anatomy": "2.2.2",
+            "@chakra-ui/shared-utils": "2.0.5",
+            "@chakra-ui/theme-tools": "2.1.2"
+          }
+        },
+        "@chakra-ui/theme-tools": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/theme-tools/-/theme-tools-2.1.2.tgz",
+          "integrity": "sha512-Qdj8ajF9kxY4gLrq7gA+Azp8CtFHGO9tWMN2wfF9aQNgG9AuMhPrUzMq9AMQ0MXiYcgNq/FD3eegB43nHVmXVA==",
+          "requires": {
+            "@chakra-ui/anatomy": "2.2.2",
+            "@chakra-ui/shared-utils": "2.0.5",
+            "color2k": "^2.0.2"
+          }
+        },
+        "@chakra-ui/toast": {
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/toast/-/toast-7.0.2.tgz",
+          "integrity": "sha512-yvRP8jFKRs/YnkuE41BVTq9nB2v/KDRmje9u6dgDmE5+1bFt3bwjdf9gVbif4u5Ve7F7BGk5E093ARRVtvLvXA==",
+          "requires": {
+            "@chakra-ui/alert": "2.2.2",
+            "@chakra-ui/close-button": "2.1.1",
+            "@chakra-ui/portal": "2.1.0",
+            "@chakra-ui/react-context": "2.1.0",
+            "@chakra-ui/react-use-timeout": "2.1.0",
+            "@chakra-ui/react-use-update-effect": "2.1.0",
+            "@chakra-ui/shared-utils": "2.0.5",
+            "@chakra-ui/styled-system": "2.9.2",
+            "@chakra-ui/theme": "3.3.1"
+          }
+        },
+        "@chakra-ui/tooltip": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/tooltip/-/tooltip-2.3.1.tgz",
+          "integrity": "sha512-Rh39GBn/bL4kZpuEMPPRwYNnccRCL+w9OqamWHIB3Qboxs6h8cOyXfIdGxjo72lvhu1QI/a4KFqkM3St+WfC0A==",
+          "requires": {
+            "@chakra-ui/dom-utils": "2.1.0",
+            "@chakra-ui/popper": "3.1.0",
+            "@chakra-ui/portal": "2.1.0",
+            "@chakra-ui/react-types": "2.0.7",
+            "@chakra-ui/react-use-disclosure": "2.1.0",
+            "@chakra-ui/react-use-event-listener": "2.1.0",
+            "@chakra-ui/react-use-merge-refs": "2.1.0",
+            "@chakra-ui/shared-utils": "2.0.5"
+          }
+        },
+        "@chakra-ui/transition": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/transition/-/transition-2.1.0.tgz",
+          "integrity": "sha512-orkT6T/Dt+/+kVwJNy7zwJ+U2xAZ3EU7M3XCs45RBvUnZDr/u9vdmaM/3D/rOpmQJWgQBwKPJleUXrYWUagEDQ==",
+          "requires": {
+            "@chakra-ui/shared-utils": "2.0.5"
+          }
+        },
+        "@chakra-ui/utils": {
+          "version": "2.0.15",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/utils/-/utils-2.0.15.tgz",
+          "integrity": "sha512-El4+jL0WSaYYs+rJbuYFDbjmfCcfGDmRY95GO4xwzit6YAPZBLcR65rOEwLps+XWluZTy1xdMrusg/hW0c1aAA==",
+          "requires": {
+            "@types/lodash.mergewith": "4.6.7",
+            "css-box-model": "1.2.1",
+            "framesync": "6.1.2",
+            "lodash.mergewith": "4.6.2"
+          }
+        },
+        "@chakra-ui/visually-hidden": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@chakra-ui/visually-hidden/-/visually-hidden-2.2.0.tgz",
+          "integrity": "sha512-KmKDg01SrQ7VbTD3+cPWf/UfpF5MSwm3v7MWi0n5t8HnnadT13MF0MJCDSXbBWnzLv1ZKJ6zlyAOeARWX+DpjQ==",
+          "requires": {}
+        },
+        "@types/lodash.mergewith": {
+          "version": "4.6.7",
+          "resolved": "https://registry.npmjs.org/@types/lodash.mergewith/-/lodash.mergewith-4.6.7.tgz",
+          "integrity": "sha512-3m+lkO5CLRRYU0fhGRp7zbsGi6+BZj0uTVSwvcKU+nSlhjA9/QRNfuSGnD2mX6hQA7ZbmcCkzk5h4ZYGOtk14A==",
+          "requires": {
+            "@types/lodash": "*"
+          }
+        },
+        "@zag-js/dom-query": {
+          "version": "0.16.0",
+          "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-0.16.0.tgz",
+          "integrity": "sha512-Oqhd6+biWyKnhKwFFuZrrf6lxBz2tX2pRQe6grUnYwO6HJ8BcbqZomy2lpOdr+3itlaUqx+Ywj5E5ZZDr/LBfQ=="
+        },
+        "@zag-js/focus-visible": {
+          "version": "0.16.0",
+          "resolved": "https://registry.npmjs.org/@zag-js/focus-visible/-/focus-visible-0.16.0.tgz",
+          "integrity": "sha512-a7U/HSopvQbrDU4GLerpqiMcHKEkQkNPeDZJWz38cw/6Upunh41GjHetq5TB84hxyCaDzJ6q2nEdNoBQfC0FKA==",
+          "requires": {
+            "@zag-js/dom-query": "0.16.0"
+          }
+        },
+        "compute-scroll-into-view": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.0.3.tgz",
+          "integrity": "sha512-nadqwNxghAGTamwIqQSG433W6OADZx2vCo3UXHNrzTRHK/htu+7+L0zhjEoaeaQVNAi3YgqWDv8+tzf0hRfR+A=="
+        },
         "mathjs": {
           "version": "12.4.3",
           "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-12.4.3.tgz",
@@ -30760,18 +32189,11 @@
           }
         },
         "mobx-react-lite": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-4.1.0.tgz",
-          "integrity": "sha512-QEP10dpHHBeQNv1pks3WnHRCem2Zp636lq54M2nKO2Sarr13pL4u6diQXf65yzXUn0mkk18SyIDCm9UOJYTi1w==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-4.1.1.tgz",
+          "integrity": "sha512-iUxiMpsvNraCKXU+yPotsOncNNmyeS2B5DKL+TL6Tar/xm+wwNJAubJmtRSeAoYawdZqwv8Z/+5nPRHeQxTiXg==",
           "requires": {
             "use-sync-external-store": "^1.4.0"
-          },
-          "dependencies": {
-            "use-sync-external-store": {
-              "version": "1.5.0",
-              "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
-              "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A=="
-            }
           }
         },
         "type-fest": {
@@ -30780,9 +32202,15 @@
           "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="
         },
         "typed-function": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-4.2.1.tgz",
-          "integrity": "sha512-EGjWssW7Tsk4DGfE+5yluuljS1OGYWiI1J6e8puZz9nTMM51Oug8CD5Zo4gWMsOhq5BI+1bF+rWTm4Vbj3ivRA=="
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-4.2.2.tgz",
+          "integrity": "sha512-VwaXim9Gp1bngi/q3do8hgttYn2uC3MoT/gfuMWylnj1IeZBUAyPddHZlo1K05BDoj8DYPpMdiHqH1dDYdJf2A=="
+        },
+        "use-sync-external-store": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+          "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+          "requires": {}
         }
       }
     },
@@ -30844,18 +32272,165 @@
       }
     },
     "@concord-consortium/diagram-view": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-1.0.2.tgz",
-      "integrity": "sha512-RlaTEc8U3v2sXpBicHi4Ka8jafWv9z5vZqGkYGOMiFA+O3yvJtFY7KnFKeIOdVcIVHvGwdvUEDg4Cot0NjBknA==",
+      "version": "2.0.0-pre.2",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/diagram-view/-/diagram-view-2.0.0-pre.2.tgz",
+      "integrity": "sha512-AiR5J/O2bAAE3pPBOA3d0cbUEu+rRNzOYsmUShOUqVXsyzq8M1ehDuRa4chGzsfMhgTZsRkiOzYD5xltlmaL7w==",
       "requires": {
+        "@uiw/react-color-circle": "^2.10.1",
         "classnames": "^2.3.2",
         "iframe-phone": "^1.3.1",
         "mathjs": "^10.4.1",
         "patch-package": "^6.5.1",
         "pluralize": "^8.0.0",
-        "react-color": "^2.19.3",
         "react-textarea-autosize": "^8.3.4",
         "reactflow": "^11.7.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "ci-info": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+          "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "cross-spawn": {
+          "version": "6.0.6",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
+          "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "is-ci": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+          "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+          "requires": {
+            "ci-info": "^2.0.0"
+          }
+        },
+        "open": {
+          "version": "7.4.2",
+          "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+          "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+          "requires": {
+            "is-docker": "^2.0.0",
+            "is-wsl": "^2.1.1"
+          }
+        },
+        "patch-package": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-6.5.1.tgz",
+          "integrity": "sha512-I/4Zsalfhc6bphmJTlrLoOcAF87jcxko4q0qsv4bGcurbr8IskEOtdnt9iCmsQVGL1B+iUhSQqweyTLJfCF9rA==",
+          "requires": {
+            "@yarnpkg/lockfile": "^1.1.0",
+            "chalk": "^4.1.2",
+            "cross-spawn": "^6.0.5",
+            "find-yarn-workspace-root": "^2.0.0",
+            "fs-extra": "^9.0.0",
+            "is-ci": "^2.0.0",
+            "klaw-sync": "^6.0.0",
+            "minimist": "^1.2.6",
+            "open": "^7.4.2",
+            "rimraf": "^2.6.3",
+            "semver": "^5.6.0",
+            "slash": "^2.0.0",
+            "tmp": "^0.0.33",
+            "yaml": "^1.10.2"
+          }
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw=="
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+          "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+          "requires": {
+            "shebang-regex": "^1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ=="
+        },
+        "slash": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+          "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "tmp": {
+          "version": "0.0.33",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+          "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+          "requires": {
+            "os-tmpdir": "~1.0.2"
+          }
+        },
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
       }
     },
     "@concord-consortium/lara-interactive-api": {
@@ -30870,12 +32445,14 @@
     "@concord-consortium/log-monitor": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@concord-consortium/log-monitor/-/log-monitor-1.0.0.tgz",
-      "integrity": "sha512-3eGS2jkil8MdEYMSaW/lJV2OYaW+kQsPoRUx086D+XaYdC3sRwIGq+Laqh7/qPCApnL+tj/ZA27bWZ5u4oSF9w=="
+      "integrity": "sha512-3eGS2jkil8MdEYMSaW/lJV2OYaW+kQsPoRUx086D+XaYdC3sRwIGq+Laqh7/qPCApnL+tj/ZA27bWZ5u4oSF9w==",
+      "requires": {}
     },
     "@concord-consortium/mobx-state-tree": {
       "version": "6.0.0-cc.1",
       "resolved": "https://registry.npmjs.org/@concord-consortium/mobx-state-tree/-/mobx-state-tree-6.0.0-cc.1.tgz",
-      "integrity": "sha512-dfzSe4ba2dNreouI3YXsUv1tmNlyx2Lj3oa5QoEi2WQazMgCqQY/mCMM87z1HfflYlCnLFoDu8KP2XTp3ljTvg=="
+      "integrity": "sha512-dfzSe4ba2dNreouI3YXsUv1tmNlyx2Lj3oa5QoEi2WQazMgCqQY/mCMM87z1HfflYlCnLFoDu8KP2XTp3ljTvg==",
+      "requires": {}
     },
     "@concord-consortium/react-components": {
       "version": "1.0.0",
@@ -30886,35 +32463,30 @@
       }
     },
     "@concord-consortium/react-modal-hook": {
-      "version": "3.0.0-cc.1"
+      "version": "3.0.0-cc.1",
+      "requires": {}
     },
     "@concord-consortium/slate-editor": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/slate-editor/-/slate-editor-0.10.1.tgz",
-      "integrity": "sha512-RK86HWXAb6lg1ocbDC05C2Zfb2sxvZncvO0gjDNk6ToQK9M/R1k3cbas+Ft0xmsFBEDXG5Z9iG2bnymvHYI0zw==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/slate-editor/-/slate-editor-0.12.0.tgz",
+      "integrity": "sha512-NhYGV+3IMuIIoW23p/z4Fwdlw2P+Mt7LfbrIO88sGsChIJ1MZ/3yR2LSZrA9Asw1SthgNpRtJCsS0U/nHDNyiA==",
       "requires": {
-        "@emotion/css": "^11.13.0",
+        "@emotion/css": "^11.13.5",
         "classnames": "^2.5.1",
-        "eventemitter3": "^5.0.1",
         "html-escaper": "^3.0.3",
         "is-hotkey": "^0.2.0",
         "lodash": "^4.17.21",
-        "react-select": "^5.8.0",
+        "react-select": "^5.10.2",
         "rgb-hex": "^3.0.0",
-        "slate": "^0.103.0",
-        "slate-history": "^0.100.0",
+        "slate": "^0.118.1",
+        "slate-history": "^0.113.1",
         "slate-hyperscript": "^0.100.0",
-        "slate-react": "~0.98.4",
-        "style-to-object": "^1.0.6",
-        "tslib": "^2.6.3",
+        "slate-react": "^0.117.4",
+        "style-to-object": "^1.0.9",
+        "tslib": "^2.8.1",
         "valid-url": "^1.0.9"
       },
       "dependencies": {
-        "eventemitter3": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-          "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
-        },
         "html-escaper": {
           "version": "3.0.3"
         },
@@ -30952,7 +32524,8 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
       "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@csstools/css-color-parser": {
       "version": "3.1.0",
@@ -30968,16 +32541,14 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
       "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@csstools/css-tokenizer": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
       "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
       "dev": true
-    },
-    "@ctrl/tinycolor": {
-      "version": "3.6.0"
     },
     "@cypress/code-coverage": {
       "version": "3.12.6",
@@ -31385,7 +32956,8 @@
     "@emotion/use-insertion-effect-with-fallbacks": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
-      "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg=="
+      "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
+      "requires": {}
     },
     "@emotion/utils": {
       "version": "1.4.2",
@@ -31586,8 +33158,7 @@
       }
     },
     "@firebase/app-types": {
-      "version": "0.7.0",
-      "dev": true
+      "version": "0.7.0"
     },
     "@firebase/auth": {
       "version": "0.16.8",
@@ -31596,10 +33167,12 @@
       }
     },
     "@firebase/auth-interop-types": {
-      "version": "0.1.6"
+      "version": "0.1.6",
+      "requires": {}
     },
     "@firebase/auth-types": {
-      "version": "0.10.3"
+      "version": "0.10.3",
+      "requires": {}
     },
     "@firebase/component": {
       "version": "0.5.6",
@@ -31739,7 +33312,8 @@
       }
     },
     "@firebase/firestore-types": {
-      "version": "2.4.0"
+      "version": "2.4.0",
+      "requires": {}
     },
     "@firebase/functions": {
       "version": "0.6.16",
@@ -31794,7 +33368,8 @@
       }
     },
     "@firebase/installations-types": {
-      "version": "0.3.4"
+      "version": "0.3.4",
+      "requires": {}
     },
     "@firebase/logger": {
       "version": "0.2.6"
@@ -31811,7 +33386,8 @@
       }
     },
     "@firebase/messaging-types": {
-      "version": "0.5.0"
+      "version": "0.5.0",
+      "requires": {}
     },
     "@firebase/performance": {
       "version": "0.4.18",
@@ -31894,7 +33470,8 @@
       }
     },
     "@firebase/storage-types": {
-      "version": "0.5.0"
+      "version": "0.5.0",
+      "requires": {}
     },
     "@firebase/util": {
       "version": "1.3.0",
@@ -32145,11 +33722,6 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
       "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
       "dev": true
-    },
-    "@icons/material": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",
-      "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
     },
     "@isaacs/cliui": {
       "version": "8.0.2",
@@ -33163,7 +34735,7 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -33212,6 +34784,11 @@
     "@juggle/resize-observer": {
       "version": "3.4.0"
     },
+    "@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w=="
+    },
     "@leichtgewicht/ip-codec": {
       "version": "2.0.4",
       "dev": true
@@ -33251,52 +34828,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g=="
-    },
-    "@motionone/animation": {
-      "version": "10.15.1",
-      "requires": {
-        "@motionone/easing": "^10.15.1",
-        "@motionone/types": "^10.15.1",
-        "@motionone/utils": "^10.15.1",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@motionone/dom": {
-      "version": "10.12.0",
-      "requires": {
-        "@motionone/animation": "^10.12.0",
-        "@motionone/generators": "^10.12.0",
-        "@motionone/types": "^10.12.0",
-        "@motionone/utils": "^10.12.0",
-        "hey-listen": "^1.0.8",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@motionone/easing": {
-      "version": "10.15.1",
-      "requires": {
-        "@motionone/utils": "^10.15.1",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@motionone/generators": {
-      "version": "10.15.1",
-      "requires": {
-        "@motionone/types": "^10.15.1",
-        "@motionone/utils": "^10.15.1",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@motionone/types": {
-      "version": "10.15.1"
-    },
-    "@motionone/utils": {
-      "version": "10.15.1",
-      "requires": {
-        "@motionone/types": "^10.15.1",
-        "hey-listen": "^1.0.8",
-        "tslib": "^2.3.1"
-      }
     },
     "@napi-rs/wasm-runtime": {
       "version": "0.2.12",
@@ -33350,7 +34881,9 @@
       "dev": true
     },
     "@popperjs/core": {
-      "version": "2.11.7"
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="
     },
     "@protobufjs/aspromise": {
       "version": "1.1.2"
@@ -33385,30 +34918,6 @@
     },
     "@protobufjs/utf8": {
       "version": "1.1.0"
-    },
-    "@reach/alert": {
-      "version": "0.13.2",
-      "requires": {
-        "@reach/utils": "0.13.2",
-        "@reach/visually-hidden": "0.13.2",
-        "prop-types": "^15.7.2",
-        "tslib": "^2.1.0"
-      }
-    },
-    "@reach/utils": {
-      "version": "0.13.2",
-      "requires": {
-        "@types/warning": "^3.0.0",
-        "tslib": "^2.1.0",
-        "warning": "^4.0.3"
-      }
-    },
-    "@reach/visually-hidden": {
-      "version": "0.13.2",
-      "requires": {
-        "prop-types": "^15.7.2",
-        "tslib": "^2.1.0"
-      }
     },
     "@reactflow/background": {
       "version": "11.2.2",
@@ -33520,35 +35029,43 @@
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "6.3.1",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@svgr/babel-plugin-remove-jsx-attribute": {
       "version": "6.3.1",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@svgr/babel-plugin-remove-jsx-empty-expression": {
       "version": "6.3.1",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@svgr/babel-plugin-replace-jsx-attribute-value": {
       "version": "6.3.1",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@svgr/babel-plugin-svg-dynamic-title": {
       "version": "6.3.1",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@svgr/babel-plugin-svg-em-dimensions": {
       "version": "6.3.1",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@svgr/babel-plugin-transform-react-native-svg": {
       "version": "6.3.1",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@svgr/babel-plugin-transform-svg-component": {
       "version": "6.3.1",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@svgr/babel-preset": {
       "version": "6.3.1",
@@ -33770,7 +35287,8 @@
     "@tensorflow/tfjs-converter": {
       "version": "4.22.0",
       "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-converter/-/tfjs-converter-4.22.0.tgz",
-      "integrity": "sha512-PT43MGlnzIo+YfbsjM79Lxk9lOq6uUwZuCc8rrp0hfpLjF6Jv8jS84u2jFb+WpUeuF4K33ZDNx8CjiYrGQ2trQ=="
+      "integrity": "sha512-PT43MGlnzIo+YfbsjM79Lxk9lOq6uUwZuCc8rrp0hfpLjF6Jv8jS84u2jFb+WpUeuF4K33ZDNx8CjiYrGQ2trQ==",
+      "requires": {}
     },
     "@tensorflow/tfjs-core": {
       "version": "4.22.0",
@@ -33862,7 +35380,8 @@
     "@tensorflow/tfjs-layers": {
       "version": "4.22.0",
       "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-layers/-/tfjs-layers-4.22.0.tgz",
-      "integrity": "sha512-lybPj4ZNj9iIAPUj7a8ZW1hg8KQGfqWLlCZDi9eM/oNKCCAgchiyzx8OrYoWmRrB+AM6VNEeIT+2gZKg5ReihA=="
+      "integrity": "sha512-lybPj4ZNj9iIAPUj7a8ZW1hg8KQGfqWLlCZDi9eM/oNKCCAgchiyzx8OrYoWmRrB+AM6VNEeIT+2gZKg5ReihA==",
+      "requires": {}
     },
     "@testing-library/cypress": {
       "version": "10.0.1",
@@ -33889,12 +35408,6 @@
             "lz-string": "^1.5.0",
             "pretty-format": "^27.0.2"
           }
-        },
-        "@types/aria-query": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.3.tgz",
-          "integrity": "sha512-0Z6Tr7wjKJIk4OUEjVUQMtyunLDy339vcMaj38Kpj6jM2OE1p3S4kXExKZ7a3uXQAPCoy3sbrP1wibDKaf39oA==",
-          "dev": true
         },
         "ansi-styles": {
           "version": "4.3.0",
@@ -33948,54 +35461,28 @@
       }
     },
     "@testing-library/dom": {
-      "version": "8.10.1",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^4.2.0",
-        "aria-query": "^5.0.0",
-        "chalk": "^4.1.0",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
         "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.4.4",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
         "pretty-format": "^27.0.2"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
+        "aria-query": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+          "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
           "dev": true,
           "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
+            "dequal": "^2.0.3"
           }
         }
       }
@@ -34055,38 +35542,20 @@
       }
     },
     "@testing-library/react": {
-      "version": "12.1.5",
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.12.5",
-        "@testing-library/dom": "^8.0.0",
-        "@types/react-dom": "<18.0.0"
-      }
-    },
-    "@testing-library/react-hooks": {
-      "version": "8.0.1",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.12.5",
-        "react-error-boundary": "^3.1.0"
-      },
-      "dependencies": {
-        "react-error-boundary": {
-          "version": "3.1.4",
-          "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
-          "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.12.5"
-          }
-        }
+        "@babel/runtime": "^7.12.5"
       }
     },
     "@testing-library/user-event": {
       "version": "14.6.1",
       "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
       "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@tootallnate/once": {
       "version": "2.0.0",
@@ -34124,7 +35593,9 @@
       }
     },
     "@types/aria-query": {
-      "version": "4.2.2",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true
     },
     "@types/babel__core": {
@@ -34175,13 +35646,6 @@
       "dev": true,
       "requires": {
         "@types/node": "*"
-      }
-    },
-    "@types/chart.js": {
-      "version": "2.9.37",
-      "dev": true,
-      "requires": {
-        "moment": "^2.10.2"
       }
     },
     "@types/color-string": {
@@ -34459,7 +35923,8 @@
       }
     },
     "@types/is-hotkey": {
-      "version": "0.1.7"
+      "version": "0.1.7",
+      "dev": true
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -34554,7 +36019,9 @@
       "version": "4.14.184"
     },
     "@types/lodash.mergewith": {
-      "version": "4.6.6",
+      "version": "4.6.9",
+      "resolved": "https://registry.npmjs.org/@types/lodash.mergewith/-/lodash.mergewith-4.6.9.tgz",
+      "integrity": "sha512-fgkoCAOF47K7sxrQ7Mlud2TH023itugZs2bUg8h/KzT+BnZNrR2jAOmaokbLunHNnobXVWOezAeNn/lZqwxkcw==",
       "requires": {
         "@types/lodash": "*"
       }
@@ -34634,19 +36101,20 @@
       "dev": true
     },
     "@types/react": {
-      "version": "17.0.48",
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "requires": {
         "@types/prop-types": "*",
-        "@types/scheduler": "*",
-        "csstype": "^3.0.2"
+        "csstype": "^3.2.2"
       }
     },
     "@types/react-dom": {
-      "version": "17.0.17",
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
-      "requires": {
-        "@types/react": "^17"
-      }
+      "requires": {}
     },
     "@types/react-modal": {
       "version": "3.13.1",
@@ -34656,10 +36124,12 @@
       }
     },
     "@types/react-tabs": {
-      "version": "2.3.4",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@types/react-tabs/-/react-tabs-5.0.5.tgz",
+      "integrity": "sha512-3CZTmjR7nNrZnYbnxp/DtK5e82mhM22dN47aYObmYLcp9fC1XjIEF0mLzGKFl1fR6/R8X7DyGh9hO6lON6LVkQ==",
       "dev": true,
       "requires": {
-        "@types/react": "*"
+        "react-tabs": "*"
       }
     },
     "@types/react-transition-group": {
@@ -34675,9 +36145,6 @@
     "@types/rtree": {
       "version": "1.4.28",
       "dev": true
-    },
-    "@types/scheduler": {
-      "version": "0.16.2"
     },
     "@types/seedrandom": {
       "version": "2.4.34",
@@ -34750,9 +36217,6 @@
     "@types/w3c-web-serial": {
       "version": "1.0.2",
       "dev": true
-    },
-    "@types/warning": {
-      "version": "3.0.0"
     },
     "@types/ws": {
       "version": "8.5.3",
@@ -34878,7 +36342,8 @@
       "version": "8.59.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.2.tgz",
       "integrity": "sha512-BKK4alN7oi4C/zv4VqHQ+uRU+lTa6JGIZ7s1juw7b3RHo9OfKB+bKX3u0iVZetdsUCBBkSbdWbarJbmN0fTeSw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@typescript-eslint/type-utils": {
       "version": "8.59.2",
@@ -35024,6 +36489,12 @@
         "@codemirror/view": "^6.0.0"
       }
     },
+    "@uiw/color-convert": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@uiw/color-convert/-/color-convert-2.10.1.tgz",
+      "integrity": "sha512-/Z3YfBiX+SErRM59yQH88Id+Xy/k10nnkfTuqhX6RB2yYUcG57DoFqb6FudhiQ5fwzKvKf1k4xq9lfT1UTFUKQ==",
+      "requires": {}
+    },
     "@uiw/react-codemirror": {
       "version": "4.23.13",
       "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.23.13.tgz",
@@ -35035,6 +36506,23 @@
         "@codemirror/theme-one-dark": "^6.0.0",
         "@uiw/codemirror-extensions-basic-setup": "4.23.13",
         "codemirror": "^6.0.0"
+      }
+    },
+    "@uiw/react-color-circle": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-circle/-/react-color-circle-2.10.1.tgz",
+      "integrity": "sha512-f7/RPnpOGOktmuX1pdPBvXNRoq4irddKG3LU+6vETB7DI0aJiYZH+NXPSrdtNM9j5msdPVH6aGZmfOVJMfbx/g==",
+      "requires": {
+        "@uiw/color-convert": "2.10.1",
+        "@uiw/react-color-swatch": "2.10.1"
+      }
+    },
+    "@uiw/react-color-swatch": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-swatch/-/react-color-swatch-2.10.1.tgz",
+      "integrity": "sha512-DuGlaIszNcvtsY8BfW+RiUkEK1yVmnAamkzc/S5cQZwaAA5bCKhwwyaKPqh1/XWs7pR4pysjSNlMaeqaSOO34A==",
+      "requires": {
+        "@uiw/color-convert": "2.10.1"
       }
     },
     "@ungap/structured-clone": {
@@ -35514,7 +37002,8 @@
     },
     "@webpack-cli/configtest": {
       "version": "1.2.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@webpack-cli/info": {
       "version": "1.5.0",
@@ -35525,7 +37014,8 @@
     },
     "@webpack-cli/serve": {
       "version": "1.7.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -35537,6 +37027,24 @@
     },
     "@yarnpkg/lockfile": {
       "version": "1.1.0"
+    },
+    "@zag-js/dom-query": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-0.31.1.tgz",
+      "integrity": "sha512-oiuohEXAXhBxpzzNm9k2VHGEOLC1SXlXSbRPcfBZ9so5NRQUA++zCE7cyQJqGLTZR0t3itFLlZqDbYEXRrefwg=="
+    },
+    "@zag-js/element-size": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@zag-js/element-size/-/element-size-0.31.1.tgz",
+      "integrity": "sha512-4T3yvn5NqqAjhlP326Fv+w9RqMIBbNN9H72g5q2ohwzhSgSfZzrKtjL4rs9axY/cw9UfMfXjRjEE98e5CMq7WQ=="
+    },
+    "@zag-js/focus-visible": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@zag-js/focus-visible/-/focus-visible-0.31.1.tgz",
+      "integrity": "sha512-dbLksz7FEwyFoANbpIlNnd3bVm0clQSUsnP8yUVQucStZPsuWjCrhL2jlAbGNrTrahX96ntUMXHb/sM68TibFg==",
+      "requires": {
+        "@zag-js/dom-query": "0.31.1"
+      }
     },
     "abort-controller": {
       "version": "3.0.0",
@@ -35561,13 +37069,15 @@
     },
     "acorn-import-assertions": {
       "version": "1.8.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "agent-base": {
       "version": "6.0.2",
@@ -35628,7 +37138,8 @@
     },
     "ajv-keywords": {
       "version": "3.5.2",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ansi-colors": {
       "version": "4.1.1",
@@ -35697,7 +37208,9 @@
       }
     },
     "aria-hidden": {
-      "version": "1.2.3",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
       "requires": {
         "tslib": "^2.0.0"
       }
@@ -36038,14 +37551,11 @@
       "version": "2.9.19",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
       "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
-      "dev": true
+      "devOptional": true
     },
     "batch": {
       "version": "0.6.1",
       "dev": true
-    },
-    "batch-processor": {
-      "version": "1.0.0"
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -36171,7 +37681,7 @@
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
       "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -36240,10 +37750,14 @@
       }
     },
     "call-bind": {
-      "version": "1.0.2",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
       "requires": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
       }
     },
     "call-bind-apply-helpers": {
@@ -36253,6 +37767,15 @@
       "requires": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
+      }
+    },
+    "call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "requires": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
       }
     },
     "callsites": {
@@ -36279,7 +37802,7 @@
       "version": "1.0.30001767",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001767.tgz",
       "integrity": "sha512-34+zUAMhSH+r+9eKmYG+k2Rpt8XttfE4yXAjoZvkAPs15xcYQhyBYdalJ65BzivAvGRMViEjy6oKr/S91loekQ==",
-      "dev": true
+      "devOptional": true
     },
     "caseless": {
       "version": "0.12.0",
@@ -36309,23 +37832,11 @@
       "dev": true
     },
     "chart.js": {
-      "version": "2.9.4",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
+      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
       "requires": {
-        "chartjs-color": "^2.1.0",
-        "moment": "^2.10.2"
-      }
-    },
-    "chartjs-color": {
-      "version": "2.4.1",
-      "requires": {
-        "chartjs-color-string": "^0.6.0",
-        "color-convert": "^1.9.3"
-      }
-    },
-    "chartjs-color-string": {
-      "version": "0.6.0",
-      "requires": {
-        "color-name": "^1.0.0"
+        "@kurkle/color": "^0.3.0"
       }
     },
     "check-more-types": {
@@ -36351,8 +37862,9 @@
       "dev": true
     },
     "ci-info": {
-      "version": "3.2.0",
-      "dev": true
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ=="
     },
     "cjs-module-lexer": {
       "version": "2.2.0",
@@ -36457,6 +37969,7 @@
     },
     "color-convert": {
       "version": "1.9.3",
+      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -36470,6 +37983,11 @@
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
       }
+    },
+    "color2k": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
+      "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog=="
     },
     "colord": {
       "version": "2.9.3",
@@ -36549,9 +38067,9 @@
       }
     },
     "compute-scroll-into-view": {
-      "version": "1.0.20",
-      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.20.tgz",
-      "integrity": "sha512-UCB0ioiyj8CRjtrvaceBLqqhZCVP+1B8+NWQhmdsm0VXOJtobBCf1dBQmebCCo34qZmUwZfIH2MZLqNHazrfjg=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
+      "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw=="
     },
     "concat-map": {
       "version": "0.0.1"
@@ -36602,7 +38120,9 @@
       "version": "2.1.4"
     },
     "copy-to-clipboard": {
-      "version": "3.3.1",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
+      "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
       "requires": {
         "toggle-selection": "^1.0.6"
       }
@@ -36769,7 +38289,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "requires": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -36778,6 +38297,8 @@
     },
     "css-box-model": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz",
+      "integrity": "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==",
       "requires": {
         "tiny-invariant": "^1.0.6"
       }
@@ -36883,7 +38404,9 @@
       }
     },
     "csstype": {
-      "version": "3.0.9"
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
     },
     "cypress": {
       "version": "13.5.0",
@@ -37021,13 +38544,15 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/cypress-file-upload/-/cypress-file-upload-5.0.8.tgz",
       "integrity": "sha512-+8VzNabRk3zG6x8f8BWArF/xA/W0VK4IZNx3MV0jFWrJS/qKn8eHfa5nU73P9fOQAgwHFJx7zjg4lwOnljMO8g==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "cypress-real-events": {
       "version": "1.14.0",
       "resolved": "https://registry.npmjs.org/cypress-real-events/-/cypress-real-events-1.14.0.tgz",
       "integrity": "sha512-XmI8y3OZLh6cjRroPalzzS++iv+pGCaD9G9kfIbtspgv7GVsDt30dkZvSXfgZb4rAN+3pOkMVB7e0j4oXydW7Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "cypress-terminal-report": {
       "version": "4.1.2",
@@ -37381,7 +38906,8 @@
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.1.tgz",
       "integrity": "sha512-9JmrhGZpOlEgOLdQgSm0zxFaYoQon408V1v49aqTWuXENVlnCuY9JBZcXZiCsZQWDjTm5Qf/nIvAy77mXDAjEg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "deep-equal": {
       "version": "2.2.2",
@@ -37469,14 +38995,13 @@
       }
     },
     "define-data-property": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
-      "integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
-      "dev": true,
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
       "requires": {
-        "get-intrinsic": "^1.2.1",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.0"
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
       }
     },
     "define-lazy-prop": {
@@ -37507,6 +39032,12 @@
       "version": "1.1.2",
       "dev": true
     },
+    "dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true
+    },
     "destroy": {
       "version": "1.2.0",
       "dev": true
@@ -37521,7 +39052,9 @@
       "version": "2.1.0"
     },
     "detect-node-es": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
     },
     "dezalgo": {
       "version": "1.0.3",
@@ -37722,13 +39255,7 @@
       "version": "1.5.286",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
       "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
-      "dev": true
-    },
-    "element-resize-detector": {
-      "version": "1.2.3",
-      "requires": {
-        "batch-processor": "1.0.0"
-      }
+      "devOptional": true
     },
     "emittery": {
       "version": "0.13.1",
@@ -37907,6 +39434,11 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "es-toolkit": {
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
+      "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ=="
     },
     "es6-error": {
       "version": "4.1.1",
@@ -38107,7 +39639,8 @@
     },
     "eslint-plugin-chai-friendly": {
       "version": "0.7.2",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-cypress": {
       "version": "2.12.1",
@@ -38224,13 +39757,15 @@
     },
     "eslint-plugin-react-hooks": {
       "version": "4.6.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-unused-imports": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-4.4.1.tgz",
       "integrity": "sha512-oZGYUz1X3sRMGUB+0cZyK2VcvRX5lm/vB56PgNNcU+7ficUCKm66oZWKUubXWnOuPjQ8PvmXtCViXBMONPe7tQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-scope": {
       "version": "5.1.1",
@@ -38784,7 +40319,9 @@
       "dev": true
     },
     "focus-lock": {
-      "version": "0.9.2",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-1.3.6.tgz",
+      "integrity": "sha512-Ik/6OCk9RQQ0T5Xw+hKNLWrjSMtv51dD4GRmJjbD5a58TIEpI5a5iXagKVl3Z5UuyslMCA8Xwnu76jQob62Yhg==",
       "requires": {
         "tslib": "^2.0.3"
       }
@@ -38861,40 +40398,28 @@
       "integrity": "sha512-pwiTgt0Q7t+GHZA4yaLjObx4vXmmdcS0iSJ19o8d/goUGgItX9UZWKWNnLHehxviD8wU2IWRsnR8cD5+yOJP2Q=="
     },
     "framer-motion": {
-      "version": "6.5.1",
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
+      "integrity": "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==",
       "requires": {
-        "@emotion/is-prop-valid": "^0.8.2",
-        "@motionone/dom": "10.12.0",
-        "framesync": "6.0.1",
-        "hey-listen": "^1.0.8",
-        "popmotion": "11.0.3",
-        "style-value-types": "5.0.0",
-        "tslib": "^2.1.0"
-      },
-      "dependencies": {
-        "@emotion/is-prop-valid": {
-          "version": "0.8.8",
-          "optional": true,
-          "requires": {
-            "@emotion/memoize": "0.7.4"
-          }
-        },
-        "@emotion/memoize": {
-          "version": "0.7.4",
-          "optional": true
-        },
-        "framesync": {
-          "version": "6.0.1",
-          "requires": {
-            "tslib": "^2.1.0"
-          }
-        }
+        "motion-dom": "^12.38.0",
+        "motion-utils": "^12.36.0",
+        "tslib": "^2.4.0"
       }
     },
     "framesync": {
-      "version": "5.3.0",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/framesync/-/framesync-6.1.2.tgz",
+      "integrity": "sha512-jBTqhX6KaQVDyus8muwZbBeGGP0XgujBRbQ7gM7BRdS3CadCZIHiawyzYLnafYcvZIh5j8WE7cxZKFn7dXhu9g==",
       "requires": {
-        "tslib": "^2.1.0"
+        "tslib": "2.4.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        }
       }
     },
     "fresh": {
@@ -39005,7 +40530,7 @@
     },
     "gensync": {
       "version": "1.0.0-beta.2",
-      "dev": true
+      "devOptional": true
     },
     "get-caller-file": {
       "version": "2.0.5"
@@ -39028,7 +40553,9 @@
       }
     },
     "get-nonce": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="
     },
     "get-package-type": {
       "version": "0.1.0",
@@ -39439,10 +40966,11 @@
       "dev": true
     },
     "has-property-descriptors": {
-      "version": "1.0.0",
-      "dev": true,
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "requires": {
-        "get-intrinsic": "^1.1.1"
+        "es-define-property": "^1.0.0"
       }
     },
     "has-proto": {
@@ -39484,9 +41012,6 @@
     },
     "hexoid": {
       "version": "1.0.0"
-    },
-    "hey-listen": {
-      "version": "1.0.8"
     },
     "hoist-non-react-statics": {
       "version": "3.3.2",
@@ -39672,7 +41197,8 @@
     },
     "icss-utils": {
       "version": "5.1.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "idb": {
       "version": "3.0.2"
@@ -39753,9 +41279,9 @@
       "version": "3.1.2"
     },
     "inline-style-parser": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.4.tgz",
-      "integrity": "sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q=="
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="
     },
     "internal-slot": {
       "version": "1.0.5",
@@ -39772,12 +41298,6 @@
     "interpret": {
       "version": "2.2.0",
       "dev": true
-    },
-    "invariant": {
-      "version": "2.2.4",
-      "requires": {
-        "loose-envify": "^1.0.0"
-      }
     },
     "ipaddr.js": {
       "version": "1.9.1",
@@ -41304,7 +42824,8 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "28.0.2",
@@ -42324,6 +43845,25 @@
       "version": "0.4.1",
       "dev": true
     },
+    "json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "requires": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+        }
+      }
+    },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "dev": true
@@ -42338,7 +43878,7 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true
+      "devOptional": true
     },
     "json5-loader": {
       "version": "4.0.1",
@@ -42374,6 +43914,11 @@
         "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       }
+    },
+    "jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg=="
     },
     "jsonwebtoken": {
       "version": "8.5.1",
@@ -42653,11 +44198,6 @@
     "lodash": {
       "version": "4.17.21"
     },
-    "lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
-    },
     "lodash.camelcase": {
       "version": "4.3.0"
     },
@@ -42701,7 +44241,9 @@
       "dev": true
     },
     "lodash.mergewith": {
-      "version": "4.6.2"
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
     },
     "lodash.once": {
       "version": "4.1.1",
@@ -42884,7 +44426,8 @@
     "markdown-to-jsx": {
       "version": "7.7.13",
       "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.7.13.tgz",
-      "integrity": "sha512-DiueEq2bttFcSxUs85GJcQVrOr0+VVsPfj9AEUPqmExJ3f8P/iQNvZHltV4tm1XVhu1kl0vWBZWT3l99izRMaA=="
+      "integrity": "sha512-DiueEq2bttFcSxUs85GJcQVrOr0+VVsPfj9AEUPqmExJ3f8P/iQNvZHltV4tm1XVhu1kl0vWBZWT3l99izRMaA==",
+      "requires": {}
     },
     "match-sorter": {
       "version": "6.3.1",
@@ -42892,11 +44435,6 @@
         "@babel/runtime": "^7.12.5",
         "remove-accents": "0.4.2"
       }
-    },
-    "material-colors": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz",
-      "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "math-expression-evaluator": {
       "version": "1.4.0",
@@ -43099,15 +44637,14 @@
       }
     },
     "mobx-react-lite": {
-      "version": "3.4.0"
+      "version": "3.4.0",
+      "requires": {}
     },
     "mobx-state-tree": {
       "version": "npm:@concord-consortium/mobx-state-tree@6.0.0-cc.1",
       "resolved": "https://registry.npmjs.org/@concord-consortium/mobx-state-tree/-/mobx-state-tree-6.0.0-cc.1.tgz",
-      "integrity": "sha512-dfzSe4ba2dNreouI3YXsUv1tmNlyx2Lj3oa5QoEi2WQazMgCqQY/mCMM87z1HfflYlCnLFoDu8KP2XTp3ljTvg=="
-    },
-    "moment": {
-      "version": "2.29.4"
+      "integrity": "sha512-dfzSe4ba2dNreouI3YXsUv1tmNlyx2Lj3oa5QoEi2WQazMgCqQY/mCMM87z1HfflYlCnLFoDu8KP2XTp3ljTvg==",
+      "requires": {}
     },
     "moo-color": {
       "version": "1.0.3",
@@ -43125,6 +44662,19 @@
           "dev": true
         }
       }
+    },
+    "motion-dom": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
+      "integrity": "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==",
+      "requires": {
+        "motion-utils": "^12.36.0"
+      }
+    },
+    "motion-utils": {
+      "version": "12.36.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
+      "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg=="
     },
     "ms": {
       "version": "2.1.2"
@@ -43231,7 +44781,7 @@
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
-      "dev": true
+      "devOptional": true
     },
     "normalize-path": {
       "version": "3.0.0",
@@ -43398,8 +44948,7 @@
       }
     },
     "object-keys": {
-      "version": "1.1.1",
-      "dev": true
+      "version": "1.1.1"
     },
     "object.assign": {
       "version": "4.1.4",
@@ -43506,7 +45055,9 @@
       "integrity": "sha512-kLTDsr/xqecOJe3cRNz0R/N3mrgWCBbShnA+4C30lXVl5DPhIVU+W8XQFRJ2U9nPbTm6ay7e+oh/gYN/NNo60A=="
     },
     "os-tmpdir": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g=="
     },
     "ospath": {
       "version": "1.2.2",
@@ -43625,24 +45176,24 @@
       }
     },
     "patch-package": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-6.5.1.tgz",
-      "integrity": "sha512-I/4Zsalfhc6bphmJTlrLoOcAF87jcxko4q0qsv4bGcurbr8IskEOtdnt9iCmsQVGL1B+iUhSQqweyTLJfCF9rA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
+      "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
       "requires": {
         "@yarnpkg/lockfile": "^1.1.0",
         "chalk": "^4.1.2",
-        "cross-spawn": "^6.0.5",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
         "find-yarn-workspace-root": "^2.0.0",
-        "fs-extra": "^9.0.0",
-        "is-ci": "^2.0.0",
+        "fs-extra": "^10.0.0",
+        "json-stable-stringify": "^1.0.2",
         "klaw-sync": "^6.0.0",
         "minimist": "^1.2.6",
         "open": "^7.4.2",
-        "rimraf": "^2.6.3",
-        "semver": "^5.6.0",
+        "semver": "^7.5.3",
         "slash": "^2.0.0",
-        "tmp": "^0.0.33",
-        "yaml": "^1.10.2"
+        "tmp": "^0.2.4",
+        "yaml": "^2.2.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -43662,9 +45213,6 @@
             "supports-color": "^7.1.0"
           }
         },
-        "ci-info": {
-          "version": "2.0.0"
-        },
         "color-convert": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -43678,26 +45226,20 @@
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
-        "cross-spawn": {
-          "version": "6.0.5",
+        "fs-extra": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+          "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
           "requires": {
-            "nice-try": "^1.0.4",
-            "path-key": "^2.0.1",
-            "semver": "^5.5.0",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
           }
         },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-        },
-        "is-ci": {
-          "version": "2.0.0",
-          "requires": {
-            "ci-info": "^2.0.0"
-          }
         },
         "open": {
           "version": "7.4.2",
@@ -43706,23 +45248,10 @@
             "is-wsl": "^2.1.1"
           }
         },
-        "path-key": {
-          "version": "2.0.1"
-        },
-        "rimraf": {
-          "version": "2.7.1",
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "shebang-command": {
-          "version": "1.2.0",
-          "requires": {
-            "shebang-regex": "^1.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "1.0.0"
+        "semver": {
+          "version": "7.8.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+          "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="
         },
         "slash": {
           "version": "2.0.0"
@@ -43736,16 +45265,14 @@
           }
         },
         "tmp": {
-          "version": "0.0.33",
-          "requires": {
-            "os-tmpdir": "~1.0.2"
-          }
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+          "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow=="
         },
-        "which": {
-          "version": "1.3.1",
-          "requires": {
-            "isexe": "^2.0.0"
-          }
+        "yaml": {
+          "version": "2.8.4",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+          "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog=="
         }
       }
     },
@@ -43757,8 +45284,7 @@
       "version": "1.0.1"
     },
     "path-key": {
-      "version": "3.1.1",
-      "dev": true
+      "version": "3.1.1"
     },
     "path-parse": {
       "version": "1.0.7"
@@ -43832,23 +45358,6 @@
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
       "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="
     },
-    "popmotion": {
-      "version": "11.0.3",
-      "requires": {
-        "framesync": "6.0.1",
-        "hey-listen": "^1.0.8",
-        "style-value-types": "5.0.0",
-        "tslib": "^2.1.0"
-      },
-      "dependencies": {
-        "framesync": {
-          "version": "6.0.1",
-          "requires": {
-            "tslib": "^2.1.0"
-          }
-        }
-      }
-    },
     "popper.js": {
       "version": "1.16.1"
     },
@@ -43870,7 +45379,8 @@
     "popsicle-content-encoding": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/popsicle-content-encoding/-/popsicle-content-encoding-1.0.0.tgz",
-      "integrity": "sha512-4Df+vTfM8wCCJVTzPujiI6eOl3SiWQkcZg0AMrOkD1enMXsF3glIkFUZGvour1Sj7jOWCsNSEhBxpbbhclHhzw=="
+      "integrity": "sha512-4Df+vTfM8wCCJVTzPujiI6eOl3SiWQkcZg0AMrOkD1enMXsF3glIkFUZGvour1Sj7jOWCsNSEhBxpbbhclHhzw==",
+      "requires": {}
     },
     "popsicle-cookie-jar": {
       "version": "1.0.1",
@@ -43884,7 +45394,8 @@
     "popsicle-redirects": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/popsicle-redirects/-/popsicle-redirects-1.1.1.tgz",
-      "integrity": "sha512-mC2HrKjdTAWDalOjGxlXw9j6Qxrz/Yd2ui6bPxpi2IQDYWpF4gUAMxbA8EpSWJhLi0PuWKDwTHHPrUPGutAoIA=="
+      "integrity": "sha512-mC2HrKjdTAWDalOjGxlXw9j6Qxrz/Yd2ui6bPxpi2IQDYWpF4gUAMxbA8EpSWJhLi0PuWKDwTHHPrUPGutAoIA==",
+      "requires": {}
     },
     "popsicle-transport-http": {
       "version": "1.2.1",
@@ -43897,12 +45408,14 @@
     "popsicle-transport-xhr": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/popsicle-transport-xhr/-/popsicle-transport-xhr-2.0.0.tgz",
-      "integrity": "sha512-5Sbud4Widngf1dodJE5cjEYXkzEUIl8CzyYRYR57t6vpy9a9KPGQX6KBKdPjmBZlR5A06pOBXuJnVr23l27rtA=="
+      "integrity": "sha512-5Sbud4Widngf1dodJE5cjEYXkzEUIl8CzyYRYR57t6vpy9a9KPGQX6KBKdPjmBZlR5A06pOBXuJnVr23l27rtA==",
+      "requires": {}
     },
     "popsicle-user-agent": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/popsicle-user-agent/-/popsicle-user-agent-1.0.0.tgz",
-      "integrity": "sha512-epKaq3TTfTzXcxBxjpoKYMcTTcAX8Rykus6QZu77XNhJuRHSRxMd+JJrbX/3PFI0opFGSN0BabbAYCbGxbu0mA=="
+      "integrity": "sha512-epKaq3TTfTzXcxBxjpoKYMcTTcAX8Rykus6QZu77XNhJuRHSRxMd+JJrbX/3PFI0opFGSN0BabbAYCbGxbu0mA==",
+      "requires": {}
     },
     "postcss": {
       "version": "8.4.31",
@@ -43936,7 +45449,8 @@
     },
     "postcss-modules-extract-imports": {
       "version": "3.0.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -44225,51 +45739,49 @@
       }
     },
     "react": {
-      "version": "17.0.2",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "react-chartjs-2": {
-      "version": "2.11.2",
-      "requires": {
-        "lodash": "^4.17.19",
-        "prop-types": "^15.7.2"
-      }
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.1.tgz",
+      "integrity": "sha512-h5IPXKg9EXpjoBzUfyWJvllMjG2mQ4EiuHQFhms/AjUm0XSZHhyRy2xVmLXHKrtcdrPO4mnGqRtYoD0vp95A0A==",
+      "requires": {}
     },
     "react-clientside-effect": {
-      "version": "1.2.6",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.8.tgz",
+      "integrity": "sha512-ma2FePH0z3px2+WOu6h+YycZcEvFmmxIlAb62cF52bG86eMySciO/EQZeQMXd07kPCYB0a1dWDT5J+KE9mCDUw==",
       "requires": {
         "@babel/runtime": "^7.12.13"
       }
     },
-    "react-color": {
-      "version": "2.19.3",
-      "resolved": "https://registry.npmjs.org/react-color/-/react-color-2.19.3.tgz",
-      "integrity": "sha512-LEeGE/ZzNLIsFWa1TMe8y5VYqr7bibneWmvJwm1pCn/eNmrabWDh659JSPn9BuaMpEfU83WTOJfnCcjDZwNQTA==",
-      "requires": {
-        "@icons/material": "^0.2.4",
-        "lodash": "^4.17.15",
-        "lodash-es": "^4.17.15",
-        "material-colors": "^1.2.1",
-        "prop-types": "^15.5.10",
-        "reactcss": "^1.2.0",
-        "tinycolor2": "^1.4.1"
-      }
-    },
     "react-data-grid": {
-      "version": "7.0.0-canary.46",
+      "version": "7.0.0-beta.44",
+      "resolved": "https://registry.npmjs.org/react-data-grid/-/react-data-grid-7.0.0-beta.44.tgz",
+      "integrity": "sha512-VTql8VPBJEf7E+zkrqYW+jaQT1/m47dxigWzPq59QESJ8LhU59kHyzIx06BUpjdZKdK/tzbWaw2yyJpKoNnt5g==",
       "requires": {
-        "clsx": "^1.1.1"
+        "clsx": "^2.0.0"
+      },
+      "dependencies": {
+        "clsx": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+          "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="
+        }
       }
     },
     "react-dom": {
-      "version": "17.0.2",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "requires": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "scheduler": "^0.20.2"
+        "scheduler": "^0.23.2"
       }
     },
     "react-dom-factories": {
@@ -44284,23 +45796,28 @@
       }
     },
     "react-fast-compare": {
-      "version": "3.2.0"
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
     },
     "react-focus-lock": {
-      "version": "2.5.2",
+      "version": "2.13.7",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.13.7.tgz",
+      "integrity": "sha512-20lpZHEQrXPb+pp1tzd4ULL6DyO5D2KnR0G69tTDdydrmNhU7pdFmbQUYVyHUgp+xN29IuFR0PVuhOmvaZL9Og==",
       "requires": {
         "@babel/runtime": "^7.0.0",
-        "focus-lock": "^0.9.1",
+        "focus-lock": "^1.3.6",
         "prop-types": "^15.6.2",
-        "react-clientside-effect": "^1.2.5",
-        "use-callback-ref": "^1.2.5",
-        "use-sidecar": "^1.0.5"
+        "react-clientside-effect": "^1.2.7",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
       }
     },
     "react-hook-form": {
       "version": "7.63.0",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.63.0.tgz",
-      "integrity": "sha512-ZwueDMvUeucovM2VjkCf7zIHcs1aAlDimZu2Hvel5C5907gUzMpm4xCrQXtRzCvsBqFjonB4m3x4LzCFI1ZKWA=="
+      "integrity": "sha512-ZwueDMvUeucovM2VjkCf7zIHcs1aAlDimZu2Hvel5C5907gUzMpm4xCrQXtRzCvsBqFjonB4m3x4LzCFI1ZKWA==",
+      "requires": {}
     },
     "react-is": {
       "version": "16.13.1"
@@ -44326,37 +45843,38 @@
       }
     },
     "react-remove-scroll": {
-      "version": "2.4.1",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
       "requires": {
-        "react-remove-scroll-bar": "^2.1.0",
-        "react-style-singleton": "^2.1.0",
-        "tslib": "^1.0.0",
-        "use-callback-ref": "^1.2.3",
-        "use-sidecar": "^1.0.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1"
-        }
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
       }
     },
     "react-remove-scroll-bar": {
-      "version": "2.3.4",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
       "requires": {
-        "react-style-singleton": "^2.2.1",
+        "react-style-singleton": "^2.2.2",
         "tslib": "^2.0.0"
       }
     },
     "react-resize-detector": {
-      "version": "8.1.0",
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-12.3.0.tgz",
+      "integrity": "sha512-mIDOVrTHKGnKe6qEUWi8dFdfHM5CPyTOpqoHctdMQf89Ljm/0qqDIzkP3vTRZZJi9/raaMiRxDEOqO4you5x+A==",
       "requires": {
-        "lodash": "^4.17.21"
+        "es-toolkit": "^1.39.6"
       }
     },
     "react-select": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.10.1.tgz",
-      "integrity": "sha512-roPEZUL4aRZDx6DcsD+ZNreVl+fM8VsKn0Wtex1v4IazH60ILp5xhdlp464IsEAlJdXeD+BhDAFsBVMfvLQueA==",
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.10.2.tgz",
+      "integrity": "sha512-Z33nHdEFWq9tfnfVXaiM12rbJmk+QjFEztWLtmXqQhz6Al4UZZ9xc0wiatmGtUOCCnHN0WizL3tCMYRENX4rVQ==",
       "requires": {
         "@babel/runtime": "^7.12.0",
         "@emotion/cache": "^11.4.0",
@@ -44369,28 +45887,29 @@
         "use-isomorphic-layout-effect": "^1.2.0"
       }
     },
-    "react-sizeme": {
-      "version": "3.0.2",
-      "requires": {
-        "element-resize-detector": "^1.2.2",
-        "invariant": "^2.2.4",
-        "shallowequal": "^1.1.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
     "react-style-singleton": {
-      "version": "2.2.1",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
       "requires": {
         "get-nonce": "^1.0.0",
-        "invariant": "^2.2.4",
         "tslib": "^2.0.0"
       }
     },
     "react-tabs": {
-      "version": "3.2.3",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/react-tabs/-/react-tabs-6.1.1.tgz",
+      "integrity": "sha512-CPiuKoMFf89B7QlbFfdBD9XmUWiE3qudQputMVZB8GQvPJZRX/gqjDaDWOPDwGinEfpJKEuBCkGt83Tt4efeyA==",
       "requires": {
-        "clsx": "^1.1.0",
+        "clsx": "^2.0.0",
         "prop-types": "^15.5.0"
+      },
+      "dependencies": {
+        "clsx": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+          "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="
+        }
       }
     },
     "react-textarea-autosize": {
@@ -44416,14 +45935,6 @@
         "dom-helpers": "^5.0.1",
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2"
-      }
-    },
-    "reactcss": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/reactcss/-/reactcss-1.2.3.tgz",
-      "integrity": "sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==",
-      "requires": {
-        "lodash": "^4.0.1"
       }
     },
     "reactflow": {
@@ -44708,7 +46219,8 @@
     "rete-structures": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/rete-structures/-/rete-structures-2.0.1.tgz",
-      "integrity": "sha512-8S7zkoHLnDOz7T9L4qfwp6efdp790wk3sZBF2qsHLtHJIyAxC8lDNNngy7R2Eh762nadgfcn/ItHpLPmpXQGeQ=="
+      "integrity": "sha512-8S7zkoHLnDOz7T9L4qfwp6efdp790wk3sZBF2qsHLtHJIyAxC8lDNNngy7R2Eh762nadgfcn/ItHpLPmpXQGeQ==",
+      "requires": {}
     },
     "retry": {
       "version": "0.13.1",
@@ -44849,10 +46361,11 @@
       }
     },
     "scheduler": {
-      "version": "0.20.2",
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "schema-utils": {
@@ -44872,11 +46385,11 @@
       }
     },
     "scroll-into-view-if-needed": {
-      "version": "2.2.31",
-      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-2.2.31.tgz",
-      "integrity": "sha512-dGCXy99wZQivjmjIqihaBQNjryrz5rueJY7eHfTdyWEiR4ttYpsajb14rn9s5d4DY4EcY6+4+U/maARBXJedkA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-3.1.0.tgz",
+      "integrity": "sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==",
       "requires": {
-        "compute-scroll-into-view": "^1.0.20"
+        "compute-scroll-into-view": "^3.0.2"
       }
     },
     "seedrandom": {
@@ -45048,6 +46561,19 @@
       "version": "2.0.0",
       "dev": true
     },
+    "set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "requires": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      }
+    },
     "set-function-name": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.1.tgz",
@@ -45073,14 +46599,12 @@
     },
     "shebang-command": {
       "version": "2.0.0",
-      "dev": true,
       "requires": {
         "shebang-regex": "^3.0.0"
       }
     },
     "shebang-regex": {
-      "version": "3.0.0",
-      "dev": true
+      "version": "3.0.0"
     },
     "shell-quote": {
       "version": "1.7.3",
@@ -45120,27 +46644,19 @@
       "dev": true
     },
     "slate": {
-      "version": "0.103.0",
-      "resolved": "https://registry.npmjs.org/slate/-/slate-0.103.0.tgz",
-      "integrity": "sha512-eCUOVqUpADYMZ59O37QQvUdnFG+8rin0OGQAXNHvHbQeVJ67Bu0spQbcy621vtf8GQUXTEQBlk6OP9atwwob4w==",
+      "version": "0.118.1",
+      "resolved": "https://registry.npmjs.org/slate/-/slate-0.118.1.tgz",
+      "integrity": "sha512-6H1DNgnSwAFhq/pIgf+tLvjNzH912M5XrKKhP9Frmbds2zFXdSJ6L/uFNyVKxQIkPzGWPD0m+wdDfmEuGFH5Tg==",
       "requires": {
         "immer": "^10.0.3",
-        "is-plain-object": "^5.0.0",
         "tiny-warning": "^1.0.3"
-      },
-      "dependencies": {
-        "is-plain-object": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-          "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
-        }
       }
     },
     "slate-dom": {
       "version": "0.117.4",
       "resolved": "https://registry.npmjs.org/slate-dom/-/slate-dom-0.117.4.tgz",
       "integrity": "sha512-eu5MMpphkCnr22R6hgFoQt/tEaHBjSdSy7uJjPOm++hCxstoLefp04EY50A4rXBovjkYoAncb9j8QoijZd0ENA==",
-      "dev": true,
+      "peer": true,
       "requires": {
         "@juggle/resize-observer": "^3.4.0",
         "direction": "^1.0.4",
@@ -45155,14 +46671,14 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
           "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-          "dev": true
+          "peer": true
         }
       }
     },
     "slate-history": {
-      "version": "0.100.0",
-      "resolved": "https://registry.npmjs.org/slate-history/-/slate-history-0.100.0.tgz",
-      "integrity": "sha512-x5rUuWLNtH97hs9PrFovGgt3Qc5zkTm/5mcUB+0NR/TK923eLax4HsL6xACLHMs245nI6aJElyM1y6hN0y5W/Q==",
+      "version": "0.113.1",
+      "resolved": "https://registry.npmjs.org/slate-history/-/slate-history-0.113.1.tgz",
+      "integrity": "sha512-J9NSJ+UG2GxoW0lw5mloaKcN0JI0x2IA5M5FxyGiInpn+QEutxT1WK7S/JneZCMFJBoHs1uu7S7e6pxQjubHmQ==",
       "requires": {
         "is-plain-object": "^5.0.0"
       },
@@ -45190,31 +46706,16 @@
       }
     },
     "slate-react": {
-      "version": "0.98.4",
-      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.98.4.tgz",
-      "integrity": "sha512-8Of3v9hFuX8rIRc86LuuBhU9t8ps+9ARKL4yyhCrKQYZ93Ep/LFA3GvPGvtf3zYuVadZ8tkhRH8tbHOGNAndLw==",
+      "version": "0.117.4",
+      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.117.4.tgz",
+      "integrity": "sha512-9ckilyUzQS1VHJnstIpgInhcWnTDgv2Cd7m1HOQVl3zasChoapPSMftzT/wl/48grZaZYZIi4xVuzGTcFRUWFg==",
       "requires": {
         "@juggle/resize-observer": "^3.4.0",
-        "@types/is-hotkey": "^0.1.1",
-        "@types/lodash": "^4.14.149",
-        "direction": "^1.0.3",
-        "is-hotkey": "^0.1.6",
-        "is-plain-object": "^5.0.0",
-        "lodash": "^4.17.4",
-        "scroll-into-view-if-needed": "^2.2.20",
-        "tiny-invariant": "1.0.6"
-      },
-      "dependencies": {
-        "is-hotkey": {
-          "version": "0.1.8",
-          "resolved": "https://registry.npmjs.org/is-hotkey/-/is-hotkey-0.1.8.tgz",
-          "integrity": "sha512-qs3NZ1INIS+H+yeo7cD9pDfwYV/jqRh1JG9S9zYrNudkoUQg7OL7ziXqRKu+InFjUIDoP2o6HIkLYMh1pcWgyQ=="
-        },
-        "is-plain-object": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-          "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
-        }
+        "direction": "^1.0.4",
+        "is-hotkey": "^0.2.0",
+        "lodash": "^4.17.21",
+        "scroll-into-view-if-needed": "^3.1.0",
+        "tiny-invariant": "1.3.1"
       }
     },
     "slice-ansi": {
@@ -45582,7 +47083,8 @@
     },
     "style-loader": {
       "version": "3.3.1",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "style-mod": {
       "version": "4.1.2",
@@ -45590,18 +47092,11 @@
       "integrity": "sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw=="
     },
     "style-to-object": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.8.tgz",
-      "integrity": "sha512-xT47I/Eo0rwJmaXC4oilDGDWLohVhR6o/xAQcPQN8q6QBuZVL8qMYL85kLmST5cPjAorwvqIA4qXTRQoYHaL6g==",
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
       "requires": {
-        "inline-style-parser": "0.2.4"
-      }
-    },
-    "style-value-types": {
-      "version": "5.0.0",
-      "requires": {
-        "hey-listen": "^1.0.8",
-        "tslib": "^2.1.0"
+        "inline-style-parser": "0.2.7"
       }
     },
     "styled-components": {
@@ -45886,9 +47381,6 @@
       "version": "0.2.0",
       "dev": true
     },
-    "throttle-debounce": {
-      "version": "3.0.1"
-    },
     "throttleit": {
       "version": "1.0.0",
       "dev": true
@@ -45910,17 +47402,14 @@
       "version": "2.1.0"
     },
     "tiny-invariant": {
-      "version": "1.0.6"
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
+      "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw=="
     },
     "tiny-warning": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
-    },
-    "tinycolor2": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
-      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="
     },
     "tinyglobby": {
       "version": "0.2.16",
@@ -45936,7 +47425,8 @@
           "version": "6.5.0",
           "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
           "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "picomatch": {
           "version": "4.0.4",
@@ -45981,7 +47471,9 @@
       }
     },
     "toggle-selection": {
-      "version": "1.0.6"
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ=="
     },
     "toidentifier": {
       "version": "1.0.1",
@@ -46022,7 +47514,8 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
       "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ts-expect": {
       "version": "1.3.0",
@@ -47375,7 +48868,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "escalade": "^3.2.0",
         "picocolors": "^1.1.1"
@@ -47421,7 +48914,9 @@
       "dev": true
     },
     "use-callback-ref": {
-      "version": "1.3.0",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
       "requires": {
         "tslib": "^2.0.0"
       }
@@ -47429,17 +48924,20 @@
     "use-composed-ref": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.3.0.tgz",
-      "integrity": "sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ=="
+      "integrity": "sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ==",
+      "requires": {}
     },
     "use-immer": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/use-immer/-/use-immer-0.11.0.tgz",
-      "integrity": "sha512-RNAqi3GqsWJ4bcCd4LMBgdzvPmTABam24DUaFiKfX9s3MSorNRz9RDZYJkllJoMHUxVLMDetwAuCDeyWNrp1yA=="
+      "integrity": "sha512-RNAqi3GqsWJ4bcCd4LMBgdzvPmTABam24DUaFiKfX9s3MSorNRz9RDZYJkllJoMHUxVLMDetwAuCDeyWNrp1yA==",
+      "requires": {}
     },
     "use-isomorphic-layout-effect": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.0.tgz",
-      "integrity": "sha512-q6ayo8DWoPZT0VdG4u3D3uxcgONP3Mevx2i2b0434cwWBoL+aelL1DzkXI6w3PhTZzUeR2kaVlZn70iCiseP6w=="
+      "integrity": "sha512-q6ayo8DWoPZT0VdG4u3D3uxcgONP3Mevx2i2b0434cwWBoL+aelL1DzkXI6w3PhTZzUeR2kaVlZn70iCiseP6w==",
+      "requires": {}
     },
     "use-latest": {
       "version": "1.2.1",
@@ -47450,7 +48948,8 @@
       }
     },
     "use-memo-one": {
-      "version": "1.1.3"
+      "version": "1.1.3",
+      "requires": {}
     },
     "use-resize-observer": {
       "version": "9.0.2",
@@ -47459,14 +48958,17 @@
       }
     },
     "use-sidecar": {
-      "version": "1.1.2",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
       "requires": {
         "detect-node-es": "^1.1.0",
         "tslib": "^2.0.0"
       }
     },
     "use-sync-external-store": {
-      "version": "1.2.0"
+      "version": "1.2.0",
+      "requires": {}
     },
     "usehooks-ts": {
       "version": "2.16.0",
@@ -47917,7 +49419,6 @@
     },
     "which": {
       "version": "2.0.2",
-      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }
@@ -48059,7 +49560,8 @@
       "version": "8.19.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "xhr-mock": {
       "version": "2.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@concord-consortium/mobx-state-tree": "^6.0.0-cc.1",
         "@concord-consortium/react-components": "^1.0.0",
         "@concord-consortium/react-modal-hook": "^3.0.0-cc.1",
-        "@concord-consortium/slate-editor": "^0.12.0",
+        "@concord-consortium/slate-editor": "0.13.0-pre.0",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",
         "@dnd-kit/sortable": "^10.0.0",
@@ -4197,9 +4197,9 @@
       }
     },
     "node_modules/@concord-consortium/slate-editor": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/slate-editor/-/slate-editor-0.12.0.tgz",
-      "integrity": "sha512-NhYGV+3IMuIIoW23p/z4Fwdlw2P+Mt7LfbrIO88sGsChIJ1MZ/3yR2LSZrA9Asw1SthgNpRtJCsS0U/nHDNyiA==",
+      "version": "0.13.0-pre.0",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/slate-editor/-/slate-editor-0.13.0-pre.0.tgz",
+      "integrity": "sha512-4AXREm0Yq2QrELOsqie8b61mUrDUAkycW9Vo4hE9DNt/fqkXH6y1CTfy7LQJYf1NOLHV+MH95+RZuFL5LdBNVA==",
       "license": "MIT",
       "dependencies": {
         "@emotion/css": "^11.13.5",
@@ -32467,9 +32467,9 @@
       "requires": {}
     },
     "@concord-consortium/slate-editor": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/slate-editor/-/slate-editor-0.12.0.tgz",
-      "integrity": "sha512-NhYGV+3IMuIIoW23p/z4Fwdlw2P+Mt7LfbrIO88sGsChIJ1MZ/3yR2LSZrA9Asw1SthgNpRtJCsS0U/nHDNyiA==",
+      "version": "0.13.0-pre.0",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/slate-editor/-/slate-editor-0.13.0-pre.0.tgz",
+      "integrity": "sha512-4AXREm0Yq2QrELOsqie8b61mUrDUAkycW9Vo4hE9DNt/fqkXH6y1CTfy7LQJYf1NOLHV+MH95+RZuFL5LdBNVA==",
       "requires": {
         "@emotion/css": "^11.13.5",
         "classnames": "^2.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@visx/scale": "3.5.0",
         "@visx/shape": "3.5.0",
         "@visx/text": "3.3.0",
-        "chart.js": "^4.5.1",
+        "chart.js": "^2.9.4",
         "classnames": "^2.3.1",
         "client-oauth2": "^4.3.3",
         "clsx": "^1.2.1",
@@ -68,7 +68,7 @@
         "query-string": "7.1.1",
         "rc-slider": "^10.5.0",
         "react": "^18.3.1",
-        "react-chartjs-2": "^5.3.1",
+        "react-chartjs-2": "^2.11.2",
         "react-data-grid": "7.0.0-beta.44",
         "react-dom": "^18.3.1",
         "react-dom-factories": "^1.0.2",
@@ -76,8 +76,9 @@
         "react-hook-form": "^7.63.0",
         "react-modal": "^3.15.1",
         "react-query": "^3.39.2",
-        "react-resize-detector": "^12.3.0",
+        "react-resize-detector": "^8.0.4",
         "react-select": "^5.4.0",
+        "react-sizeme": "^3.0.2",
         "react-tabs": "^6.1.1",
         "react-tippy": "^1.4.0",
         "resize-observer-polyfill": "^1.5.1",
@@ -118,6 +119,7 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
+        "@types/chart.js": "^2.9.37",
         "@types/color-string": "^1.5.2",
         "@types/common-tags": "^1.8.1",
         "@types/d3": "^7.4.0",
@@ -186,7 +188,7 @@
         "sass": "^1.54.5",
         "sass-loader": "^13.0.2",
         "script-loader": "^0.7.2",
-        "string-replace-loader": "^3.1.0",
+        "slate-dom": "^0.117.4",
         "style-loader": "^3.3.1",
         "terser": "^5.46.0",
         "ts-jest": "^29.4.6",
@@ -252,7 +254,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
       "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -262,7 +264,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
@@ -293,12 +295,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@babel/core/node_modules/debug": {
       "version": "4.3.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.1.2"
@@ -316,7 +318,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "devOptional": true,
+      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -364,7 +366,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
       "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.28.6",
@@ -381,7 +383,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
@@ -391,7 +393,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "devOptional": true,
+      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -400,7 +402,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
@@ -558,7 +560,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
       "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.28.6",
@@ -680,7 +682,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
       "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -704,7 +706,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
       "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.28.6",
@@ -5171,6 +5173,7 @@
     },
     "node_modules/@firebase/app-types": {
       "version": "0.7.0",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/app/node_modules/@firebase/app-types": {
@@ -7438,7 +7441,7 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -7496,12 +7499,6 @@
     "node_modules/@juggle/resize-observer": {
       "version": "3.4.0",
       "license": "Apache-2.0"
-    },
-    "node_modules/@kurkle/color": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
-      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
-      "license": "MIT"
     },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.4",
@@ -8810,6 +8807,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/chart.js": {
+      "version": "2.9.41",
+      "resolved": "https://registry.npmjs.org/@types/chart.js/-/chart.js-2.9.41.tgz",
+      "integrity": "sha512-3dvkDvueckY83UyUXtJMalYoH6faOLkWQoaTlJgB4Djde3oORmNP0Jw85HtzTuXyliUHcdp704s0mZFQKio/KQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "moment": "^2.10.2"
       }
     },
     "node_modules/@types/color-string": {
@@ -11506,7 +11513,7 @@
       "version": "2.9.19",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
       "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
@@ -11515,6 +11522,12 @@
     "node_modules/batch": {
       "version": "0.6.1",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/batch-processor": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/batch-processor/-/batch-processor-1.0.0.tgz",
+      "integrity": "sha512-xoLQD8gmmR32MeuBHgH0Tzd5PuSZx71ZsbhVxOCRbgktZEPe4SQy7s9Z50uPp0F/f7iw2XmkHN2xkgbMfckMDA==",
       "license": "MIT"
     },
     "node_modules/bcrypt-pbkdf": {
@@ -11687,7 +11700,7 @@
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
       "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -11896,7 +11909,7 @@
       "version": "1.0.30001767",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001767.tgz",
       "integrity": "sha512-34+zUAMhSH+r+9eKmYG+k2Rpt8XttfE4yXAjoZvkAPs15xcYQhyBYdalJ65BzivAvGRMViEjy6oKr/S91loekQ==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -11951,15 +11964,32 @@
       }
     },
     "node_modules/chart.js": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
-      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-2.9.4.tgz",
+      "integrity": "sha512-B07aAzxcrikjAPyV+01j7BmOpxtQETxTSlQ26BEYJ+3iUkbNKaOJ/nDbT6JjyqYxseM0ON12COHYdU2cTIjC7A==",
       "license": "MIT",
       "dependencies": {
-        "@kurkle/color": "^0.3.0"
-      },
-      "engines": {
-        "pnpm": ">=8"
+        "chartjs-color": "^2.1.0",
+        "moment": "^2.10.2"
+      }
+    },
+    "node_modules/chartjs-color": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chartjs-color/-/chartjs-color-2.4.1.tgz",
+      "integrity": "sha512-haqOg1+Yebys/Ts/9bLo/BqUcONQOdr/hoEr2LLTRl6C5LXctUdHxsCYfvQVg5JIxITrfCNUDr4ntqmQk9+/0w==",
+      "license": "MIT",
+      "dependencies": {
+        "chartjs-color-string": "^0.6.0",
+        "color-convert": "^1.9.3"
+      }
+    },
+    "node_modules/chartjs-color-string": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/chartjs-color-string/-/chartjs-color-string-0.6.0.tgz",
+      "integrity": "sha512-TIB5OKn1hPJvO7JcteW4WY/63v6KwEdt6udfnDE9iCAZgy+V4SrbSxoIbTw/xkUIapjEI4ExGtD0+6D3KyFd7A==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0"
       }
     },
     "node_modules/check-more-types": {
@@ -12166,7 +12196,6 @@
     },
     "node_modules/color-convert": {
       "version": "1.9.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
@@ -14074,8 +14103,17 @@
       "version": "1.5.286",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
       "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
+    },
+    "node_modules/element-resize-detector": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/element-resize-detector/-/element-resize-detector-1.2.4.tgz",
+      "integrity": "sha512-Fl5Ftk6WwXE0wqCgNoseKWndjzZlDCwuPTcoVZfCP9R3EHQF8qUtr3YUPNETegRBOKqQKPW3n4kiIWngGi8tKg==",
+      "license": "MIT",
+      "dependencies": {
+        "batch-processor": "1.0.0"
+      }
     },
     "node_modules/emittery": {
       "version": "0.13.1",
@@ -14326,16 +14364,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/es-toolkit": {
-      "version": "1.46.1",
-      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
-      "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
-      "license": "MIT",
-      "workspaces": [
-        "docs",
-        "benchmarks"
-      ]
     },
     "node_modules/es6-error": {
       "version": "4.1.1",
@@ -16051,7 +16079,7 @@
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -17250,6 +17278,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/ipaddr.js": {
@@ -21081,7 +21118,7 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "devOptional": true,
+      "dev": true,
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -22257,6 +22294,15 @@
         "mobx": "^6.3.0"
       }
     },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/moo-color": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/moo-color/-/moo-color-1.0.3.tgz",
@@ -22471,7 +22517,7 @@
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/normalize-path": {
@@ -23987,13 +24033,18 @@
       }
     },
     "node_modules/react-chartjs-2": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.1.tgz",
-      "integrity": "sha512-h5IPXKg9EXpjoBzUfyWJvllMjG2mQ4EiuHQFhms/AjUm0XSZHhyRy2xVmLXHKrtcdrPO4mnGqRtYoD0vp95A0A==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-2.11.2.tgz",
+      "integrity": "sha512-hcPS9vmRJeAALPPf0uo02BiD8BDm0HNmneJYTZVR74UKprXOpql+Jy1rVuj93rKw0Jfx77mkcRfXPxTe5K83uw==",
       "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.7.2"
+      },
       "peerDependencies": {
-        "chart.js": "^4.1.1",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+        "chart.js": "^2.3",
+        "react": "^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0",
+        "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/react-clientside-effect": {
@@ -24199,15 +24250,16 @@
       }
     },
     "node_modules/react-resize-detector": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-12.3.0.tgz",
-      "integrity": "sha512-mIDOVrTHKGnKe6qEUWi8dFdfHM5CPyTOpqoHctdMQf89Ljm/0qqDIzkP3vTRZZJi9/raaMiRxDEOqO4you5x+A==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-8.1.0.tgz",
+      "integrity": "sha512-S7szxlaIuiy5UqLhLL1KY3aoyGHbZzsTpYal9eYMwCyKqoqoVLCmIgAgNyIM1FhnP2KyBygASJxdhejrzjMb+w==",
       "license": "MIT",
       "dependencies": {
-        "es-toolkit": "^1.39.6"
+        "lodash": "^4.17.21"
       },
       "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0"
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-select": {
@@ -24229,6 +24281,18 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-sizeme": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/react-sizeme/-/react-sizeme-3.0.2.tgz",
+      "integrity": "sha512-xOIAOqqSSmKlKFJLO3inBQBdymzDuXx4iuwkNcJmC96jeiOg5ojByvL+g3MW9LPEsojLbC6pf68zOfobK8IPlw==",
+      "license": "MIT",
+      "dependencies": {
+        "element-resize-detector": "^1.2.2",
+        "invariant": "^2.2.4",
+        "shallowequal": "^1.1.0",
+        "throttle-debounce": "^3.0.1"
       }
     },
     "node_modules/react-style-singleton": {
@@ -25341,8 +25405,8 @@
       "version": "0.117.4",
       "resolved": "https://registry.npmjs.org/slate-dom/-/slate-dom-0.117.4.tgz",
       "integrity": "sha512-eu5MMpphkCnr22R6hgFoQt/tEaHBjSdSy7uJjPOm++hCxstoLefp04EY50A4rXBovjkYoAncb9j8QoijZd0ENA==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@juggle/resize-observer": "^3.4.0",
         "direction": "^1.0.4",
@@ -25360,8 +25424,8 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
       "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -25756,35 +25820,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/string-replace-loader": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "loader-utils": "^2.0.0",
-        "schema-utils": "^3.0.0"
-      },
-      "peerDependencies": {
-        "webpack": "^5"
-      }
-    },
-    "node_modules/string-replace-loader/node_modules/schema-utils": {
-      "version": "3.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/json-schema": "^7.0.8",
-        "ajv": "^6.12.5",
-        "ajv-keywords": "^3.5.2"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/string-width": {
@@ -26406,6 +26441,15 @@
       "version": "0.2.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/throttle-debounce": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-3.0.1.tgz",
+      "integrity": "sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/throttleit": {
       "version": "1.0.0",
@@ -28592,7 +28636,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -29851,13 +29895,13 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
       "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
-      "devOptional": true
+      "dev": true
     },
     "@babel/core": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -29880,11 +29924,11 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
           "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-          "devOptional": true
+          "dev": true
         },
         "debug": {
           "version": "4.3.2",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "ms": "2.1.2"
           }
@@ -29893,7 +29937,7 @@
           "version": "6.3.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
           "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-          "devOptional": true
+          "dev": true
         }
       }
     },
@@ -29928,7 +29972,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
       "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "@babel/compat-data": "^7.28.6",
         "@babel/helper-validator-option": "^7.27.1",
@@ -29941,7 +29985,7 @@
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
           "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "yallist": "^3.0.2"
           }
@@ -29950,13 +29994,13 @@
           "version": "6.3.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
           "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-          "devOptional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
           "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-          "devOptional": true
+          "dev": true
         }
       }
     },
@@ -30059,7 +30103,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
       "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.28.6",
         "@babel/helper-validator-identifier": "^7.28.5",
@@ -30135,7 +30179,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
       "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
-      "devOptional": true
+      "dev": true
     },
     "@babel/helper-wrap-function": {
       "version": "7.18.11",
@@ -30151,7 +30195,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
       "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "@babel/template": "^7.28.6",
         "@babel/types": "^7.28.6"
@@ -30983,8 +31027,7 @@
     "@chakra-ui/icons": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/@chakra-ui/icons/-/icons-2.2.4.tgz",
-      "integrity": "sha512-l5QdBgwrAg3Sc2BRqtNkJpfuLw/pWRDwwT58J6c4PqQT6wzXxyNa8Q0PForu1ltB5qEiFb1kxr/F/HO1EwNa6g==",
-      "requires": {}
+      "integrity": "sha512-l5QdBgwrAg3Sc2BRqtNkJpfuLw/pWRDwwT58J6c4PqQT6wzXxyNa8Q0PForu1ltB5qEiFb1kxr/F/HO1EwNa6g=="
     },
     "@chakra-ui/lazy-utils": {
       "version": "2.0.5",
@@ -31021,20 +31064,17 @@
     "@chakra-ui/react-children-utils": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@chakra-ui/react-children-utils/-/react-children-utils-2.0.6.tgz",
-      "integrity": "sha512-QVR2RC7QsOsbWwEnq9YduhpqSFnZGvjjGREV8ygKi8ADhXh93C8azLECCUVgRJF2Wc+So1fgxmjLcbZfY2VmBA==",
-      "requires": {}
+      "integrity": "sha512-QVR2RC7QsOsbWwEnq9YduhpqSFnZGvjjGREV8ygKi8ADhXh93C8azLECCUVgRJF2Wc+So1fgxmjLcbZfY2VmBA=="
     },
     "@chakra-ui/react-context": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@chakra-ui/react-context/-/react-context-2.1.0.tgz",
-      "integrity": "sha512-iahyStvzQ4AOwKwdPReLGfDesGG+vWJfEsn0X/NoGph/SkN+HXtv2sCfYFFR9k7bb+Kvc6YfpLlSuLvKMHi2+w==",
-      "requires": {}
+      "integrity": "sha512-iahyStvzQ4AOwKwdPReLGfDesGG+vWJfEsn0X/NoGph/SkN+HXtv2sCfYFFR9k7bb+Kvc6YfpLlSuLvKMHi2+w=="
     },
     "@chakra-ui/react-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@chakra-ui/react-types/-/react-types-2.0.7.tgz",
-      "integrity": "sha512-12zv2qIZ8EHwiytggtGvo4iLT0APris7T0qaAWqzpUGS0cdUtR8W+V1BJ5Ocq+7tA6dzQ/7+w5hmXih61TuhWQ==",
-      "requires": {}
+      "integrity": "sha512-12zv2qIZ8EHwiytggtGvo4iLT0APris7T0qaAWqzpUGS0cdUtR8W+V1BJ5Ocq+7tA6dzQ/7+w5hmXih61TuhWQ=="
     },
     "@chakra-ui/react-use-animation-state": {
       "version": "2.1.0",
@@ -31048,8 +31088,7 @@
     "@chakra-ui/react-use-callback-ref": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-callback-ref/-/react-use-callback-ref-2.1.0.tgz",
-      "integrity": "sha512-efnJrBtGDa4YaxDzDE90EnKD3Vkh5a1t3w7PhnRQmsphLy3g2UieasoKTlT2Hn118TwDjIv5ZjHJW6HbzXA9wQ==",
-      "requires": {}
+      "integrity": "sha512-efnJrBtGDa4YaxDzDE90EnKD3Vkh5a1t3w7PhnRQmsphLy3g2UieasoKTlT2Hn118TwDjIv5ZjHJW6HbzXA9wQ=="
     },
     "@chakra-ui/react-use-controllable-state": {
       "version": "2.1.0",
@@ -31105,14 +31144,12 @@
     "@chakra-ui/react-use-latest-ref": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-latest-ref/-/react-use-latest-ref-2.1.0.tgz",
-      "integrity": "sha512-m0kxuIYqoYB0va9Z2aW4xP/5b7BzlDeWwyXCH6QpT2PpW3/281L3hLCm1G0eOUcdVlayqrQqOeD6Mglq+5/xoQ==",
-      "requires": {}
+      "integrity": "sha512-m0kxuIYqoYB0va9Z2aW4xP/5b7BzlDeWwyXCH6QpT2PpW3/281L3hLCm1G0eOUcdVlayqrQqOeD6Mglq+5/xoQ=="
     },
     "@chakra-ui/react-use-merge-refs": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-merge-refs/-/react-use-merge-refs-2.1.0.tgz",
-      "integrity": "sha512-lERa6AWF1cjEtWSGjxWTaSMvneccnAVH4V4ozh8SYiN9fSPZLlSG3kNxfNzdFvMEhM7dnP60vynF7WjGdTgQbQ==",
-      "requires": {}
+      "integrity": "sha512-lERa6AWF1cjEtWSGjxWTaSMvneccnAVH4V4ozh8SYiN9fSPZLlSG3kNxfNzdFvMEhM7dnP60vynF7WjGdTgQbQ=="
     },
     "@chakra-ui/react-use-outside-click": {
       "version": "2.2.0",
@@ -31135,14 +31172,12 @@
     "@chakra-ui/react-use-previous": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-previous/-/react-use-previous-2.1.0.tgz",
-      "integrity": "sha512-pjxGwue1hX8AFcmjZ2XfrQtIJgqbTF3Qs1Dy3d1krC77dEsiCUbQ9GzOBfDc8pfd60DrB5N2tg5JyHbypqh0Sg==",
-      "requires": {}
+      "integrity": "sha512-pjxGwue1hX8AFcmjZ2XfrQtIJgqbTF3Qs1Dy3d1krC77dEsiCUbQ9GzOBfDc8pfd60DrB5N2tg5JyHbypqh0Sg=="
     },
     "@chakra-ui/react-use-safe-layout-effect": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-safe-layout-effect/-/react-use-safe-layout-effect-2.1.0.tgz",
-      "integrity": "sha512-Knbrrx/bcPwVS1TorFdzrK/zWA8yuU/eaXDkNj24IrKoRlQrSBFarcgAEzlCHtzuhufP3OULPkELTzz91b0tCw==",
-      "requires": {}
+      "integrity": "sha512-Knbrrx/bcPwVS1TorFdzrK/zWA8yuU/eaXDkNj24IrKoRlQrSBFarcgAEzlCHtzuhufP3OULPkELTzz91b0tCw=="
     },
     "@chakra-ui/react-use-size": {
       "version": "2.1.0",
@@ -31170,8 +31205,7 @@
     "@chakra-ui/react-use-update-effect": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@chakra-ui/react-use-update-effect/-/react-use-update-effect-2.1.0.tgz",
-      "integrity": "sha512-ND4Q23tETaR2Qd3zwCKYOOS1dfssojPLJMLvUtUbW5M9uW1ejYWgGUobeAiOVfSplownG8QYMmHTP86p/v0lbA==",
-      "requires": {}
+      "integrity": "sha512-ND4Q23tETaR2Qd3zwCKYOOS1dfssojPLJMLvUtUbW5M9uW1ejYWgGUobeAiOVfSplownG8QYMmHTP86p/v0lbA=="
     },
     "@chakra-ui/react-utils": {
       "version": "2.0.12",
@@ -31210,8 +31244,7 @@
     "@chakra-ui/skip-nav": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@chakra-ui/skip-nav/-/skip-nav-2.1.0.tgz",
-      "integrity": "sha512-Hk+FG+vadBSH0/7hwp9LJnLjkO0RPGnx7gBJWI4/SpoJf3e4tZlWYtwGj0toYY4aGKl93jVghuwGbDBEMoHDug==",
-      "requires": {}
+      "integrity": "sha512-Hk+FG+vadBSH0/7hwp9LJnLjkO0RPGnx7gBJWI4/SpoJf3e4tZlWYtwGj0toYY4aGKl93jVghuwGbDBEMoHDug=="
     },
     "@chakra-ui/stepper": {
       "version": "2.3.1",
@@ -31476,8 +31509,7 @@
         "use-sync-external-store": {
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
-          "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
-          "requires": {}
+          "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="
         }
       }
     },
@@ -31611,8 +31643,7 @@
         "@chakra-ui/control-box": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/@chakra-ui/control-box/-/control-box-2.1.0.tgz",
-          "integrity": "sha512-gVrRDyXFdMd8E7rulL0SKeoljkLQiPITFnsyMO8EFHNZ+AHt5wK4LIguYVEq88APqAGZGfHFWXr79RYrNiE3Mg==",
-          "requires": {}
+          "integrity": "sha512-gVrRDyXFdMd8E7rulL0SKeoljkLQiPITFnsyMO8EFHNZ+AHt5wK4LIguYVEq88APqAGZGfHFWXr79RYrNiE3Mg=="
         },
         "@chakra-ui/counter": {
           "version": "2.1.0",
@@ -31627,8 +31658,7 @@
         "@chakra-ui/css-reset": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/@chakra-ui/css-reset/-/css-reset-2.3.0.tgz",
-          "integrity": "sha512-cQwwBy5O0jzvl0K7PLTLgp8ijqLPKyuEMiDXwYzl95seD3AoeuoCLyzZcJtVqaUZ573PiBdAbY/IlZcwDOItWg==",
-          "requires": {}
+          "integrity": "sha512-cQwwBy5O0jzvl0K7PLTLgp8ijqLPKyuEMiDXwYzl95seD3AoeuoCLyzZcJtVqaUZ573PiBdAbY/IlZcwDOItWg=="
         },
         "@chakra-ui/descendant": {
           "version": "3.1.0",
@@ -31732,8 +31762,7 @@
         "@chakra-ui/live-region": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/@chakra-ui/live-region/-/live-region-2.1.0.tgz",
-          "integrity": "sha512-ZOxFXwtaLIsXjqnszYYrVuswBhnIHHP+XIgK1vC6DePKtyK590Wg+0J0slDwThUAd4MSSIUa/nNX84x1GMphWw==",
-          "requires": {}
+          "integrity": "sha512-ZOxFXwtaLIsXjqnszYYrVuswBhnIHHP+XIgK1vC6DePKtyK590Wg+0J0slDwThUAd4MSSIUa/nNX84x1GMphWw=="
         },
         "@chakra-ui/media-query": {
           "version": "3.3.0",
@@ -32143,8 +32172,7 @@
         "@chakra-ui/visually-hidden": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/@chakra-ui/visually-hidden/-/visually-hidden-2.2.0.tgz",
-          "integrity": "sha512-KmKDg01SrQ7VbTD3+cPWf/UfpF5MSwm3v7MWi0n5t8HnnadT13MF0MJCDSXbBWnzLv1ZKJ6zlyAOeARWX+DpjQ==",
-          "requires": {}
+          "integrity": "sha512-KmKDg01SrQ7VbTD3+cPWf/UfpF5MSwm3v7MWi0n5t8HnnadT13MF0MJCDSXbBWnzLv1ZKJ6zlyAOeARWX+DpjQ=="
         },
         "@types/lodash.mergewith": {
           "version": "4.6.7",
@@ -32209,8 +32237,7 @@
         "use-sync-external-store": {
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
-          "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
-          "requires": {}
+          "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="
         }
       }
     },
@@ -32445,14 +32472,12 @@
     "@concord-consortium/log-monitor": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@concord-consortium/log-monitor/-/log-monitor-1.0.0.tgz",
-      "integrity": "sha512-3eGS2jkil8MdEYMSaW/lJV2OYaW+kQsPoRUx086D+XaYdC3sRwIGq+Laqh7/qPCApnL+tj/ZA27bWZ5u4oSF9w==",
-      "requires": {}
+      "integrity": "sha512-3eGS2jkil8MdEYMSaW/lJV2OYaW+kQsPoRUx086D+XaYdC3sRwIGq+Laqh7/qPCApnL+tj/ZA27bWZ5u4oSF9w=="
     },
     "@concord-consortium/mobx-state-tree": {
       "version": "6.0.0-cc.1",
       "resolved": "https://registry.npmjs.org/@concord-consortium/mobx-state-tree/-/mobx-state-tree-6.0.0-cc.1.tgz",
-      "integrity": "sha512-dfzSe4ba2dNreouI3YXsUv1tmNlyx2Lj3oa5QoEi2WQazMgCqQY/mCMM87z1HfflYlCnLFoDu8KP2XTp3ljTvg==",
-      "requires": {}
+      "integrity": "sha512-dfzSe4ba2dNreouI3YXsUv1tmNlyx2Lj3oa5QoEi2WQazMgCqQY/mCMM87z1HfflYlCnLFoDu8KP2XTp3ljTvg=="
     },
     "@concord-consortium/react-components": {
       "version": "1.0.0",
@@ -32463,8 +32488,7 @@
       }
     },
     "@concord-consortium/react-modal-hook": {
-      "version": "3.0.0-cc.1",
-      "requires": {}
+      "version": "3.0.0-cc.1"
     },
     "@concord-consortium/slate-editor": {
       "version": "0.13.0-pre.0",
@@ -32524,8 +32548,7 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
       "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@csstools/css-color-parser": {
       "version": "3.1.0",
@@ -32541,8 +32564,7 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
       "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@csstools/css-tokenizer": {
       "version": "3.0.4",
@@ -32956,8 +32978,7 @@
     "@emotion/use-insertion-effect-with-fallbacks": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
-      "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
-      "requires": {}
+      "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg=="
     },
     "@emotion/utils": {
       "version": "1.4.2",
@@ -33158,7 +33179,8 @@
       }
     },
     "@firebase/app-types": {
-      "version": "0.7.0"
+      "version": "0.7.0",
+      "dev": true
     },
     "@firebase/auth": {
       "version": "0.16.8",
@@ -33167,12 +33189,10 @@
       }
     },
     "@firebase/auth-interop-types": {
-      "version": "0.1.6",
-      "requires": {}
+      "version": "0.1.6"
     },
     "@firebase/auth-types": {
-      "version": "0.10.3",
-      "requires": {}
+      "version": "0.10.3"
     },
     "@firebase/component": {
       "version": "0.5.6",
@@ -33312,8 +33332,7 @@
       }
     },
     "@firebase/firestore-types": {
-      "version": "2.4.0",
-      "requires": {}
+      "version": "2.4.0"
     },
     "@firebase/functions": {
       "version": "0.6.16",
@@ -33368,8 +33387,7 @@
       }
     },
     "@firebase/installations-types": {
-      "version": "0.3.4",
-      "requires": {}
+      "version": "0.3.4"
     },
     "@firebase/logger": {
       "version": "0.2.6"
@@ -33386,8 +33404,7 @@
       }
     },
     "@firebase/messaging-types": {
-      "version": "0.5.0",
-      "requires": {}
+      "version": "0.5.0"
     },
     "@firebase/performance": {
       "version": "0.4.18",
@@ -33470,8 +33487,7 @@
       }
     },
     "@firebase/storage-types": {
-      "version": "0.5.0",
-      "requires": {}
+      "version": "0.5.0"
     },
     "@firebase/util": {
       "version": "1.3.0",
@@ -33680,8 +33696,7 @@
     "@heroicons/react": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
-      "integrity": "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==",
-      "requires": {}
+      "integrity": "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ=="
     },
     "@humanwhocodes/config-array": {
       "version": "0.13.0",
@@ -34735,7 +34750,7 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -34783,11 +34798,6 @@
     },
     "@juggle/resize-observer": {
       "version": "3.4.0"
-    },
-    "@kurkle/color": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
-      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w=="
     },
     "@leichtgewicht/ip-codec": {
       "version": "2.0.4",
@@ -35029,43 +35039,35 @@
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "6.3.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@svgr/babel-plugin-remove-jsx-attribute": {
       "version": "6.3.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@svgr/babel-plugin-remove-jsx-empty-expression": {
       "version": "6.3.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@svgr/babel-plugin-replace-jsx-attribute-value": {
       "version": "6.3.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@svgr/babel-plugin-svg-dynamic-title": {
       "version": "6.3.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@svgr/babel-plugin-svg-em-dimensions": {
       "version": "6.3.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@svgr/babel-plugin-transform-react-native-svg": {
       "version": "6.3.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@svgr/babel-plugin-transform-svg-component": {
       "version": "6.3.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@svgr/babel-preset": {
       "version": "6.3.1",
@@ -35287,8 +35289,7 @@
     "@tensorflow/tfjs-converter": {
       "version": "4.22.0",
       "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-converter/-/tfjs-converter-4.22.0.tgz",
-      "integrity": "sha512-PT43MGlnzIo+YfbsjM79Lxk9lOq6uUwZuCc8rrp0hfpLjF6Jv8jS84u2jFb+WpUeuF4K33ZDNx8CjiYrGQ2trQ==",
-      "requires": {}
+      "integrity": "sha512-PT43MGlnzIo+YfbsjM79Lxk9lOq6uUwZuCc8rrp0hfpLjF6Jv8jS84u2jFb+WpUeuF4K33ZDNx8CjiYrGQ2trQ=="
     },
     "@tensorflow/tfjs-core": {
       "version": "4.22.0",
@@ -35380,8 +35381,7 @@
     "@tensorflow/tfjs-layers": {
       "version": "4.22.0",
       "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-layers/-/tfjs-layers-4.22.0.tgz",
-      "integrity": "sha512-lybPj4ZNj9iIAPUj7a8ZW1hg8KQGfqWLlCZDi9eM/oNKCCAgchiyzx8OrYoWmRrB+AM6VNEeIT+2gZKg5ReihA==",
-      "requires": {}
+      "integrity": "sha512-lybPj4ZNj9iIAPUj7a8ZW1hg8KQGfqWLlCZDi9eM/oNKCCAgchiyzx8OrYoWmRrB+AM6VNEeIT+2gZKg5ReihA=="
     },
     "@testing-library/cypress": {
       "version": "10.0.1",
@@ -35554,8 +35554,7 @@
       "version": "14.6.1",
       "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
       "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@tootallnate/once": {
       "version": "2.0.0",
@@ -35646,6 +35645,15 @@
       "dev": true,
       "requires": {
         "@types/node": "*"
+      }
+    },
+    "@types/chart.js": {
+      "version": "2.9.41",
+      "resolved": "https://registry.npmjs.org/@types/chart.js/-/chart.js-2.9.41.tgz",
+      "integrity": "sha512-3dvkDvueckY83UyUXtJMalYoH6faOLkWQoaTlJgB4Djde3oORmNP0Jw85HtzTuXyliUHcdp704s0mZFQKio/KQ==",
+      "dev": true,
+      "requires": {
+        "moment": "^2.10.2"
       }
     },
     "@types/color-string": {
@@ -36113,8 +36121,7 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@types/react-modal": {
       "version": "3.13.1",
@@ -36342,8 +36349,7 @@
       "version": "8.59.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.2.tgz",
       "integrity": "sha512-BKK4alN7oi4C/zv4VqHQ+uRU+lTa6JGIZ7s1juw7b3RHo9OfKB+bKX3u0iVZetdsUCBBkSbdWbarJbmN0fTeSw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@typescript-eslint/type-utils": {
       "version": "8.59.2",
@@ -36492,8 +36498,7 @@
     "@uiw/color-convert": {
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/@uiw/color-convert/-/color-convert-2.10.1.tgz",
-      "integrity": "sha512-/Z3YfBiX+SErRM59yQH88Id+Xy/k10nnkfTuqhX6RB2yYUcG57DoFqb6FudhiQ5fwzKvKf1k4xq9lfT1UTFUKQ==",
-      "requires": {}
+      "integrity": "sha512-/Z3YfBiX+SErRM59yQH88Id+Xy/k10nnkfTuqhX6RB2yYUcG57DoFqb6FudhiQ5fwzKvKf1k4xq9lfT1UTFUKQ=="
     },
     "@uiw/react-codemirror": {
       "version": "4.23.13",
@@ -37002,8 +37007,7 @@
     },
     "@webpack-cli/configtest": {
       "version": "1.2.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@webpack-cli/info": {
       "version": "1.5.0",
@@ -37014,8 +37018,7 @@
     },
     "@webpack-cli/serve": {
       "version": "1.7.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -37069,15 +37072,13 @@
     },
     "acorn-import-assertions": {
       "version": "1.8.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "agent-base": {
       "version": "6.0.2",
@@ -37138,8 +37139,7 @@
     },
     "ajv-keywords": {
       "version": "3.5.2",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ansi-colors": {
       "version": "4.1.1",
@@ -37551,11 +37551,16 @@
       "version": "2.9.19",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
       "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
-      "devOptional": true
+      "dev": true
     },
     "batch": {
       "version": "0.6.1",
       "dev": true
+    },
+    "batch-processor": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/batch-processor/-/batch-processor-1.0.0.tgz",
+      "integrity": "sha512-xoLQD8gmmR32MeuBHgH0Tzd5PuSZx71ZsbhVxOCRbgktZEPe4SQy7s9Z50uPp0F/f7iw2XmkHN2xkgbMfckMDA=="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -37681,7 +37686,7 @@
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
       "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -37802,7 +37807,7 @@
       "version": "1.0.30001767",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001767.tgz",
       "integrity": "sha512-34+zUAMhSH+r+9eKmYG+k2Rpt8XttfE4yXAjoZvkAPs15xcYQhyBYdalJ65BzivAvGRMViEjy6oKr/S91loekQ==",
-      "devOptional": true
+      "dev": true
     },
     "caseless": {
       "version": "0.12.0",
@@ -37832,11 +37837,29 @@
       "dev": true
     },
     "chart.js": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
-      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-2.9.4.tgz",
+      "integrity": "sha512-B07aAzxcrikjAPyV+01j7BmOpxtQETxTSlQ26BEYJ+3iUkbNKaOJ/nDbT6JjyqYxseM0ON12COHYdU2cTIjC7A==",
       "requires": {
-        "@kurkle/color": "^0.3.0"
+        "chartjs-color": "^2.1.0",
+        "moment": "^2.10.2"
+      }
+    },
+    "chartjs-color": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chartjs-color/-/chartjs-color-2.4.1.tgz",
+      "integrity": "sha512-haqOg1+Yebys/Ts/9bLo/BqUcONQOdr/hoEr2LLTRl6C5LXctUdHxsCYfvQVg5JIxITrfCNUDr4ntqmQk9+/0w==",
+      "requires": {
+        "chartjs-color-string": "^0.6.0",
+        "color-convert": "^1.9.3"
+      }
+    },
+    "chartjs-color-string": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/chartjs-color-string/-/chartjs-color-string-0.6.0.tgz",
+      "integrity": "sha512-TIB5OKn1hPJvO7JcteW4WY/63v6KwEdt6udfnDE9iCAZgy+V4SrbSxoIbTw/xkUIapjEI4ExGtD0+6D3KyFd7A==",
+      "requires": {
+        "color-name": "^1.0.0"
       }
     },
     "check-more-types": {
@@ -37969,7 +37992,6 @@
     },
     "color-convert": {
       "version": "1.9.3",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -38544,15 +38566,13 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/cypress-file-upload/-/cypress-file-upload-5.0.8.tgz",
       "integrity": "sha512-+8VzNabRk3zG6x8f8BWArF/xA/W0VK4IZNx3MV0jFWrJS/qKn8eHfa5nU73P9fOQAgwHFJx7zjg4lwOnljMO8g==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "cypress-real-events": {
       "version": "1.14.0",
       "resolved": "https://registry.npmjs.org/cypress-real-events/-/cypress-real-events-1.14.0.tgz",
       "integrity": "sha512-XmI8y3OZLh6cjRroPalzzS++iv+pGCaD9G9kfIbtspgv7GVsDt30dkZvSXfgZb4rAN+3pOkMVB7e0j4oXydW7Q==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "cypress-terminal-report": {
       "version": "4.1.2",
@@ -38906,8 +38926,7 @@
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.1.tgz",
       "integrity": "sha512-9JmrhGZpOlEgOLdQgSm0zxFaYoQon408V1v49aqTWuXENVlnCuY9JBZcXZiCsZQWDjTm5Qf/nIvAy77mXDAjEg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "deep-equal": {
       "version": "2.2.2",
@@ -39255,7 +39274,15 @@
       "version": "1.5.286",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
       "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
-      "devOptional": true
+      "dev": true
+    },
+    "element-resize-detector": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/element-resize-detector/-/element-resize-detector-1.2.4.tgz",
+      "integrity": "sha512-Fl5Ftk6WwXE0wqCgNoseKWndjzZlDCwuPTcoVZfCP9R3EHQF8qUtr3YUPNETegRBOKqQKPW3n4kiIWngGi8tKg==",
+      "requires": {
+        "batch-processor": "1.0.0"
+      }
     },
     "emittery": {
       "version": "0.13.1",
@@ -39434,11 +39461,6 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
-    },
-    "es-toolkit": {
-      "version": "1.46.1",
-      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
-      "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ=="
     },
     "es6-error": {
       "version": "4.1.1",
@@ -39639,8 +39661,7 @@
     },
     "eslint-plugin-chai-friendly": {
       "version": "0.7.2",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-plugin-cypress": {
       "version": "2.12.1",
@@ -39757,15 +39778,13 @@
     },
     "eslint-plugin-react-hooks": {
       "version": "4.6.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-plugin-unused-imports": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-4.4.1.tgz",
       "integrity": "sha512-oZGYUz1X3sRMGUB+0cZyK2VcvRX5lm/vB56PgNNcU+7ficUCKm66oZWKUubXWnOuPjQ8PvmXtCViXBMONPe7tQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-scope": {
       "version": "5.1.1",
@@ -40530,7 +40549,7 @@
     },
     "gensync": {
       "version": "1.0.0-beta.2",
-      "devOptional": true
+      "dev": true
     },
     "get-caller-file": {
       "version": "2.0.5"
@@ -41197,8 +41216,7 @@
     },
     "icss-utils": {
       "version": "5.1.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "idb": {
       "version": "3.0.2"
@@ -41298,6 +41316,14 @@
     "interpret": {
       "version": "2.2.0",
       "dev": true
+    },
+    "invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "requires": {
+        "loose-envify": "^1.0.0"
+      }
     },
     "ipaddr.js": {
       "version": "1.9.1",
@@ -42824,8 +42850,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "28.0.2",
@@ -43878,7 +43903,7 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "devOptional": true
+      "dev": true
     },
     "json5-loader": {
       "version": "4.0.1",
@@ -44426,8 +44451,7 @@
     "markdown-to-jsx": {
       "version": "7.7.13",
       "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.7.13.tgz",
-      "integrity": "sha512-DiueEq2bttFcSxUs85GJcQVrOr0+VVsPfj9AEUPqmExJ3f8P/iQNvZHltV4tm1XVhu1kl0vWBZWT3l99izRMaA==",
-      "requires": {}
+      "integrity": "sha512-DiueEq2bttFcSxUs85GJcQVrOr0+VVsPfj9AEUPqmExJ3f8P/iQNvZHltV4tm1XVhu1kl0vWBZWT3l99izRMaA=="
     },
     "match-sorter": {
       "version": "6.3.1",
@@ -44637,14 +44661,17 @@
       }
     },
     "mobx-react-lite": {
-      "version": "3.4.0",
-      "requires": {}
+      "version": "3.4.0"
     },
     "mobx-state-tree": {
       "version": "npm:@concord-consortium/mobx-state-tree@6.0.0-cc.1",
       "resolved": "https://registry.npmjs.org/@concord-consortium/mobx-state-tree/-/mobx-state-tree-6.0.0-cc.1.tgz",
-      "integrity": "sha512-dfzSe4ba2dNreouI3YXsUv1tmNlyx2Lj3oa5QoEi2WQazMgCqQY/mCMM87z1HfflYlCnLFoDu8KP2XTp3ljTvg==",
-      "requires": {}
+      "integrity": "sha512-dfzSe4ba2dNreouI3YXsUv1tmNlyx2Lj3oa5QoEi2WQazMgCqQY/mCMM87z1HfflYlCnLFoDu8KP2XTp3ljTvg=="
+    },
+    "moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how=="
     },
     "moo-color": {
       "version": "1.0.3",
@@ -44781,7 +44808,7 @@
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
-      "devOptional": true
+      "dev": true
     },
     "normalize-path": {
       "version": "3.0.0",
@@ -45379,8 +45406,7 @@
     "popsicle-content-encoding": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/popsicle-content-encoding/-/popsicle-content-encoding-1.0.0.tgz",
-      "integrity": "sha512-4Df+vTfM8wCCJVTzPujiI6eOl3SiWQkcZg0AMrOkD1enMXsF3glIkFUZGvour1Sj7jOWCsNSEhBxpbbhclHhzw==",
-      "requires": {}
+      "integrity": "sha512-4Df+vTfM8wCCJVTzPujiI6eOl3SiWQkcZg0AMrOkD1enMXsF3glIkFUZGvour1Sj7jOWCsNSEhBxpbbhclHhzw=="
     },
     "popsicle-cookie-jar": {
       "version": "1.0.1",
@@ -45394,8 +45420,7 @@
     "popsicle-redirects": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/popsicle-redirects/-/popsicle-redirects-1.1.1.tgz",
-      "integrity": "sha512-mC2HrKjdTAWDalOjGxlXw9j6Qxrz/Yd2ui6bPxpi2IQDYWpF4gUAMxbA8EpSWJhLi0PuWKDwTHHPrUPGutAoIA==",
-      "requires": {}
+      "integrity": "sha512-mC2HrKjdTAWDalOjGxlXw9j6Qxrz/Yd2ui6bPxpi2IQDYWpF4gUAMxbA8EpSWJhLi0PuWKDwTHHPrUPGutAoIA=="
     },
     "popsicle-transport-http": {
       "version": "1.2.1",
@@ -45408,14 +45433,12 @@
     "popsicle-transport-xhr": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/popsicle-transport-xhr/-/popsicle-transport-xhr-2.0.0.tgz",
-      "integrity": "sha512-5Sbud4Widngf1dodJE5cjEYXkzEUIl8CzyYRYR57t6vpy9a9KPGQX6KBKdPjmBZlR5A06pOBXuJnVr23l27rtA==",
-      "requires": {}
+      "integrity": "sha512-5Sbud4Widngf1dodJE5cjEYXkzEUIl8CzyYRYR57t6vpy9a9KPGQX6KBKdPjmBZlR5A06pOBXuJnVr23l27rtA=="
     },
     "popsicle-user-agent": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/popsicle-user-agent/-/popsicle-user-agent-1.0.0.tgz",
-      "integrity": "sha512-epKaq3TTfTzXcxBxjpoKYMcTTcAX8Rykus6QZu77XNhJuRHSRxMd+JJrbX/3PFI0opFGSN0BabbAYCbGxbu0mA==",
-      "requires": {}
+      "integrity": "sha512-epKaq3TTfTzXcxBxjpoKYMcTTcAX8Rykus6QZu77XNhJuRHSRxMd+JJrbX/3PFI0opFGSN0BabbAYCbGxbu0mA=="
     },
     "postcss": {
       "version": "8.4.31",
@@ -45449,8 +45472,7 @@
     },
     "postcss-modules-extract-imports": {
       "version": "3.0.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -45747,10 +45769,13 @@
       }
     },
     "react-chartjs-2": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.1.tgz",
-      "integrity": "sha512-h5IPXKg9EXpjoBzUfyWJvllMjG2mQ4EiuHQFhms/AjUm0XSZHhyRy2xVmLXHKrtcdrPO4mnGqRtYoD0vp95A0A==",
-      "requires": {}
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-2.11.2.tgz",
+      "integrity": "sha512-hcPS9vmRJeAALPPf0uo02BiD8BDm0HNmneJYTZVR74UKprXOpql+Jy1rVuj93rKw0Jfx77mkcRfXPxTe5K83uw==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.7.2"
+      }
     },
     "react-clientside-effect": {
       "version": "1.2.8",
@@ -45816,8 +45841,7 @@
     "react-hook-form": {
       "version": "7.63.0",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.63.0.tgz",
-      "integrity": "sha512-ZwueDMvUeucovM2VjkCf7zIHcs1aAlDimZu2Hvel5C5907gUzMpm4xCrQXtRzCvsBqFjonB4m3x4LzCFI1ZKWA==",
-      "requires": {}
+      "integrity": "sha512-ZwueDMvUeucovM2VjkCf7zIHcs1aAlDimZu2Hvel5C5907gUzMpm4xCrQXtRzCvsBqFjonB4m3x4LzCFI1ZKWA=="
     },
     "react-is": {
       "version": "16.13.1"
@@ -45864,11 +45888,11 @@
       }
     },
     "react-resize-detector": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-12.3.0.tgz",
-      "integrity": "sha512-mIDOVrTHKGnKe6qEUWi8dFdfHM5CPyTOpqoHctdMQf89Ljm/0qqDIzkP3vTRZZJi9/raaMiRxDEOqO4you5x+A==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-8.1.0.tgz",
+      "integrity": "sha512-S7szxlaIuiy5UqLhLL1KY3aoyGHbZzsTpYal9eYMwCyKqoqoVLCmIgAgNyIM1FhnP2KyBygASJxdhejrzjMb+w==",
       "requires": {
-        "es-toolkit": "^1.39.6"
+        "lodash": "^4.17.21"
       }
     },
     "react-select": {
@@ -45885,6 +45909,17 @@
         "prop-types": "^15.6.0",
         "react-transition-group": "^4.3.0",
         "use-isomorphic-layout-effect": "^1.2.0"
+      }
+    },
+    "react-sizeme": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/react-sizeme/-/react-sizeme-3.0.2.tgz",
+      "integrity": "sha512-xOIAOqqSSmKlKFJLO3inBQBdymzDuXx4iuwkNcJmC96jeiOg5ojByvL+g3MW9LPEsojLbC6pf68zOfobK8IPlw==",
+      "requires": {
+        "element-resize-detector": "^1.2.2",
+        "invariant": "^2.2.4",
+        "shallowequal": "^1.1.0",
+        "throttle-debounce": "^3.0.1"
       }
     },
     "react-style-singleton": {
@@ -46219,8 +46254,7 @@
     "rete-structures": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/rete-structures/-/rete-structures-2.0.1.tgz",
-      "integrity": "sha512-8S7zkoHLnDOz7T9L4qfwp6efdp790wk3sZBF2qsHLtHJIyAxC8lDNNngy7R2Eh762nadgfcn/ItHpLPmpXQGeQ==",
-      "requires": {}
+      "integrity": "sha512-8S7zkoHLnDOz7T9L4qfwp6efdp790wk3sZBF2qsHLtHJIyAxC8lDNNngy7R2Eh762nadgfcn/ItHpLPmpXQGeQ=="
     },
     "retry": {
       "version": "0.13.1",
@@ -46656,7 +46690,7 @@
       "version": "0.117.4",
       "resolved": "https://registry.npmjs.org/slate-dom/-/slate-dom-0.117.4.tgz",
       "integrity": "sha512-eu5MMpphkCnr22R6hgFoQt/tEaHBjSdSy7uJjPOm++hCxstoLefp04EY50A4rXBovjkYoAncb9j8QoijZd0ENA==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "@juggle/resize-observer": "^3.4.0",
         "direction": "^1.0.4",
@@ -46671,7 +46705,7 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
           "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-          "peer": true
+          "dev": true
         }
       }
     },
@@ -46954,25 +46988,6 @@
         "strip-ansi": "^6.0.0"
       }
     },
-    "string-replace-loader": {
-      "version": "3.1.0",
-      "dev": true,
-      "requires": {
-        "loader-utils": "^2.0.0",
-        "schema-utils": "^3.0.0"
-      },
-      "dependencies": {
-        "schema-utils": {
-          "version": "3.1.1",
-          "dev": true,
-          "requires": {
-            "@types/json-schema": "^7.0.8",
-            "ajv": "^6.12.5",
-            "ajv-keywords": "^3.5.2"
-          }
-        }
-      }
-    },
     "string-width": {
       "version": "4.2.3",
       "requires": {
@@ -47083,8 +47098,7 @@
     },
     "style-loader": {
       "version": "3.3.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "style-mod": {
       "version": "4.1.2",
@@ -47381,6 +47395,11 @@
       "version": "0.2.0",
       "dev": true
     },
+    "throttle-debounce": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-3.0.1.tgz",
+      "integrity": "sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg=="
+    },
     "throttleit": {
       "version": "1.0.0",
       "dev": true
@@ -47425,8 +47444,7 @@
           "version": "6.5.0",
           "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
           "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "picomatch": {
           "version": "4.0.4",
@@ -47514,8 +47532,7 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
       "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ts-expect": {
       "version": "1.3.0",
@@ -48868,7 +48885,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "escalade": "^3.2.0",
         "picocolors": "^1.1.1"
@@ -48924,20 +48941,17 @@
     "use-composed-ref": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.3.0.tgz",
-      "integrity": "sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ==",
-      "requires": {}
+      "integrity": "sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ=="
     },
     "use-immer": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/use-immer/-/use-immer-0.11.0.tgz",
-      "integrity": "sha512-RNAqi3GqsWJ4bcCd4LMBgdzvPmTABam24DUaFiKfX9s3MSorNRz9RDZYJkllJoMHUxVLMDetwAuCDeyWNrp1yA==",
-      "requires": {}
+      "integrity": "sha512-RNAqi3GqsWJ4bcCd4LMBgdzvPmTABam24DUaFiKfX9s3MSorNRz9RDZYJkllJoMHUxVLMDetwAuCDeyWNrp1yA=="
     },
     "use-isomorphic-layout-effect": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.0.tgz",
-      "integrity": "sha512-q6ayo8DWoPZT0VdG4u3D3uxcgONP3Mevx2i2b0434cwWBoL+aelL1DzkXI6w3PhTZzUeR2kaVlZn70iCiseP6w==",
-      "requires": {}
+      "integrity": "sha512-q6ayo8DWoPZT0VdG4u3D3uxcgONP3Mevx2i2b0434cwWBoL+aelL1DzkXI6w3PhTZzUeR2kaVlZn70iCiseP6w=="
     },
     "use-latest": {
       "version": "1.2.1",
@@ -48948,8 +48962,7 @@
       }
     },
     "use-memo-one": {
-      "version": "1.1.3",
-      "requires": {}
+      "version": "1.1.3"
     },
     "use-resize-observer": {
       "version": "9.0.2",
@@ -48967,8 +48980,7 @@
       }
     },
     "use-sync-external-store": {
-      "version": "1.2.0",
-      "requires": {}
+      "version": "1.2.0"
     },
     "usehooks-ts": {
       "version": "2.16.0",
@@ -49560,8 +49572,7 @@
       "version": "8.19.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "xhr-mock": {
       "version": "2.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -188,6 +188,7 @@
         "sass": "^1.54.5",
         "sass-loader": "^13.0.2",
         "script-loader": "^0.7.2",
+        "slate-dom": "^0.117.4",
         "string-replace-loader": "^3.1.0",
         "style-loader": "^3.3.1",
         "terser": "^5.46.0",
@@ -24472,6 +24473,35 @@
         "tiny-warning": "^1.0.3"
       }
     },
+    "node_modules/slate-dom": {
+      "version": "0.117.4",
+      "resolved": "https://registry.npmjs.org/slate-dom/-/slate-dom-0.117.4.tgz",
+      "integrity": "sha512-eu5MMpphkCnr22R6hgFoQt/tEaHBjSdSy7uJjPOm++hCxstoLefp04EY50A4rXBovjkYoAncb9j8QoijZd0ENA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@juggle/resize-observer": "^3.4.0",
+        "direction": "^1.0.4",
+        "is-hotkey": "^0.2.0",
+        "is-plain-object": "^5.0.0",
+        "lodash": "^4.17.21",
+        "scroll-into-view-if-needed": "^3.1.0",
+        "tiny-invariant": "1.3.1"
+      },
+      "peerDependencies": {
+        "slate": ">=0.99.0"
+      }
+    },
+    "node_modules/slate-dom/node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/slate-history": {
       "version": "0.100.0",
       "resolved": "https://registry.npmjs.org/slate-history/-/slate-history-0.100.0.tgz",
@@ -45103,6 +45133,29 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
           "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
+        }
+      }
+    },
+    "slate-dom": {
+      "version": "0.117.4",
+      "resolved": "https://registry.npmjs.org/slate-dom/-/slate-dom-0.117.4.tgz",
+      "integrity": "sha512-eu5MMpphkCnr22R6hgFoQt/tEaHBjSdSy7uJjPOm++hCxstoLefp04EY50A4rXBovjkYoAncb9j8QoijZd0ENA==",
+      "dev": true,
+      "requires": {
+        "@juggle/resize-observer": "^3.4.0",
+        "direction": "^1.0.4",
+        "is-hotkey": "^0.2.0",
+        "is-plain-object": "^5.0.0",
+        "lodash": "^4.17.21",
+        "scroll-into-view-if-needed": "^3.1.0",
+        "tiny-invariant": "1.3.1"
+      },
+      "dependencies": {
+        "is-plain-object": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+          "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -258,7 +258,7 @@
     "@concord-consortium/mobx-state-tree": "^6.0.0-cc.1",
     "@concord-consortium/react-components": "^1.0.0",
     "@concord-consortium/react-modal-hook": "^3.0.0-cc.1",
-    "@concord-consortium/slate-editor": "^0.12.0",
+    "@concord-consortium/slate-editor": "0.13.0-pre.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -231,7 +231,6 @@
     "sass": "^1.54.5",
     "sass-loader": "^13.0.2",
     "script-loader": "^0.7.2",
-    "slate-dom": "^0.117.4",
     "style-loader": "^3.3.1",
     "terser": "^5.46.0",
     "ts-jest": "^29.4.6",

--- a/package.json
+++ b/package.json
@@ -231,6 +231,7 @@
     "sass": "^1.54.5",
     "sass-loader": "^13.0.2",
     "script-loader": "^0.7.2",
+    "slate-dom": "^0.117.4",
     "style-loader": "^3.3.1",
     "terser": "^5.46.0",
     "ts-jest": "^29.4.6",

--- a/src/components/tiles/text/text-tile.tsx
+++ b/src/components/tiles/text/text-tile.tsx
@@ -325,7 +325,7 @@ export default class TextToolComponent extends BaseComponent<ITileProps, IState>
                   <Slate
                     editor={this.editor as ReactEditor}
                     initialValue={this.state.initialValue}
-                    onChange={this.handleChange}
+                    onValueChange={this.handleChange}
                   >
                     <SlateEditor
                       placeholder={placeholderText}

--- a/src/models/document/document-content-tests/dc-test-utils.ts
+++ b/src/models/document/document-content-tests/dc-test-utils.ts
@@ -35,9 +35,9 @@ export { mockUniqueId };
 // This is needed so MST can deserialize snapshots referring to tools
 import { registerTileTypes } from "../../../register-tile-types";
 registerTileTypes(["Drawing", "Geometry", "Image", "Table", "Text"]);
-// slate-editor v0.12 dropped registerPlugins(); registrations now happen as side effects
-// of createEditor() (via withCoreMarks/withCoreBlocks/etc.). Trigger them once so tests
-// can serialize Slate values without first instantiating an editor.
+// createEditor() registers slate-editor's built-in element and mark renderers
+// as a side effect. Trigger it at module load so tests can serialize Slate
+// values without first instantiating an editor.
 createEditor();
 
 export function prepareTileForMatch(tile: any) {

--- a/src/models/document/document-content-tests/dc-test-utils.ts
+++ b/src/models/document/document-content-tests/dc-test-utils.ts
@@ -1,3 +1,4 @@
+import { createEditor } from "@concord-consortium/slate-editor";
 import { IDocumentExportOptions } from "../../tiles/tile-content-info";
 import { safeJsonParse } from "../../../utilities/js-utils";
 import { DocumentContentModel, DocumentContentModelType, DocumentContentSnapshotType } from "../document-content";
@@ -37,7 +38,6 @@ registerTileTypes(["Drawing", "Geometry", "Image", "Table", "Text"]);
 // slate-editor v0.12 dropped registerPlugins(); registrations now happen as side effects
 // of createEditor() (via withCoreMarks/withCoreBlocks/etc.). Trigger them once so tests
 // can serialize Slate values without first instantiating an editor.
-import { createEditor } from "@concord-consortium/slate-editor";
 createEditor();
 
 export function prepareTileForMatch(tile: any) {

--- a/src/models/document/document-content-tests/dc-test-utils.ts
+++ b/src/models/document/document-content-tests/dc-test-utils.ts
@@ -34,8 +34,11 @@ export { mockUniqueId };
 // This is needed so MST can deserialize snapshots referring to tools
 import { registerTileTypes } from "../../../register-tile-types";
 registerTileTypes(["Drawing", "Geometry", "Image", "Table", "Text"]);
-import { registerPlugins } from "@concord-consortium/slate-editor";
-registerPlugins();
+// slate-editor v0.12 dropped registerPlugins(); registrations now happen as side effects
+// of createEditor() (via withCoreMarks/withCoreBlocks/etc.). Trigger them once so tests
+// can serialize Slate values without first instantiating an editor.
+import { createEditor } from "@concord-consortium/slate-editor";
+createEditor();
 
 export function prepareTileForMatch(tile: any) {
   if (tile?.content?.type === "Geometry") {

--- a/src/models/tiles/text/text-registration.ts
+++ b/src/models/tiles/text/text-registration.ts
@@ -1,4 +1,3 @@
-import { registerPlugins } from "@concord-consortium/slate-editor";
 import TextToolComponent from "../../../components/tiles/text/text-tile";
 import { HighlightsPlugin, kHighlightTextPluginName } from "../../../plugins/text/highlights-plugin";
 import { registerTileComponentInfo } from "../tile-component-info";
@@ -9,6 +8,13 @@ import { registerTextPluginInfo } from "./text-plugin-info";
 import Icon from "../../../clue/assets/icons/text-tool.svg";
 import HeaderIcon from "../../../assets/icons/sort-by-tools/text-tile-id.svg";
 
+// slate-editor v0.12 dropped the public registerPlugins() helper. The built-in
+// element components and mark renderers are now registered as side effects of
+// createEditor() (via withCoreMarks/withCoreBlocks/etc.). We invoke it once at
+// module load so paths like slateToHtml() that don't go through SlateEditor
+// still find the renderers registered.
+import { createEditor } from "@concord-consortium/slate-editor";
+createEditor();
 registerTileContentInfo({
   type: kTextTileType,
   displayName: "Text",
@@ -20,8 +26,6 @@ registerTextPluginInfo({
   pluginName: kHighlightTextPluginName,
   createSlatePlugin: (textContent) => new HighlightsPlugin(textContent)
 });
-
-registerPlugins();
 
 registerTileComponentInfo({
   type: kTextTileType,

--- a/src/models/tiles/text/text-registration.ts
+++ b/src/models/tiles/text/text-registration.ts
@@ -1,3 +1,4 @@
+import { createEditor } from "@concord-consortium/slate-editor";
 import TextToolComponent from "../../../components/tiles/text/text-tile";
 import { HighlightsPlugin, kHighlightTextPluginName } from "../../../plugins/text/highlights-plugin";
 import { registerTileComponentInfo } from "../tile-component-info";
@@ -13,7 +14,6 @@ import HeaderIcon from "../../../assets/icons/sort-by-tools/text-tile-id.svg";
 // createEditor() (via withCoreMarks/withCoreBlocks/etc.). We invoke it once at
 // module load so paths like slateToHtml() that don't go through SlateEditor
 // still find the renderers registered.
-import { createEditor } from "@concord-consortium/slate-editor";
 createEditor();
 registerTileContentInfo({
   type: kTextTileType,

--- a/src/models/tiles/text/text-registration.ts
+++ b/src/models/tiles/text/text-registration.ts
@@ -9,11 +9,9 @@ import { registerTextPluginInfo } from "./text-plugin-info";
 import Icon from "../../../clue/assets/icons/text-tool.svg";
 import HeaderIcon from "../../../assets/icons/sort-by-tools/text-tile-id.svg";
 
-// slate-editor v0.12 dropped the public registerPlugins() helper. The built-in
-// element components and mark renderers are now registered as side effects of
-// createEditor() (via withCoreMarks/withCoreBlocks/etc.). We invoke it once at
-// module load so paths like slateToHtml() that don't go through SlateEditor
-// still find the renderers registered.
+// createEditor() registers slate-editor's built-in element and mark renderers
+// (via withCoreMarks/withCoreBlocks/etc.) as a side effect. Invoke it at module
+// load so non-editor paths like slateToHtml() find the renderers registered.
 createEditor();
 registerTileContentInfo({
   type: kTextTileType,

--- a/src/plugins/shared-variables/slate/text-tile-buttons.tsx
+++ b/src/plugins/shared-variables/slate/text-tile-buttons.tsx
@@ -99,13 +99,15 @@ function castToVariablesPlugin(plugin?: ITextPlugin): VariablesPlugin|undefined 
 }
 
 function handleClose(editor: Editor) {
-  // focus the editor after closing the dialog, which is what the user expects and
-  // also required for certain slate selection synchronization mechanisms to work.
-  // focusing twice shouldn't be necessary, but sometimes seems to help ¯\_(ツ)_/¯
-  ReactEditor.focus(editor);
+  // Defer focus restoration until after React has committed any state changes
+  // from the modal's OK handler (e.g. variable chip insertion). Calling
+  // ReactEditor.focus synchronously here races React 18's batched render:
+  // editor.selection points into the newly-inserted node, but slate-react's
+  // KEY_TO_ELEMENT map isn't populated for that node until React commits, so
+  // toDOMRange throws "Cannot resolve a DOM node from Slate node".
   setTimeout(() => {
     ReactEditor.focus(editor);
-  }, 10);
+  }, 0);
 }
 
 export const NewVariableTextButton = observer(


### PR DESCRIPTION
> PR 3 of 6. Base: `CLUE-489-2-rdg`.

## What's in this PR

`@concord-consortium/slate-editor` `0.13.0-pre.0` migration + text-tile runtime/cypress fixes. (The pinned version is a pre-release of v0.13; the API breakage motivating the upgrade was introduced in v0.12 and carried forward.)

At this point the build and Jest tests run. The Cypress smoke test does not pass though so the built code is not deployed to S3.

### slate-editor API change (v0.12+)

v0.12 dropped the public `registerPlugins()` helper. Built-in element components and mark renderers are now registered as side effects of `createEditor()` (via `withCoreMarks`, `withCoreBlocks`, etc.). Replaced `registerPlugins()` calls with explicit `createEditor()` invocations in:
- `src/models/tiles/text/text-registration.ts`
- `src/models/document/document-content-tests/dc-test-utils.ts`

`slate-dom` is added as a direct devDep because branch 3 in isolation still requires `--legacy-peer-deps`, which leaves `slate-react`'s `slate-dom` peer unmet. It's dropped on branch 4 where the dep bumps clear the peer-deps conflict.

### Runtime fix: text-tile redo stack

Switched `TextTile` from `onChange` to slate-editor's `onValueChange`. Under React 18's automatic batching, `onChange` fired during typing was reentering MST in a way that wiped the redo stack on every keystroke. slate-editor had to be updated so the `onValueChange` was handled the same as when using vanilla Slate. This is the 0.13-pre.0 release of slate-editor. https://github.com/concord-consortium/slate-editor/pull/90

### Runtime fix: slate variable dialog focus

Deferred focus of the variable dialog input to the next tick to avoid a React 18 render race in `text-tile-buttons.tsx`. Under React 17 the dialog's first render happened synchronously; under 18 the focus call ran before the dialog input existed in the DOM.

### Cypress fixes

- `cy.realType` for text-tool typing — `cy.type` doesn't fire `beforeinput` events under the new slate-react, which slate's input pipeline depends on.
- `cy.realPress` for meta-key shortcuts in `TextToolTile.js` — same root cause.

## Test plan

Note: these can't really be demonstrated until the code is deploying to S3.
- [ ] Text tile typing → undo → redo retains the redo stack
- [ ] Variable dialog opens with its input focused
- [ ] Highlights, links, variables, lists, bold/italic/underline still work
- [ ] Cypress `text_tool_spec` and `slate-variable-tile-spec` pass
- [ ] `text-content.test.ts` passes