### PR TITLE
CLUE-489 React 18 (6/6) — remaining tile cypress + runtime fixes

### DIFF
--- a/cypress/e2e/functional/teacher_tests/teacher_sort_work_view_3_spec.js
+++ b/cypress/e2e/functional/teacher_tests/teacher_sort_work_view_3_spec.js
@@ -41,15 +41,20 @@ describe('SortWorkView Tests', () => {
       cy.wrap($el).find("[data-testid=doc-group]").should("have.length", 1);
       cy.wrap($el).find("[data-testid=doc-group-label]").should("not.exist");
     });
-    cy.get("[data-testid=doc-group-list]").invoke("prop", "scrollLeft").should("be.eq", 0);
-    cy.get("[data-testid=scroll-button-left]").should("exist").and("be.disabled");
-    cy.get("[data-testid=scroll-button-right]").should("exist").and("not.be.disabled");
-    cy.get("[data-testid=scroll-button-right]").click();
-    cy.get("[data-testid=scroll-button-left]").should("exist").and("not.be.disabled");
-    cy.get("[data-testid=doc-group-list]").invoke("prop", "scrollLeft").should("be.gt", 0);
-    cy.get("[data-testid=scroll-button-left]").click();
-    cy.get("[data-testid=scroll-button-left]").should("exist").and("be.disabled");
-    cy.get("[data-testid=doc-group-list]").invoke("prop", "scrollLeft").should("be.eq", 0);
+    // The Investigation layout renders one set of scroll buttons per
+    // section-document-list, so scope the scroll-behavior assertions to a
+    // single section to avoid multi-element subjects on `.click()`.
+    cy.get("[data-testid=section-document-list]").first().within(() => {
+      cy.get("[data-testid=doc-group-list]").invoke("prop", "scrollLeft").should("be.eq", 0);
+      cy.get("[data-testid=scroll-button-left]").should("exist").and("be.disabled");
+      cy.get("[data-testid=scroll-button-right]").should("exist").and("not.be.disabled");
+      cy.get("[data-testid=scroll-button-right]").click();
+      cy.get("[data-testid=scroll-button-left]").should("exist").and("not.be.disabled");
+      cy.get("[data-testid=doc-group-list]").invoke("prop", "scrollLeft").should("be.gt", 0);
+      cy.get("[data-testid=scroll-button-left]").click();
+      cy.get("[data-testid=scroll-button-left]").should("exist").and("be.disabled");
+      cy.get("[data-testid=doc-group-list]").invoke("prop", "scrollLeft").should("be.eq", 0);
+    });
 
     // Apply secondary sort
     sortWork.getSecondarySortByMenu().click();

--- a/cypress/support/elements/tile/DataCardToolTile.js
+++ b/cypress/support/elements/tile/DataCardToolTile.js
@@ -172,6 +172,7 @@ class DataCardToolTile {
     .trigger("mousedown", {force:true});
     this.getDropZone(dropStack)
     .trigger('mousemove', {force:true })
+    .wait(50)
     .trigger("mouseup", {force:true })
     .wait(1000);
   }

--- a/src/components/document/document-group.test.tsx
+++ b/src/components/document/document-group.test.tsx
@@ -1,0 +1,42 @@
+import { render } from "@testing-library/react";
+import React from "react";
+import { DocumentGroupComponent } from "./document-group";
+import { DocumentGroup } from "../../models/stores/document-group";
+
+jest.mock("../thumbnail/simple-document-item", () => ({
+  SimpleDocumentItem: function MockSimpleDocumentItem({ document }: { document: { key: string } }) {
+    return <div data-testid="simple-document-item">{document.key}</div>;
+  }
+}));
+
+function createTestDocumentGroup(docCount: number) {
+  const documents = Array.from({ length: docCount }, (_, i) => ({
+    key: `doc-${i}`,
+    uid: `user-${i}`,
+  })) as any;
+  return new DocumentGroup({
+    label: "Test",
+    sortType: "Group",
+    documents,
+    stores: {} as any
+  });
+}
+
+describe("DocumentGroupComponent", () => {
+  it("does not render scroll buttons before the container width is measured", () => {
+    // In jsdom, offsetWidth is 0, so containerWidth stays 0 and visibleCount = 0.
+    // If scroll buttons render in that state, clicking them computes
+    // scrollAmount = visibleCount * scrollUnit = 0 — a silent no-op that
+    // leaves the arrow-disabled state out of sync with reality.
+    const documentGroup = createTestDocumentGroup(10);
+    const { queryByTestId } = render(
+      <DocumentGroupComponent
+        documentGroup={documentGroup}
+        secondarySort="None"
+        onSelectDocument={() => undefined}
+      />
+    );
+    expect(queryByTestId("scroll-button-left")).not.toBeInTheDocument();
+    expect(queryByTestId("scroll-button-right")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/document/document-group.tsx
+++ b/src/components/document/document-group.tsx
@@ -118,7 +118,10 @@ export const DocumentGroupComponent = observer(function DocumentGroupComponent(p
           {documentGroup.icon ? <documentGroup.icon className="tool-icon"/> : null}{documentGroup.label}
         </div>
       }
-      {visibleCount < docCount && renderScrollButton("left", leftArrowDisabled)}
+      {/* Gate on visibleCount > 0: before the ResizeObserver fires, visibleCount is 0
+          and handleScroll's scrollAmount would be 0 — a silent no-op click. Render the
+          buttons only once we have a measurement, so a click always actually scrolls. */}
+      {visibleCount > 0 && visibleCount < docCount && renderScrollButton("left", leftArrowDisabled)}
       <div ref={docListContainerRef} className="doc-group-list simple" data-testid="doc-group-list">
         {sortedGroupDocuments?.map((doc) => {
           return (
@@ -130,7 +133,7 @@ export const DocumentGroupComponent = observer(function DocumentGroupComponent(p
           );
         })}
       </div>
-      {visibleCount < docCount && renderScrollButton("right", rightArrowDisabled)}
+      {visibleCount > 0 && visibleCount < docCount && renderScrollButton("right", rightArrowDisabled)}
       {!isUnsorted && <div className="doc-group-count" data-testid="doc-group-count">{docCount}</div>}
     </div>
   );

--- a/src/components/document/document-group.tsx
+++ b/src/components/document/document-group.tsx
@@ -28,6 +28,10 @@ export const DocumentGroupComponent = observer(function DocumentGroupComponent(p
   const [leftArrowDisabled, setLeftArrowDisabled] = useState(true);
   const [rightArrowDisabled, setRightArrowDisabled] = useState(false);
   const sortedGroupDocuments = sortDocumentsInGroup(documentGroup);
+  // Gate on visibleCount > 0: before the ResizeObserver fires, visibleCount is 0
+  // and handleScroll's scrollAmount would be 0 — a silent no-op click. Render the
+  // buttons only once we have a measurement, so a click always actually scrolls.
+  const showScrollButtons = visibleCount > 0 && visibleCount < docCount;
 
   // Each document in the group is represented by a square box. The group of document boxes is displayed in
   // a single row. If there are more boxes than can fit within the row's width, scroll buttons are added
@@ -118,10 +122,7 @@ export const DocumentGroupComponent = observer(function DocumentGroupComponent(p
           {documentGroup.icon ? <documentGroup.icon className="tool-icon"/> : null}{documentGroup.label}
         </div>
       }
-      {/* Gate on visibleCount > 0: before the ResizeObserver fires, visibleCount is 0
-          and handleScroll's scrollAmount would be 0 — a silent no-op click. Render the
-          buttons only once we have a measurement, so a click always actually scrolls. */}
-      {visibleCount > 0 && visibleCount < docCount && renderScrollButton("left", leftArrowDisabled)}
+      {showScrollButtons && renderScrollButton("left", leftArrowDisabled)}
       <div ref={docListContainerRef} className="doc-group-list simple" data-testid="doc-group-list">
         {sortedGroupDocuments?.map((doc) => {
           return (
@@ -133,7 +134,7 @@ export const DocumentGroupComponent = observer(function DocumentGroupComponent(p
           );
         })}
       </div>
-      {visibleCount > 0 && visibleCount < docCount && renderScrollButton("right", rightArrowDisabled)}
+      {showScrollButtons && renderScrollButton("right", rightArrowDisabled)}
       {!isUnsorted && <div className="doc-group-count" data-testid="doc-group-count">{docCount}</div>}
     </div>
   );

--- a/src/plugins/bar-graph/chart-area.tsx
+++ b/src/plugins/bar-graph/chart-area.tsx
@@ -129,8 +129,11 @@ export const ChartArea = observer(function BarGraphChart({ width, height }: IPro
   }, []);
 
   const handleBarBlur = useCallback((e: React.FocusEvent) => {
-    // Only clear selection if focus is leaving the bar graph entirely (not moving between bars).
-    if (!svgRef.current?.contains(e.relatedTarget as Node | null)) {
+    // Don't clear case selection when focus is moving to another tile (e.g. the linked
+    // table) — that tile's click handler is about to read the current selection and would
+    // see an empty set, mis-toggling its row state. Only clear when focus is leaving for
+    // an unrelated, non-focusable target (relatedTarget=null).
+    if (e.relatedTarget == null) {
       model?.sharedModel?.dataSet.setSelectedCases([]);
     }
   }, [model]);

--- a/src/plugins/data-card/components/case-attribute.tsx
+++ b/src/plugins/data-card/components/case-attribute.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { observer } from "mobx-react";
 import { isAlive } from "mobx-state-tree";
 import escapeStringRegexp from "escape-string-regexp";
@@ -83,6 +83,16 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
   const [textLinesNeeded, setTextLinesNeeded] = useState(measureTextLines(getName(), 120));
   const editingName = currEditFacet === "name" && currEditAttrId === attrKey;
   const editingValue = currEditFacet === "value" && currEditAttrId === attrKey;
+  const nameInputRef = useRef<HTMLTextAreaElement | null>(null);
+
+  // When the name textarea enters edit mode, focus it and select its content
+  // so a keypress (or cy.type) replaces the existing name rather than appending.
+  useEffect(() => {
+    if (editingName && nameInputRef.current) {
+      nameInputRef.current.focus();
+      nameInputRef.current.select();
+    }
+  }, [editingName]);
 
   const validCompletions = useCallback((aValues: string[], userString: string) => {
     const values = uniq(aValues).sort();
@@ -350,6 +360,7 @@ export const CaseAttribute: React.FC<IProps> = observer(props => {
       <div className={nameAreaClasses} onClick={handleNameClick}>
         { !readOnly && editingName
           ? <textarea
+              ref={nameInputRef}
               className={nameInputClasses}
               value={nameCandidate}
               onChange={handleNameChange}

--- a/src/plugins/dataflow/components/dataflow-program.tsx
+++ b/src/plugins/dataflow/components/dataflow-program.tsx
@@ -190,12 +190,13 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
   // Routes ArrowKey / Escape / Tab to the rete manager's connection-mode state machine.
   // Registered as a document capture-phase listener (rather than a React onKeyDown
   // on the program container) because the focus trap's own document capture-phase
-  // listener calls `stopPropagation` for Escape — that swallows the event before it
-  // reaches React's bubble-phase handlers and exits the trap instead of cancelling
-  // the in-flight connection. Children mount before parents, so this listener is
-  // registered before the trap's (which lives on the parent TileComponent) and
-  // fires first in capture order. We `stopPropagation` so the trap never sees these
-  // keys while a connection is in flight.
+  // listener handles Escape by exiting the trap (which refocuses the tile
+  // container) — that would override our refocus to the source socket. Children
+  // mount before parents, so this listener is registered before the trap's (which
+  // lives on the parent TileComponent) and fires first in capture order. We use
+  // `stopImmediatePropagation` for Escape because the trap controller's listener
+  // is a sibling document-capture listener; plain `stopPropagation` would not
+  // prevent it from also seeing the event.
   private handleConnectingKeyDown = (e: KeyboardEvent) => {
     const reteManager = this.reteManager;
     if (!reteManager?.isConnecting) return;
@@ -227,7 +228,7 @@ export class DataflowProgram extends BaseComponent<IProps, IState> {
         break;
       case "Escape":
         e.preventDefault();
-        e.stopPropagation();
+        e.stopImmediatePropagation();
         reteManager.cancelConnecting();
         break;
       case "Tab":

--- a/src/plugins/graph/adornments/adornment.tsx
+++ b/src/plugins/graph/adornments/adornment.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React from "react";
 import { clsx } from "clsx";
 import { observer } from "mobx-react-lite";
 import { IAdornmentModel } from "./adornment-models";
@@ -9,6 +9,7 @@ import { getAdornmentComponentInfo } from "./adornment-component-info";
 import { IDotsRef, transitionDuration } from "../graph-types";
 import { uniqueId } from "../../../utilities/js-utils";
 import { useMemoOne } from "use-memo-one";
+import { useFadeTransition } from "./use-fade-transition";
 
 import "./adornment.scss";
 
@@ -30,14 +31,9 @@ export const Adornment = observer(function Adornment(
                      : layout.plotWidth,
     subPlotHeight = rightCats.length > 0
                       ? layout.plotHeight / rightCats.length
-                      : layout.plotHeight,
-    isFadeInComplete = useRef(false),
-    isFadeOutComplete = useRef(false);
+                      : layout.plotHeight;
 
-  useEffect(function fadeInCleanup() {
-    isFadeInComplete.current = adornment.isVisible;
-    isFadeOutComplete.current = !adornment.isVisible;
-  }, [adornment.isVisible]);
+  const fadeState = useFadeTransition(adornment.isVisible, transitionDuration);
 
   const classFromSubPlotKey = adornment.classNameFromKey(subPlotKey);
   // The adornmentKey is a unique value used for React's key prop and for the adornment wrapper's HTML ID.
@@ -57,9 +53,9 @@ export const Adornment = observer(function Adornment(
     `${adornmentKey}-wrapper`,
     `${classFromSubPlotKey}`,
     {
-      'fadeIn': adornment.isVisible && !isFadeInComplete.current,
-      'fadeOut': !adornment.isVisible && !isFadeOutComplete.current,
-      'hidden': !adornment.isVisible && isFadeOutComplete.current
+      'fadeIn': fadeState === 'fadingIn',
+      'fadeOut': fadeState === 'fadingOut',
+      'hidden': fadeState === 'hidden'
     }
   );
 

--- a/src/plugins/graph/adornments/use-fade-transition.test.ts
+++ b/src/plugins/graph/adornments/use-fade-transition.test.ts
@@ -1,0 +1,84 @@
+import { renderHook, act } from "@testing-library/react";
+import { useFadeTransition } from "./use-fade-transition";
+
+describe("useFadeTransition", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("starts in 'fadingIn' when mounted visible", () => {
+    const { result } = renderHook(() => useFadeTransition(true, 1000));
+    expect(result.current).toBe("fadingIn");
+  });
+
+  it("transitions from 'fadingIn' to 'visible' after the duration elapses", () => {
+    const { result } = renderHook(() => useFadeTransition(true, 1000));
+    expect(result.current).toBe("fadingIn");
+    act(() => { jest.advanceTimersByTime(1000); });
+    expect(result.current).toBe("visible");
+  });
+
+  it("stays 'fadingIn' through unrelated re-renders during the transition", () => {
+    // This is the regression we're fixing: the old ref-based logic dropped the
+    // fadeIn class on the next re-render, so any concurrent state change ate
+    // the animation window before tests (or users) could see it.
+    const { result, rerender } = renderHook(
+      ({ isVisible }) => useFadeTransition(isVisible, 1000),
+      { initialProps: { isVisible: true } }
+    );
+    expect(result.current).toBe("fadingIn");
+    rerender({ isVisible: true });
+    rerender({ isVisible: true });
+    expect(result.current).toBe("fadingIn");
+  });
+
+  it("starts in 'hidden' when mounted invisible, without flashing 'fadingOut'", () => {
+    const { result } = renderHook(() => useFadeTransition(false, 1000));
+    expect(result.current).toBe("hidden");
+    act(() => { jest.advanceTimersByTime(1000); });
+    expect(result.current).toBe("hidden");
+  });
+
+  it("transitions through 'fadingOut' to 'hidden' when isVisible flips true → false", () => {
+    const { result, rerender } = renderHook(
+      ({ isVisible }) => useFadeTransition(isVisible, 1000),
+      { initialProps: { isVisible: true } }
+    );
+    act(() => { jest.advanceTimersByTime(1000); });
+    expect(result.current).toBe("visible");
+    rerender({ isVisible: false });
+    expect(result.current).toBe("fadingOut");
+    act(() => { jest.advanceTimersByTime(1000); });
+    expect(result.current).toBe("hidden");
+  });
+
+  it("transitions through 'fadingIn' to 'visible' when isVisible flips false → true", () => {
+    const { result, rerender } = renderHook(
+      ({ isVisible }) => useFadeTransition(isVisible, 1000),
+      { initialProps: { isVisible: false } }
+    );
+    rerender({ isVisible: true });
+    expect(result.current).toBe("fadingIn");
+    act(() => { jest.advanceTimersByTime(1000); });
+    expect(result.current).toBe("visible");
+  });
+
+  it("cancels the pending transition when isVisible flips mid-animation", () => {
+    const { result, rerender } = renderHook(
+      ({ isVisible }) => useFadeTransition(isVisible, 1000),
+      { initialProps: { isVisible: true } }
+    );
+    expect(result.current).toBe("fadingIn");
+    act(() => { jest.advanceTimersByTime(500); });
+    rerender({ isVisible: false });
+    expect(result.current).toBe("fadingOut");
+    // The remaining 500ms of the original fadeIn timer must not fire and flip us to 'visible'.
+    act(() => { jest.advanceTimersByTime(500); });
+    expect(result.current).toBe("fadingOut");
+    act(() => { jest.advanceTimersByTime(500); });
+    expect(result.current).toBe("hidden");
+  });
+});

--- a/src/plugins/graph/adornments/use-fade-transition.ts
+++ b/src/plugins/graph/adornments/use-fade-transition.ts
@@ -1,0 +1,26 @@
+import { useEffect, useRef, useState } from "react";
+
+export type FadeState = "visible" | "fadingIn" | "hidden" | "fadingOut";
+
+// Drives a four-state fade transition off a boolean `isVisible` flag. The
+// returned state survives unrelated re-renders for the full `durationMs`
+// window, unlike a ref-based approach where any re-render between the first
+// paint and the animation completing would drop the fading class.
+export function useFadeTransition(isVisible: boolean, durationMs: number): FadeState {
+  const [state, setState] = useState<FadeState>(isVisible ? "fadingIn" : "hidden");
+  const isFirstRunRef = useRef(true);
+
+  useEffect(() => {
+    const settledState: FadeState = isVisible ? "visible" : "hidden";
+    if (isFirstRunRef.current) {
+      isFirstRunRef.current = false;
+      if (!isVisible) return;
+    } else {
+      setState(isVisible ? "fadingIn" : "fadingOut");
+    }
+    const timer = setTimeout(() => setState(settledState), durationMs);
+    return () => clearTimeout(timer);
+  }, [isVisible, durationMs]);
+
+  return state;
+}

--- a/src/plugins/graph/components/background.tsx
+++ b/src/plugins/graph/components/background.tsx
@@ -153,19 +153,22 @@ export const Background = forwardRef<SVGGElement, IProps>((props, ref) => {
     }
   }, [graphModel.editingLayer]);
 
-  const onClick = useCallback((event: { offsetX: number, offsetY: number, shiftKey: boolean }) => {
-    // If not shifted, clicking on background deselects everything
+  // The drag behavior handles point-adding (via dragEndAddMode) for both real drags
+  // and click-without-movement, since d3-drag always fires its "end" event on mouseup.
+  // This handler runs after drag-end on plain clicks (and is suppressed by d3-drag on
+  // drags with movement), so it should NOT add a point or it would duplicate the one
+  // dragEndAddMode already added.
+  const onClick = useCallback((event: { shiftKey: boolean }) => {
+    // If not shifted, clicking on background deselects everything.
+    // (For left-clicks the drag-start handler already cleared the selection; this
+    // handles ctrl/right-click and other paths where drag doesn't engage.)
     if (!event.shiftKey) {
       graphModel.clearAllSelectedCases();
-    }
-    if (graphModel.editingMode==="add") {
-      const coords = pointCoordinates(event.offsetX, event.offsetY);
-      addAndSelectPoint(coords);
     }
     graphModel.adornments.forEach(adornment => {
       adornment.toggleSelected();
     });
-  }, [addAndSelectPoint, graphModel, pointCoordinates]);
+  }, [graphModel]);
 
   // Define the dragging behaviors for "edit" mode and for "add" mode, then assemble into one "drag" object.
   const

--- a/src/plugins/graph/models/graph-layer-model.ts
+++ b/src/plugins/graph/models/graph-layer-model.ts
@@ -59,7 +59,9 @@ export const GraphLayerModel = types
       this.updateAdornments(true);
     },
     autoAssignAttributeID(place: GraphPlace, role: GraphAttrRole, dataSetID: string, attrID: string) {
-      this.setAttributeID(role, dataSetID, attrID);
+      // Auto-assignment is system-initiated, so don't mark the attribute as selected.
+      self.config.setAttributeForRole(role, { attributeID: attrID }, false);
+      this.updateAdornments(true);
       self.autoAssignedAttributes.push({ place, role, dataSetID, attrID });
     },
     clearAutoAssignedAttributes() {

--- a/src/plugins/numberline/components/numberline-tile.tsx
+++ b/src/plugins/numberline/components/numberline-tile.tsx
@@ -197,8 +197,14 @@ export const NumberlineTile: React.FC<ITileProps> = observer(function Numberline
 
   const handleMouseClick = (e: Event, optionClicked: CreatePointType) => {
     if (!readOnly){
-      if (hoverPointId) {
-        const hoverPoint = content.getPoint(hoverPointId);
+      // Recompute the hovered point against the click's actual position rather
+      // than trusting the stale hoverPointId from the last mousemove. Without
+      // this, two rapid clicks at different ticks (no mousemove between them —
+      // touchpad taps, cypress synthetic clicks) both target the point created
+      // by the first click, so the second click never creates a new point.
+      const hoveredId = findHoverPoint(e as MouseEvent);
+      if (hoveredId) {
+        const hoverPoint = content.getPoint(hoveredId);
         if (hoverPoint) {
           content.setSelectedPoint(hoverPoint);
           setSelectedPointId(hoverPoint.id);

--- a/src/plugins/numberline/components/numberline-tile.tsx
+++ b/src/plugins/numberline/components/numberline-tile.tsx
@@ -195,14 +195,14 @@ export const NumberlineTile: React.FC<ITileProps> = observer(function Numberline
     return isBetweenYBounds && isBetweenXBounds;
   };
 
-  const handleMouseClick = (e: Event, optionClicked: CreatePointType) => {
+  const handleMouseClick = (e: MouseEvent, optionClicked: CreatePointType) => {
     if (!readOnly){
       // Recompute the hovered point against the click's actual position rather
       // than trusting the stale hoverPointId from the last mousemove. Without
       // this, two rapid clicks at different ticks (no mousemove between them —
       // touchpad taps, cypress synthetic clicks) both target the point created
       // by the first click, so the second click never creates a new point.
-      const hoveredId = findHoverPoint(e as MouseEvent);
+      const hoveredId = findHoverPoint(e);
       if (hoveredId) {
         const hoverPoint = content.getPoint(hoveredId);
         if (hoverPoint) {


### PR DESCRIPTION
> PR 6 of 6. Base: `CLUE-489-5-diagram-drawing`.

## What's in this PR

The remaining per-tile cypress + runtime fixes uncovered by the React 18 upgrade. Each is small and independent; they're grouped together because none of them is large enough to merit its own PR.

### Runtime fixes

- **`xy-plot background`**: drop duplicate point-add from `onClick`. React 18's automatic batching made the duplicate visible.
- **`data-card attribute name`**: select attribute name text on edit-mode entry (under React 18 the input would mount unselected).
- **`bar-graph chart-area`**: don't clear shared selection on blur to a sibling tile.
- **`graph link auto-assigned attribute`**: don't auto-select on link creation.
- **`numberline hover`**: recompute hover state on click, not just mousemove.
- **`dataflow Escape handling`**: use `stopImmediatePropagation` for Escape during connecting state.

### Render-race fixes

- **`document-group`**: gate scroll-button render on `visibleCount > 0` so a pre-ResizeObserver click can't no-op (fixes `teacher_sort_work_view_3_spec`).
- **`graph adornment fade transition`**: replace ref+effect with a `useFadeTransition` hook that holds the fading class as state across unrelated re-renders for the full animation duration (fixes `xy_plot_tool_spec` "Test movable line"). Includes jest coverage for the new hook.

### Cypress timing fixes

- **`dragCardToStack`**: wait between mousemove and mouseup.
- **`teacher_sort_work_view_3`**: scope scroll-button checks to the first section.

## Test plan

- [x] xy-plot, data card, bar-graph, graph linking, numberline, dataflow Escape — manual smoke
- [x] Document group scroll buttons (sort work view) work under fast clicks
- [x] Cypress specs touching these areas pass