### PR TITLE
CLUE-489 React 18 (5/6) — diagram + drawing tile fixes

### DIFF
--- a/cypress/e2e/functional/tile_tests/arrow_annotation_spec.js
+++ b/cypress/e2e/functional/tile_tests/arrow_annotation_spec.js
@@ -291,7 +291,7 @@ context('Arrow Annotations (Sparrows)', function () {
     drawToolTile.getEllipseDrawing().find("ellipse").click({ force: true, scrollBehavior: false });
     clueCanvas.clickToolbarButton('drawing', 'delete'); // delete the object under the second end; arrow should remain since it was not attached.
     aa.getAnnotationArrows().should("have.length", 1);
-    drawToolTile.getRectangleDrawing().eq(0).click({ force: true, scrollBehavior: false });
+    drawToolTile.getRectangleDrawing().eq(0).find("rect").click({ force: true, scrollBehavior: false });
     clueCanvas.clickToolbarButton('drawing', 'delete'); // delete the object under the first end; arrow should be deleted.
     aa.getAnnotationArrows().should("have.length", 0);
 

--- a/cypress/e2e/functional/tile_tests/arrow_annotation_spec.js
+++ b/cypress/e2e/functional/tile_tests/arrow_annotation_spec.js
@@ -152,7 +152,7 @@ context('Arrow Annotations (Sparrows)', function () {
     aa.getAnnotationButtons().should("have.length", 3);
     // Group the two rectangles
     aa.getAnnotationModeButton().click(); // sparrow mode off
-    drawToolTile.getRectangleDrawing().eq(0).click();
+    drawToolTile.selectFirstRectangle();
     drawToolTile.getRectangleDrawing().eq(1).click({ shiftKey: true });
     clueCanvas.clickToolbarButton('drawing', 'group');
     aa.getAnnotationModeButton().click(); // sparrow mode on

--- a/cypress/e2e/functional/tile_tests/arrow_annotation_spec.js
+++ b/cypress/e2e/functional/tile_tests/arrow_annotation_spec.js
@@ -160,7 +160,13 @@ context('Arrow Annotations (Sparrows)', function () {
     aa.getAnnotationButtons().should("have.length", 3); // doesn't change number of buttons
     // Ungroup the two rectangles
     aa.getAnnotationModeButton().click(); // sparrow mode off
-    drawToolTile.getDrawTile().click();
+    // Deselect by clicking empty drawing-layer space — target .drawing-layer
+    // directly (not the outer .tool-tile) so the click reaches the
+    // SelectionDrawingTool's pointerdown handler. See drawing_tool_spec.js for
+    // the same pattern.
+    drawToolTile.getDrawTileComponent().find('.drawing-layer')
+      .trigger("pointerdown", 20, 20, { isPrimary: true })
+      .trigger("pointerup", 20, 20, { isPrimary: true });
     drawToolTile.getGroupDrawing().eq(0).find("rect.group-rect").eq(0).click();
     clueCanvas.clickToolbarButton('drawing', 'ungroup');
     aa.getAnnotationModeButton().click(); // sparrow mode on

--- a/cypress/e2e/functional/tile_tests/diagram_tool_spec.js
+++ b/cypress/e2e/functional/tile_tests/diagram_tool_spec.js
@@ -267,12 +267,9 @@ context('Diagram Tool Tile', function () {
     const eName = "vn3";
     const eValue = "2.5";
     const eUnit = "meter";
-    diagramTile.getVariableCardField("name").clear();
-    diagramTile.getVariableCardField("name").type(eName);
-    diagramTile.getVariableCardField("value").clear();
-    diagramTile.getVariableCardField("value").type(eValue);
-    diagramTile.getVariableCardField("unit").clear();
-    diagramTile.getVariableCardField("unit").type(eUnit);
+    diagramTile.getVariableCardField("name").focus().clear().type(eName);
+    diagramTile.getVariableCardField("value").focus().clear().type(eValue);
+    diagramTile.getVariableCardField("unit").focus().clear().type(eUnit);
     diagramTile.getVariableCardField("name").should("have.value", eName);
     diagramTile.getVariableCardField("value").should("have.value", eValue);
     diagramTile.getVariableCardField("unit").should("have.value", eUnit);

--- a/cypress/e2e/functional/tile_tests/diagram_tool_spec.js
+++ b/cypress/e2e/functional/tile_tests/diagram_tool_spec.js
@@ -166,7 +166,9 @@ context('Diagram Tool Tile', function () {
     draggable().then((button) => {
       const rect = button[0].getBoundingClientRect();
       draggable().trigger('mousedown', { force: true });
+      cy.wait(50);
       draggable().trigger('mousemove', { force: true, clientX: rect.left+50, clientY: rect.top-200});
+      cy.wait(50);
       draggable().trigger('mouseup', { force: true });
       cy.wait(300); // wait for the variable card to be fully created, otherwise undo fails
     });

--- a/cypress/e2e/functional/tile_tests/drawing_tool_spec.js
+++ b/cypress/e2e/functional/tile_tests/drawing_tool_spec.js
@@ -1029,22 +1029,13 @@ context('Draw Tool Tile', function () {
     cy.log("verify selection tool rejects non-primary events");
     // First create something to try to select
     drawToolTile.drawRectangle(100, 50, 100, 100);
-    // The new rectangle is auto-selected; clear the selection via the model
-    // before the non-primary drag, so the assertion below measures what the
-    // non-primary drag did rather than the pre-existing auto-selection. A
-    // synthetic click on the tile element doesn't reliably reach the drawing
-    // layer's pointerdown handler.
+    // Clear the rectangle's auto-selection by clicking empty canvas (outside
+    // the rectangle's 100,50→200,150 bounds), so the assertion below measures
+    // what the non-primary drag did rather than the pre-existing selection.
     drawToolTile.getDrawToolSelect().click();
-    cy.window().then((win) => {
-      const docs = win.stores?.documents?.all || [];
-      docs.forEach((d) => {
-        d.content?.tileMap?.forEach?.((t) => {
-          if (t.content?.type === "Drawing" && t.content.setSelectedIds) {
-            t.content.setSelectedIds([]);
-          }
-        });
-      });
-    });
+    drawToolTile.getDrawTile()
+      .trigger("pointerdown", 50, 30, { isPrimary: true })
+      .trigger("pointerup", 50, 30, { isPrimary: true });
 
     drawToolTile.getSelectionBox().should("not.exist");
     drawToolTile.getDrawTile()

--- a/cypress/e2e/functional/tile_tests/drawing_tool_spec.js
+++ b/cypress/e2e/functional/tile_tests/drawing_tool_spec.js
@@ -400,8 +400,10 @@ context('Draw Tool Tile', function () {
     // The hover box is rendered as a selection-box with a different color
     drawToolTile.getHighlightBox().should("exist").should("have.attr", "stroke").and("eq", "#bbdd00");
 
-    // The best way I found to remove the hover was to delete the rectangle
-    drawToolTile.getRectangleDrawing().first().click({ force: true });
+    // The best way I found to remove the hover was to delete the rectangle.
+    // Drill into the inner rect — force:true on the wrapper g doesn't reach the
+    // pointerdown handler (same pattern as the Group test fix).
+    drawToolTile.getRectangleDrawing().first().find("rect").click({ force: true });
     drawToolTile.getDrawToolDelete().click();
     drawToolTile.getHighlightBox().should("not.exist");
 
@@ -505,7 +507,7 @@ context('Draw Tool Tile', function () {
     // delete the first 4 with the toolbar button
     for (let i = 0; i < 4; i++) {
       drawToolTile.getDrawToolSelect().click();
-      drawToolTile.getRectangleDrawing().first().click({ force: true });
+      drawToolTile.getRectangleDrawing().first().find("rect").click({ force: true });
       drawToolTile.getDrawToolDelete().click();
     }
     // Delete with backspace key.
@@ -513,13 +515,13 @@ context('Draw Tool Tile', function () {
     // (the drawing tile redirects focus on pointer events for the focus trap). Trigger the
     // keydown directly on the drawing-layer so it reaches the React onKeyDown handler.
     drawToolTile.getDrawToolSelect().click();
-    drawToolTile.getRectangleDrawing().first().click({ force: true });
+    drawToolTile.getRectangleDrawing().first().find("rect").click({ force: true });
     drawToolTile.getDrawTileComponent().find('.drawing-layer')
       .trigger("keydown", { key: "Backspace", keyCode: 8, which: 8, force: true });
 
     // Delete with delete key
     drawToolTile.getDrawToolSelect().click();
-    drawToolTile.getRectangleDrawing().first().click({ force: true });
+    drawToolTile.getRectangleDrawing().first().find("rect").click({ force: true });
     drawToolTile.getDrawTileComponent().find('.drawing-layer')
       .trigger("keydown", { key: "Delete", keyCode: 46, which: 46, force: true });
 
@@ -555,9 +557,11 @@ context('Draw Tool Tile', function () {
     cy.log("deletes ellipse drawing");
     drawToolTile.getDrawTile().click();
     drawToolTile.getDrawToolSelect().click();
-    drawToolTile.getEllipseDrawing().first().click({ force: true });
+    // Drill into the inner ellipse — force:true on the wrapper g doesn't reach
+    // the pointerdown handler (same pattern as the Group test fix).
+    drawToolTile.getEllipseDrawing().first().find("ellipse").click({ force: true });
     drawToolTile.getDrawToolDelete().click();
-    drawToolTile.getEllipseDrawing().first().click({ force: true });
+    drawToolTile.getEllipseDrawing().first().find("ellipse").click({ force: true });
     drawToolTile.getDrawToolDelete().click();
     drawToolTile.getEllipseDrawing().should("not.exist");
 
@@ -600,12 +604,13 @@ context('Draw Tool Tile', function () {
 
     cy.log("deletes stamp drawing");
     drawToolTile.getDrawToolSelect().click();
-    // drawToolTile.getImageDrawing().click({force:true, scrollBehavior: false});
-    drawToolTile.getImageDrawing().eq(0).click({ force: true });
+    // Drill into the inner image — force:true on the wrapper g doesn't reach
+    // the pointerdown handler (same pattern as the Group test fix).
+    drawToolTile.getImageDrawing().eq(0).find("image").click({ force: true });
     drawToolTile.getDrawToolDelete().click();
-    drawToolTile.getImageDrawing().eq(1).click({ force: true });
+    drawToolTile.getImageDrawing().eq(1).find("image").click({ force: true });
     drawToolTile.getDrawToolDelete().click();
-    drawToolTile.getImageDrawing().click({ force: true });
+    drawToolTile.getImageDrawing().find("image").click({ force: true });
     drawToolTile.getDrawToolDelete().click();
     drawToolTile.getImageDrawing().should("not.exist");
   });
@@ -1027,10 +1032,23 @@ context('Draw Tool Tile', function () {
     cy.log("verify selection tool rejects non-primary events");
     // First create something to try to select
     drawToolTile.drawRectangle(100, 50, 100, 100);
-    // Deselect the rectangle
-    drawToolTile.getDrawTile().click(50, 50);
-
+    // The new rectangle is auto-selected; clear the selection via the model
+    // before the non-primary drag, so the assertion below measures what the
+    // non-primary drag did rather than the pre-existing auto-selection. A
+    // synthetic click on the tile element doesn't reliably reach the drawing
+    // layer's pointerdown handler.
     drawToolTile.getDrawToolSelect().click();
+    cy.window().then((win) => {
+      const docs = win.stores?.documents?.all || [];
+      docs.forEach((d) => {
+        d.content?.tileMap?.forEach?.((t) => {
+          if (t.content?.type === "Drawing" && t.content.setSelectedIds) {
+            t.content.setSelectedIds([]);
+          }
+        });
+      });
+    });
+
     drawToolTile.getSelectionBox().should("not.exist");
     drawToolTile.getDrawTile()
       .trigger("pointerdown", 90, 40, { isPrimary: false })

--- a/cypress/e2e/functional/tile_tests/drawing_tool_spec.js
+++ b/cypress/e2e/functional/tile_tests/drawing_tool_spec.js
@@ -401,9 +401,7 @@ context('Draw Tool Tile', function () {
     drawToolTile.getHighlightBox().should("exist").should("have.attr", "stroke").and("eq", "#bbdd00");
 
     // The best way I found to remove the hover was to delete the rectangle.
-    // Drill into the inner rect — force:true on the wrapper g doesn't reach the
-    // pointerdown handler (same pattern as the Group test fix).
-    drawToolTile.getRectangleDrawing().first().find("rect").click({ force: true });
+    drawToolTile.selectFirstRectangle();
     drawToolTile.getDrawToolDelete().click();
     drawToolTile.getHighlightBox().should("not.exist");
 
@@ -507,7 +505,7 @@ context('Draw Tool Tile', function () {
     // delete the first 4 with the toolbar button
     for (let i = 0; i < 4; i++) {
       drawToolTile.getDrawToolSelect().click();
-      drawToolTile.getRectangleDrawing().first().find("rect").click({ force: true });
+      drawToolTile.selectFirstRectangle();
       drawToolTile.getDrawToolDelete().click();
     }
     // Delete with backspace key.
@@ -515,13 +513,13 @@ context('Draw Tool Tile', function () {
     // (the drawing tile redirects focus on pointer events for the focus trap). Trigger the
     // keydown directly on the drawing-layer so it reaches the React onKeyDown handler.
     drawToolTile.getDrawToolSelect().click();
-    drawToolTile.getRectangleDrawing().first().find("rect").click({ force: true });
+    drawToolTile.selectFirstRectangle();
     drawToolTile.getDrawTileComponent().find('.drawing-layer')
       .trigger("keydown", { key: "Backspace", keyCode: 8, which: 8, force: true });
 
     // Delete with delete key
     drawToolTile.getDrawToolSelect().click();
-    drawToolTile.getRectangleDrawing().first().find("rect").click({ force: true });
+    drawToolTile.selectFirstRectangle();
     drawToolTile.getDrawTileComponent().find('.drawing-layer')
       .trigger("keydown", { key: "Delete", keyCode: 46, which: 46, force: true });
 

--- a/cypress/e2e/functional/tile_tests/drawing_tool_spec.js
+++ b/cypress/e2e/functional/tile_tests/drawing_tool_spec.js
@@ -679,8 +679,7 @@ context('Draw Tool Tile', function () {
     drawToolTile.getDrawToolSelect().click();
     // Click the inner rect.group-rect — the wrapper g doesn't carry the pointerdown
     // handler, so a force:true click on the wrapper bypasses cypress's hit-testing
-    // and dispatches into dead space. (Same pattern as the rectangle click below,
-    // fixed in 1821f19b5 for that line but missed here.)
+    // and dispatches into dead space.
     drawToolTile.getGroupDrawing().eq(0).find('rect.group-rect').click({ force: true });
     // Shift+click the new rectangle to add it to the selection
     drawToolTile.getRectangleDrawing().eq(1).find("rect").click({ force: true, shiftKey: true });

--- a/cypress/e2e/functional/tile_tests/drawing_tool_spec.js
+++ b/cypress/e2e/functional/tile_tests/drawing_tool_spec.js
@@ -672,7 +672,11 @@ context('Draw Tool Tile', function () {
 
     // Select the group and the new rectangle
     drawToolTile.getDrawToolSelect().click();
-    drawToolTile.getGroupDrawing().eq(0).click({ force: true });
+    // Click the inner rect.group-rect — the wrapper g doesn't carry the pointerdown
+    // handler, so a force:true click on the wrapper bypasses cypress's hit-testing
+    // and dispatches into dead space. (Same pattern as the rectangle click below,
+    // fixed in 1821f19b5 for that line but missed here.)
+    drawToolTile.getGroupDrawing().eq(0).find('rect.group-rect').click({ force: true });
     // Shift+click the new rectangle to add it to the selection
     drawToolTile.getRectangleDrawing().eq(1).find("rect").click({ force: true, shiftKey: true });
 

--- a/cypress/support/elements/tile/DiagramToolTile.js
+++ b/cypress/support/elements/tile/DiagramToolTile.js
@@ -40,7 +40,7 @@ class DiagramToolTile {
     return cy.get('.color-editor-dialog');
   }
   getColorPicker() {
-    return cy.get('.color-editor-dialog span span');
+    return cy.get('.color-editor-dialog .w-color-circle-point');
   }
   getDiagramTileTitle(workspaceClass){
     return cy.get(`${workspaceClass || ".primary-workspace"} .editable-tile-title`);

--- a/cypress/support/elements/tile/DrawToolTile.js
+++ b/cypress/support/elements/tile/DrawToolTile.js
@@ -100,6 +100,9 @@ class DrawToolTile{
     getRectangleDrawing(){
       return this.getDrawTileComponent().find('.drawing-layer svg .transformable-rectangle');
     }
+    selectFirstRectangle(){
+      return this.getRectangleDrawing().first().click();
+    }
     getEllipseDrawing(){
       return this.getDrawTileComponent().find('.drawing-layer svg .transformable-ellipse');
     }

--- a/src/components/document/annotation-layer.tsx
+++ b/src/components/document/annotation-layer.tsx
@@ -49,7 +49,10 @@ export const AnnotationLayer = observer(function AnnotationLayer({
   const [sourcePoint, setSourcePoint] = useState<Point | undefined>();
   const [mouseX, setMouseX] = useState<number | undefined>();
   const [mouseY, setMouseY] = useState<number | undefined>();
-  const [isBackgroundClick, setIsBackgroundClick] = useState(false);
+  // Ref (not useState) because mousedown sets this flag and the subsequent click
+  // handler reads it within the same tick — under React 18 createRoot batching, a
+  // useState update from mousedown wouldn't be visible to the click closure.
+  const isBackgroundClickRef = useRef(false);
   // Use `setLayoutTick` to force a post-layout render (e.g., after tiles/rows change).
   const [_layoutTick, setLayoutTick] = useState(0);
   const divRef = useRef<Element|null>(null);
@@ -161,7 +164,7 @@ export const AnnotationLayer = observer(function AnnotationLayer({
     // followed by a mouseup, a click event is sent to the AnnotationLayer. But we don't want to
     // consider that as a real background click & initiate drawing a sparrow.
     const isBackground = (event.target instanceof SVGElement) && event.target.classList.contains('annotation-svg');
-    setIsBackgroundClick(isBackground);
+    isBackgroundClickRef.current = isBackground;
   };
 
   const handleMouseMove = (event: { clientX: number, clientY: number }) => {
@@ -363,8 +366,8 @@ export const AnnotationLayer = observer(function AnnotationLayer({
   };
 
   const handleBackgroundClick: MouseEventHandler<HTMLDivElement> = event => {
-    if (!isBackgroundClick) return;
-    setIsBackgroundClick(false); // reset for next time.
+    if (!isBackgroundClickRef.current) return;
+    isBackgroundClickRef.current = false; // reset for next time.
 
     // Update the mouseX and mouseY state based on this new event
     handleMouseMove(event);


### PR DESCRIPTION
> PR 5 of 6. Base: `CLUE-489-4-misc-deps`.

## What's in this PR

Per-tile cypress + runtime fixes for the diagram and drawing tiles, surfaced by the React 18 upgrade.

More of the Cypress tests are passing now:
Pass: 185
Fail: 14
No regressions from the previous PR (4/6)

### Diagram tile

- Color picker library changed selector format; cypress updated.
- `dnd-kit` drags need a wait between successive triggers under React 18's batched scheduler (otherwise the second drag's pointermove fires before the first drag's state has settled).
- Variable card field cypress: focus before `cy.clear().type()` — React 18 doesn't preserve focus across the implicit re-render.

### Drawing tile

- `arrow_annotation_spec`: target `.drawing-layer` for group deselect; click inner rect to select for delete (selector changes after React 18 timing shifts).
- `drawing_tool_spec`: click `rect.group-rect` in the Group test; misc remaining `drawing_tool_spec` failures.

### Runtime: annotation-layer background-click

One runtime fix in this PR is not test-only: switched `annotation-layer.tsx`'s background-click flag from a state variable to a ref. Under React 18 the flag was being read before the state update flushed, causing background clicks to be misclassified as drag starts.

## Test plan

- [x] Drawing toolbar group/ungroup, arrow annotation, delete inner shapes
- [x] Diagram tile: create variables, drag, resize, color, expressions
- [x] Cypress `drawing_tool_spec`, `diagram_tool_spec` pass, and most of `arrow_annotation_spec` passes.

