### PR TITLE
feat: XY Plot keyboard nav (CLUE-502)

### DIFF
--- a/cypress/e2e/functional/tile_tests/arrow_annotation_spec.js
+++ b/cypress/e2e/functional/tile_tests/arrow_annotation_spec.js
@@ -22,7 +22,8 @@ const tableToolTile = new TableToolTile;
 const textToolTile = new TextToolTile;
 const xyTile = new XYPlotToolTile;
 
-const queryParams = `${Cypress.config("qaConfigSubtabsUnitStudent5")}`;
+const queryParams = `${Cypress.config("qaConfigSubtabsUnitStudent5")}`
+  .replace("fakeUser=student:5", "fakeUser=student:random");
 const queryParamsQa = `${Cypress.config("qaUnitStudent7Investigation3")}`;
 const queryParamsGroup = `${Cypress.config("qaUnitGroup")}&fakeUser=student:15`;
 

--- a/cypress/e2e/functional/tile_tests/xy_plot_tool_keyboard_spec.js
+++ b/cypress/e2e/functional/tile_tests/xy_plot_tool_keyboard_spec.js
@@ -1,0 +1,452 @@
+import ClueCanvas from '../../../support/elements/common/cCanvas';
+import XYPlotToolTile from '../../../support/elements/tile/XYPlotToolTile';
+import TableToolTile from '../../../support/elements/tile/TableToolTile';
+
+const clueCanvas = new ClueCanvas;
+const xyTile = new XYPlotToolTile;
+const tableToolTile = new TableToolTile;
+
+context('XY Plot keyboard accessibility (CLUE-502)', function () {
+  beforeEach(function () {
+    // Use the local qa unit's content.json path rather than the bare `unit=qa`
+    // shorthand. The shorthand resolves to a remote qa unit hosted at
+    // models-resources.concord.org which is in CODAP-legend mode
+    // (defaultSeriesLegend=false) — the local file is CLUE-legend mode
+    // (defaultSeriesLegend=true), which is what these tests assume (Enter on
+    // an axis label starts an inline edit rather than opening the attribute
+    // menu).
+    cy.visit('/?appMode=qa&fakeClass=5&fakeUser=student:5&qaGroup=5'
+      + '&problem=1.1&unit=./demo/units/qa/content.json&noStorage');
+    cy.waitForLoad();
+    clueCanvas.addTile('graph');
+  });
+
+  function selectGraphTile() {
+    xyTile.getTile().click();
+    cy.realPress('Enter');
+    cy.focused().should('have.class', 'editable-tile-title-text');
+  }
+
+  // The empty XY-Plot tile in qa unit (CLUE-legend mode) has this trap cycle:
+  //   title → X-axis → Y-axis → add-series (legend) → toolbar → resize → wrap.
+  // Three things to know:
+  //  - The dots-group surrogate is in the DOM with tabIndex=0, but in an empty
+  //    graph it's 0×0 (the plot area has no rendered content), so the trap's
+  //    visibility filter (`width > 0 && height > 0` for SVG elements) skips it.
+  //    Once a dataset is linked, the plot is sized and the dots-group becomes a
+  //    real Tab stop.
+  //  - The legend (palette slot) always renders an `AddSeriesButton` in CLUE-
+  //    legend mode — it's `aria-disabled` until a linkable dataset exists, but
+  //    it's still focusable, so the trap visits it as the sole palette stop.
+  //  - The toolbar is a single Tab stop with internal arrow-key roving (the
+  //    standard pattern via `useRovingTabindex`), so Tab visits the first
+  //    toolbar button and the next Tab moves on to the resize handle.
+  const emptyFocusOrder = [
+    ['class', 'axis-label'],                         // X-axis label (bottom)
+    ['class', 'axis-label'],                         // Y-axis label (left)
+    ['class', 'add-series-button'],                  // legend's add-series button (palette)
+    ['class', 'toolbar-button'],                     // first toolbar button
+    ['class', 'tool-tile-resize-handle-wrapper'],    // resize handle
+  ];
+
+  function assertFocused([attr, value]) {
+    if (attr === 'class') cy.focused().should('have.class', value);
+    else if (value === '') cy.focused().should('have.attr', attr);
+    else cy.focused().should('have.attr', attr, value);
+  }
+
+  it('Tab cycles through every focus slot of an empty XY Plot in expected order', function () {
+    selectGraphTile();
+
+    emptyFocusOrder.forEach(entry => {
+      cy.realPress('Tab');
+      assertFocused(entry);
+    });
+
+    // One more Tab wraps to the title.
+    cy.realPress('Tab');
+    cy.focused().should('have.class', 'editable-tile-title-text');
+  });
+
+  it('Shift+Tab cycles in reverse through every focus slot of an empty XY Plot', function () {
+    selectGraphTile();
+
+    [...emptyFocusOrder].reverse().forEach(entry => {
+      cy.realPress(['Shift', 'Tab']);
+      assertFocused(entry);
+    });
+
+    // One more Shift+Tab wraps back to the title.
+    cy.realPress(['Shift', 'Tab']);
+    cy.focused().should('have.class', 'editable-tile-title-text');
+  });
+
+  it('Escape exits the trap and returns focus to the .tool-tile container', function () {
+    selectGraphTile();
+    cy.realPress('Tab'); // Title → X-axis label
+    cy.focused().should('have.class', 'axis-label');
+
+    cy.realPress('Escape');
+    cy.focused().should('have.class', 'tool-tile');
+  });
+
+  context('Axis label editing', function () {
+    it('Enter on a focused X-axis label opens the inline editor', function () {
+      selectGraphTile();
+      cy.realPress('Tab'); // Title → X-axis label
+      cy.focused().should('have.class', 'axis-label').and('have.class', 'bottom');
+      cy.realPress('Enter'); // enter edit mode
+      xyTile.getXAxisLabel().should('have.class', 'editing');
+      xyTile.getXAxisInput().should('be.visible');
+    });
+
+    it('Typing then Enter commits the new label and returns focus to the trigger', function () {
+      selectGraphTile();
+      cy.realPress('Tab'); // → X-axis label
+      cy.realPress('Enter'); // enter edit mode
+      xyTile.getXAxisInput().clear().type('Width');
+      cy.realPress('Enter');
+      xyTile.getXAxisLabel().should('contain.text', 'Width');
+      cy.focused().should('have.class', 'axis-label').and('have.class', 'bottom');
+    });
+
+    it('Escape during edit cancels and returns focus to the trigger', function () {
+      selectGraphTile();
+      cy.realPress('Tab');
+      cy.realPress('Enter');
+      xyTile.getXAxisInput().type('Throwaway');
+      cy.realPress('Escape');
+      xyTile.getXAxisLabel().should('not.have.class', 'editing');
+      xyTile.getXAxisLabel().should('not.contain.text', 'Throwaway');
+      cy.focused().should('have.class', 'axis-label').and('have.class', 'bottom');
+    });
+
+    it('Axis label exposes an aria-label that describes the affordance', function () {
+      selectGraphTile();
+      cy.realPress('Tab');
+      cy.focused()
+        .should('have.class', 'axis-label')
+        .invoke('attr', 'aria-label')
+        .should('match', /^X-axis label: .*, press Enter to edit$/);
+    });
+  });
+
+  context('Dots-group surrogate (empty graph)', function () {
+    // In an empty graph (no data linked) the dots-group surrogate's bounding
+    // rect is 0×0, so the trap's visibility filter skips it and Tab goes
+    // directly from Y-axis to the toolbar. The surrogate IS in the DOM with
+    // tabIndex=0, though — that's what these tests pin down. The Tab-from-
+    // Y-axis-into-dots-group routing and arrow navigation through real dots
+    // is exercised in the "Dots-group navigation (with data)" context below.
+    it('Dots-group surrogate is in the DOM with the expected accessibility attributes', function () {
+      xyTile.getTile()
+        .find('[data-graph-dots-group]')
+        .should('exist')
+        .and('have.attr', 'tabindex', '0')
+        .and('have.attr', 'role', 'group')
+        .invoke('attr', 'aria-label')
+        .should('contain', 'Data points');
+    });
+
+    it('Aria-live announcer is rendered inside the tile', function () {
+      // The announcer is unconditional and lives as a direct child of
+      // `.graph-wrapper`. The dots-keyboard hook locates it via
+      // `closest('.graph-wrapper') > :scope > [data-graph-announcer]`.
+      xyTile.getTile()
+        .find('[data-graph-announcer]')
+        .should('exist')
+        .and('have.attr', 'aria-live', 'polite');
+    });
+  });
+
+  context('Dots-group navigation (with data)', function () {
+    // Link a Table tile with three rows so the dots-group is sized and the
+    // trap's visibility filter accepts it as a tab stop. Three distinct dots
+    // are enough to verify the contract of useGraphDotsKeyboard: arrow keys
+    // move focus among them, ArrowRight/ArrowLeft are inverses, and Home/End
+    // land on different extremes. The exact reading-order is deliberately not
+    // pinned down here — that's verified at the unit level for the sort
+    // routine in use-graph-dots-keyboard.
+    beforeEach(function () {
+      clueCanvas.addTile('table');
+      tableToolTile.fillTable(tableToolTile.getTableTile(), [
+        [0, 0],
+        [1, 1],
+        [2, 4],
+      ]);
+      xyTile.getTile().click();
+      clueCanvas.clickToolbarButton('graph', 'link-tile-multiple');
+      xyTile.linkTable('Table Data 1');
+      xyTile.getGraphDot().should('have.length', 3);
+    });
+
+    function tabToDotsGroup() {
+      // Cycle from title: → X-axis → Y-axis → dots-group surrogate.
+      // (With data linked, the dots-group is now sized & visible, so the trap
+      // doesn't skip it — Tab from Y-axis lands here rather than on the legend.)
+      selectGraphTile();
+      cy.realPress('Tab');
+      cy.realPress('Tab');
+      cy.realPress('Tab');
+    }
+
+    // Identify a dot by its (X, Y) coordinate slice of buildDotAriaLabel's output,
+    // independent of trailing suffixes like ", Series: ..." or ", Selected".
+    const pointFromLabel = label => /X=\d+, Y=\d+/.exec(label || '')?.[0];
+
+    it('Tab from the Y-axis label routes into the dots-group surrogate', function () {
+      tabToDotsGroup();
+      cy.focused().then($el => {
+        const insideDotsGroup = $el.closest('[data-graph-dots-group]').length > 0;
+        expect(insideDotsGroup, 'focused element is inside the dots-group').to.be.true;
+      });
+    });
+
+    it('Initial focus into the dots-group lands on a child .graph-dot', function () {
+      tabToDotsGroup();
+      cy.focused()
+        .should('have.class', 'graph-dot')
+        .invoke('attr', 'aria-label')
+        .should('match', /^Point: X=\d/);
+    });
+
+    it('ArrowRight moves focus to a different dot', function () {
+      tabToDotsGroup();
+      cy.focused().invoke('attr', 'aria-label').then(initialLabel => {
+        const initialPoint = pointFromLabel(initialLabel);
+        cy.realPress('ArrowRight');
+        cy.focused()
+          .should('have.class', 'graph-dot')
+          .invoke('attr', 'aria-label')
+          .then(newLabel => {
+            expect(pointFromLabel(newLabel), 'arrow moved focus to a different dot')
+              .to.not.equal(initialPoint);
+          });
+      });
+    });
+
+    it('ArrowRight followed by ArrowLeft returns focus to the original dot', function () {
+      tabToDotsGroup();
+      cy.focused().invoke('attr', 'aria-label').then(initialLabel => {
+        const initialPoint = pointFromLabel(initialLabel);
+        cy.realPress('ArrowRight');
+        cy.realPress('ArrowLeft');
+        cy.focused()
+          .invoke('attr', 'aria-label')
+          .then(returnedLabel => {
+            expect(pointFromLabel(returnedLabel), 'ArrowLeft returned to the original dot')
+              .to.equal(initialPoint);
+          });
+      });
+    });
+
+    it('Home and End focus dots at the extremes of the reading order', function () {
+      tabToDotsGroup();
+      cy.realPress('End');
+      cy.focused().invoke('attr', 'aria-label').then(endLabel => {
+        const endPoint = pointFromLabel(endLabel);
+        cy.realPress('Home');
+        cy.focused()
+          .invoke('attr', 'aria-label')
+          .then(homeLabel => {
+            // The beforeEach links 3 rows, so the extremes must be distinct dots.
+            expect(pointFromLabel(homeLabel), 'Home and End focus different dots')
+              .to.not.equal(endPoint);
+          });
+      });
+    });
+
+    it('Enter on a focused dot leaves it in the selected state', function () {
+      // Enter mirrors `handleClickOnDot`: select if unselected, no-op if already
+      // selected (Shift+Enter is required to deselect). The click in
+      // selectGraphTile() may pre-select the dot at the tile centre, so we can
+      // only assert the post-Enter state, not a state change.
+      tabToDotsGroup();
+      cy.realPress('Enter');
+      cy.focused()
+        .should('have.class', 'graph-dot')
+        .invoke('attr', 'aria-label')
+        .should('match', /, Selected$/);
+    });
+
+    it('Aria-live announcer text mirrors the focused dot after Enter', function () {
+      tabToDotsGroup();
+      cy.realPress('Enter');
+      // After Enter, the hook re-reads the dot's aria-label and routes it to
+      // the announcer via a double-rAF debounce. The two strings should match.
+      cy.focused().invoke('attr', 'aria-label').then(dotLabel => {
+        xyTile.getTile()
+          .find('[data-graph-announcer]')
+          .should('have.text', dotLabel);
+      });
+    });
+  });
+
+  context('Toolbar', function () {
+    it('Tab past the legend lands on the first toolbar button', function () {
+      // Cycle in an empty CLUE-legend graph: title → X-axis → Y-axis →
+      // add-series (legend's only palette stop) → first toolbar button.
+      selectGraphTile();
+      cy.realPress('Tab'); // → X-axis label
+      cy.realPress('Tab'); // → Y-axis label
+      cy.realPress('Tab'); // → add-series-button (legend / palette slot)
+      cy.realPress('Tab'); // → first toolbar button (link-tile-multiple in qa unit)
+      cy.focused()
+        .should('have.class', 'toolbar-button')
+        .and('have.class', 'link-tile-multiple');
+    });
+
+    it('Each registered toolbar button exposes an aria-label', function () {
+      selectGraphTile();
+      // qa unit registers ['link-tile-multiple', 'fit-all', 'toggle-lock'].
+      const expected = [
+        ['link-tile-multiple', 'Add data'],
+        ['fit-all',            'Fit All'],
+        ['toggle-lock',        'Lock Axes'],
+      ];
+      expected.forEach(([name, label]) => {
+        cy.get(`button.toolbar-button.${name}`)
+          .invoke('attr', 'aria-label')
+          .should('eq', label);
+      });
+    });
+
+    it('Disabled toolbar buttons use aria-disabled (still focusable)', function () {
+      selectGraphTile();
+      // link-tile-multiple is disabled until a dataset is linkable. In a fresh
+      // empty graph it's disabled — verify aria-disabled is used (no HTML disabled).
+      cy.get('button.toolbar-button.link-tile-multiple')
+        .invoke('attr', 'aria-disabled')
+        .should('eq', 'true');
+      cy.get('button.toolbar-button.link-tile-multiple')
+        .should('not.have.attr', 'disabled');
+    });
+
+    it('Enter on a focused fit-all button activates it (no exception thrown)', function () {
+      selectGraphTile();
+      // The toolbar is a single Tab stop with arrow-key roving (useRovingTabindex).
+      // Cycle: X-axis → Y-axis → add-series (palette) → toolbar (first button),
+      // then ArrowRight to reach fit-all. In qa unit's tools array
+      // ['link-tile-multiple', 'fit-all', 'toggle-lock'], one ArrowRight from
+      // link-tile-multiple → fit-all.
+      cy.realPress('Tab'); // → X-axis
+      cy.realPress('Tab'); // → Y-axis
+      cy.realPress('Tab'); // → add-series-button (palette)
+      cy.realPress('Tab'); // → toolbar (first button)
+      cy.focused().should('have.class', 'link-tile-multiple');
+      cy.realPress('ArrowRight'); // → fit-all (roving inside toolbar)
+      cy.focused().should('have.class', 'toolbar-button').and('have.class', 'fit-all');
+      // fit-all is an immediate-action button. Pressing Enter triggers
+      // controller.autoscaleAllAxes() — no observable side effect on an empty
+      // graph (no data to scale), but the click should not throw.
+      cy.realPress('Enter');
+      // Focus remains on the toolbar button after activation.
+      cy.focused().should('have.class', 'toolbar-button').and('have.class', 'fit-all');
+    });
+
+    it('toggle-lock flips aria-pressed when activated', function () {
+      selectGraphTile();
+      cy.get('button.toolbar-button.toggle-lock')
+        .invoke('attr', 'aria-pressed')
+        .should('eq', 'false');
+      cy.get('button.toolbar-button.toggle-lock').click();
+      cy.get('button.toolbar-button.toggle-lock')
+        .invoke('attr', 'aria-pressed')
+        .should('eq', 'true');
+    });
+  });
+
+  context('Read-only mode', function () {
+    // The `/editor/` route renders three workspaces side-by-side:
+    //  - the primary (editable) workspace,
+    //  - `.read-only-local-workspace` — a read-only view of the same content,
+    //  - `.read-only-remote-workspace` — a read-only view of a remote copy.
+    // We exercise the type:"region" path via `.read-only-local-workspace`.
+    beforeEach(function () {
+      cy.visit('/editor/?appMode=qa&unit=./demo/units/qa/content.json');
+      cy.get('.editable-document-content', { timeout: 60000 });
+      clueCanvas.addTile('graph');
+    });
+
+    function readOnlyTile() {
+      return cy.get('.read-only-local-workspace .graph-tool-tile');
+    }
+
+    it('Axis labels are focusable with read-only aria-label (no "press Enter to edit" suffix)', function () {
+      readOnlyTile()
+        .find('.axis-label.bottom')
+        .should('have.attr', 'tabindex', '0')
+        .invoke('attr', 'aria-label')
+        .should('match', /^X-axis label: /)
+        .and('not.match', /press Enter to edit/);
+
+      readOnlyTile()
+        .find('.axis-label.left')
+        .should('have.attr', 'tabindex', '0')
+        .invoke('attr', 'aria-label')
+        .and('not.match', /press Enter to edit/);
+    });
+
+    it('Pressing Enter on a focused read-only axis label does NOT open the editor', function () {
+      readOnlyTile()
+        .find('.axis-label.bottom')
+        .focus();
+      cy.realPress('Enter');
+      readOnlyTile().find('.axis-label.bottom .input-textbox').should('not.exist');
+    });
+
+    it('Dots-group surrogate is present and tab-focusable in read-only mode', function () {
+      readOnlyTile()
+        .find('[data-graph-dots-group]')
+        .should('exist')
+        .and('have.attr', 'tabindex', '0')
+        .and('have.attr', 'role', 'group');
+    });
+
+    it('Aria-live announcer container is rendered in read-only mode', function () {
+      readOnlyTile()
+        .find('[data-graph-announcer]')
+        .should('exist')
+        .and('have.attr', 'aria-live', 'polite');
+    });
+  });
+
+  context('Link-tile dialog focus management', function () {
+    // The link-tile button is enabled when ANY linkable shared model
+    // (SharedDataSet, SharedVariables) is registered in the document.
+    // A Table tile registers a SharedDataSet on mount, so adding the tile
+    // alone — without populating any cells — is sufficient to enable the
+    // graph's link button (see `useProviderTileLinking.isLinkEnabled`).
+    beforeEach(function () {
+      clueCanvas.addTile('table');
+      tableToolTile.getTableTile().should('be.visible');
+    });
+
+    it('Enter on the link-tile button opens the link dialog and moves focus inside', function () {
+      // qa unit's tools array is ['link-tile-multiple', 'fit-all', 'toggle-lock'],
+      // so the first toolbar button is `link-tile-multiple`. Both link-tile and
+      // link-tile-multiple call into `useProviderTileLinking → showLinkTileDialog`
+      // and open the same dialog.
+      xyTile.getTile().click();
+      cy.get('button.toolbar-button.link-tile-multiple').focus();
+      cy.realPress('Enter');
+
+      // The dialog mounts as `.custom-modal.link-tile`. Focus should be inside it.
+      xyTile.getCustomModal().should('be.visible');
+      cy.focused().then($el => {
+        expect($el.closest('.custom-modal').length, 'focused element is inside the dialog')
+          .to.be.greaterThan(0);
+      });
+    });
+
+    it('Escape closes the link-tile dialog', function () {
+      xyTile.getTile().click();
+      cy.get('button.toolbar-button.link-tile-multiple').focus();
+      cy.realPress('Enter');
+      xyTile.getCustomModal().should('be.visible');
+
+      cy.realPress('Escape');
+      xyTile.getCustomModal().should('not.exist');
+    });
+  });
+});

--- a/cypress/e2e/functional/tile_tests/xy_plot_tool_keyboard_spec.js
+++ b/cypress/e2e/functional/tile_tests/xy_plot_tool_keyboard_spec.js
@@ -248,16 +248,18 @@ context('XY Plot keyboard accessibility (CLUE-502)', function () {
         });
       });
 
-      cy.log('Enter on a focused dot leaves it in the selected state (mirrors handleClickOnDot)');
-      // Enter mirrors handleClickOnDot: select if unselected, no-op if already
-      // selected (Shift+Enter is required to deselect). The click in
-      // selectGraphTile() may pre-select the dot at the tile centre, so we can
-      // only assert the post-Enter state, not a state change.
-      cy.realPress('Enter');
-      cy.focused()
-        .should('have.class', 'graph-dot')
-        .invoke('attr', 'aria-label')
-        .should('match', /, Selected$/);
+      cy.log('Enter on a focused dot toggles its selection state (aria toggle-button semantics)');
+      cy.focused().invoke('attr', 'aria-label').then(beforeLabel => {
+        const wasSelected = /, Selected$/.test(beforeLabel);
+        cy.realPress('Enter');
+        cy.focused()
+          .should('have.class', 'graph-dot')
+          .invoke('attr', 'aria-label')
+          .then(afterLabel => {
+            const isSelected = /, Selected$/.test(afterLabel);
+            expect(isSelected, 'Enter toggled selection state').to.equal(!wasSelected);
+          });
+      });
 
       cy.log('Aria-live announcer text mirrors the focused dot after Enter');
       // The hook re-reads the dot's aria-label and routes it to the announcer

--- a/cypress/e2e/functional/tile_tests/xy_plot_tool_keyboard_spec.js
+++ b/cypress/e2e/functional/tile_tests/xy_plot_tool_keyboard_spec.js
@@ -26,23 +26,29 @@ context('XY Plot keyboard accessibility (CLUE-502)', function () {
   }
 
   // The empty XY-Plot in qa unit (CLUE-legend mode) has this trap cycle:
-  //   title → X-axis → Y-axis → add-series (palette) → toolbar → resize → wrap.
+  //   title → X-label → Y-label → X-min → X-max → Y-min → Y-max
+  //         → add-series (palette) → toolbar → resize → wrap.
   //  - The dots-group surrogate is in the DOM but 0×0 on an empty plot, so the
   //    trap's visibility filter skips it. Once a dataset is linked it becomes
-  //    a real Tab stop (see the "Dots-group navigation (with data)" context).
+  //    a real Tab stop (between the labels and the min/max bound controls).
+  //  - The axis min/max bound controls (`.editable-border-box`) are
+  //    absolutely-positioned HTML divs that live inside the trap's content
+  //    slot via the `.graph-content-area` wrapper.
   //  - The legend palette always renders AddSeriesButton; it's aria-disabled
   //    until a linkable dataset exists but stays focusable, so the trap visits it.
   //  - The toolbar is a single Tab stop with internal arrow-key roving
-  //    (useRovingTabindex), so Tab visits the first toolbar button then jumps
-  //    on to the resize handle.
-  // Direction-agnostic — the toolbar is a single roving tab stop, so forward
-  // Tab into it lands on the first button (link-tile-multiple) while Shift+Tab
-  // from the resize handle lands on the last (toggle-lock). Both still match
-  // the generic `toolbar-button` class. The specific "first button is
-  // link-tile-multiple" assertion lives in the ArrowRight roving section below.
+  //    (useRovingTabindex). Direction-agnostic match: forward Tab lands on
+  //    the first button (link-tile-multiple); reverse from the resize handle
+  //    lands on the last (toggle-lock). Both still match `toolbar-button`.
+  //    The specific "first button is link-tile-multiple" assertion lives in
+  //    the ArrowRight roving section below.
   const emptyFocusOrder = [
     ['class', 'axis-label'],                         // X-axis label (bottom)
     ['class', 'axis-label'],                         // Y-axis label (left)
+    ['class', 'editable-border-box'],                // X-axis min
+    ['class', 'editable-border-box'],                // X-axis max
+    ['class', 'editable-border-box'],                // Y-axis min
+    ['class', 'editable-border-box'],                // Y-axis max
     ['class', 'add-series-button'],                  // legend palette
     ['class', 'toolbar-button'],                     // toolbar (either end of the roving range)
     ['class', 'tool-tile-resize-handle-wrapper'],    // resize handle
@@ -102,6 +108,20 @@ context('XY Plot keyboard accessibility (CLUE-502)', function () {
     xyTile.getXAxisLabel().should('contain.text', 'Width');
     cy.focused().should('have.class', 'axis-label').and('have.class', 'bottom');
 
+    cy.log('Tabbing past the Y-axis label lands on the X-axis min bound control');
+    cy.realPress('Tab'); // → Y-axis label
+    cy.realPress('Tab'); // → X-axis min (first .editable-border-box in DOM order)
+    cy.focused()
+      .should('have.attr', 'data-testid', 'editable-border-box-bottom-min')
+      .invoke('attr', 'aria-label')
+      .should('match', /^X-axis minimum: .*, press Enter to edit$/);
+
+    cy.log('Enter on a focused bound opens its numeric editor; Escape cancels and returns focus');
+    cy.realPress('Enter');
+    cy.get('[data-testid="editable-border-box-bottom-min"] .input-textbox').should('be.visible');
+    cy.realPress('Escape');
+    cy.focused().should('have.attr', 'data-testid', 'editable-border-box-bottom-min');
+
     cy.log('Dots-group surrogate and aria-live announcer scaffolding are present');
     xyTile.getTile()
       .find('[data-graph-dots-group]')
@@ -131,9 +151,12 @@ context('XY Plot keyboard accessibility (CLUE-502)', function () {
       .should('not.have.attr', 'disabled');
 
     cy.log('ArrowRight roves within the toolbar; Enter on fit-all activates without throwing');
-    // Currently inside the trap with focus on axis-label.bottom (from the
-    // Width{enter} commit). Tab forward: Y-axis → add-series → toolbar.
-    cy.realPress('Tab'); // → Y-axis
+    // Currently inside the trap with focus on X-axis min (from the bound-edit
+    // section above). Tab forward through remaining content focusables
+    // (X-max, Y-min, Y-max), then through the palette to the toolbar.
+    cy.realPress('Tab'); // → X-axis max
+    cy.realPress('Tab'); // → Y-axis min
+    cy.realPress('Tab'); // → Y-axis max
     cy.realPress('Tab'); // → add-series (palette)
     cy.realPress('Tab'); // → first toolbar button (link-tile-multiple)
     cy.focused().should('have.class', 'link-tile-multiple');

--- a/cypress/e2e/functional/tile_tests/xy_plot_tool_keyboard_spec.js
+++ b/cypress/e2e/functional/tile_tests/xy_plot_tool_keyboard_spec.js
@@ -8,15 +8,13 @@ const tableToolTile = new TableToolTile;
 
 context('XY Plot keyboard accessibility (CLUE-502)', function () {
   beforeEach(function () {
-    // Use the local qa unit's content.json path rather than the bare `unit=qa`
-    // shorthand. The shorthand resolves to a remote qa unit hosted at
-    // models-resources.concord.org which is in CODAP-legend mode
-    // (defaultSeriesLegend=false) — the local file is CLUE-legend mode
+    // Use the local qa unit's content.json rather than the bare `unit=qa`
+    // shorthand. The shorthand resolves to a remote qa unit in CODAP-legend
+    // mode (defaultSeriesLegend=false); the local file is CLUE-legend mode
     // (defaultSeriesLegend=true), which is what these tests assume (Enter on
-    // an axis label starts an inline edit rather than opening the attribute
-    // menu).
+    // an axis label starts an inline edit rather than opening the attr menu).
     cy.visit('/?appMode=qa&fakeClass=5&fakeUser=student:5&qaGroup=5'
-      + '&problem=1.1&unit=./demo/units/qa/content.json&noStorage');
+      + '&unit=./demo/units/qa/content.json&noStorage');
     cy.waitForLoad();
     clueCanvas.addTile('graph');
   });
@@ -27,25 +25,26 @@ context('XY Plot keyboard accessibility (CLUE-502)', function () {
     cy.focused().should('have.class', 'editable-tile-title-text');
   }
 
-  // The empty XY-Plot tile in qa unit (CLUE-legend mode) has this trap cycle:
-  //   title → X-axis → Y-axis → add-series (legend) → toolbar → resize → wrap.
-  // Three things to know:
-  //  - The dots-group surrogate is in the DOM with tabIndex=0, but in an empty
-  //    graph it's 0×0 (the plot area has no rendered content), so the trap's
-  //    visibility filter (`width > 0 && height > 0` for SVG elements) skips it.
-  //    Once a dataset is linked, the plot is sized and the dots-group becomes a
-  //    real Tab stop.
-  //  - The legend (palette slot) always renders an `AddSeriesButton` in CLUE-
-  //    legend mode — it's `aria-disabled` until a linkable dataset exists, but
-  //    it's still focusable, so the trap visits it as the sole palette stop.
-  //  - The toolbar is a single Tab stop with internal arrow-key roving (the
-  //    standard pattern via `useRovingTabindex`), so Tab visits the first
-  //    toolbar button and the next Tab moves on to the resize handle.
+  // The empty XY-Plot in qa unit (CLUE-legend mode) has this trap cycle:
+  //   title → X-axis → Y-axis → add-series (palette) → toolbar → resize → wrap.
+  //  - The dots-group surrogate is in the DOM but 0×0 on an empty plot, so the
+  //    trap's visibility filter skips it. Once a dataset is linked it becomes
+  //    a real Tab stop (see the "Dots-group navigation (with data)" context).
+  //  - The legend palette always renders AddSeriesButton; it's aria-disabled
+  //    until a linkable dataset exists but stays focusable, so the trap visits it.
+  //  - The toolbar is a single Tab stop with internal arrow-key roving
+  //    (useRovingTabindex), so Tab visits the first toolbar button then jumps
+  //    on to the resize handle.
+  // Direction-agnostic — the toolbar is a single roving tab stop, so forward
+  // Tab into it lands on the first button (link-tile-multiple) while Shift+Tab
+  // from the resize handle lands on the last (toggle-lock). Both still match
+  // the generic `toolbar-button` class. The specific "first button is
+  // link-tile-multiple" assertion lives in the ArrowRight roving section below.
   const emptyFocusOrder = [
     ['class', 'axis-label'],                         // X-axis label (bottom)
     ['class', 'axis-label'],                         // Y-axis label (left)
-    ['class', 'add-series-button'],                  // legend's add-series button (palette)
-    ['class', 'toolbar-button'],                     // first toolbar button
+    ['class', 'add-series-button'],                  // legend palette
+    ['class', 'toolbar-button'],                     // toolbar (either end of the roving range)
     ['class', 'tool-tile-resize-handle-wrapper'],    // resize handle
   ];
 
@@ -55,118 +54,111 @@ context('XY Plot keyboard accessibility (CLUE-502)', function () {
     else cy.focused().should('have.attr', attr, value);
   }
 
-  it('Tab cycles through every focus slot of an empty XY Plot in expected order', function () {
+  it('Empty XY Plot — tab cycling, axis-label editing, surrogate scaffold, toolbar contracts', function () {
     selectGraphTile();
 
+    cy.log('Tab cycles forward through every focus slot, then wraps to title');
     emptyFocusOrder.forEach(entry => {
       cy.realPress('Tab');
       assertFocused(entry);
     });
-
-    // One more Tab wraps to the title.
     cy.realPress('Tab');
     cy.focused().should('have.class', 'editable-tile-title-text');
-  });
 
-  it('Shift+Tab cycles in reverse through every focus slot of an empty XY Plot', function () {
-    selectGraphTile();
-
+    cy.log('Shift+Tab cycles in reverse, then wraps to title');
     [...emptyFocusOrder].reverse().forEach(entry => {
       cy.realPress(['Shift', 'Tab']);
       assertFocused(entry);
     });
-
-    // One more Shift+Tab wraps back to the title.
     cy.realPress(['Shift', 'Tab']);
     cy.focused().should('have.class', 'editable-tile-title-text');
-  });
 
-  it('Escape exits the trap and returns focus to the .tool-tile container', function () {
-    selectGraphTile();
-    cy.realPress('Tab'); // Title → X-axis label
-    cy.focused().should('have.class', 'axis-label');
-
+    cy.log('Escape exits the trap to the .tool-tile container');
+    cy.realPress('Tab'); // → X-axis label
     cy.realPress('Escape');
     cy.focused().should('have.class', 'tool-tile');
-  });
 
-  context('Axis label editing', function () {
-    it('Enter on a focused X-axis label opens the inline editor', function () {
-      selectGraphTile();
-      cy.realPress('Tab'); // Title → X-axis label
-      cy.focused().should('have.class', 'axis-label').and('have.class', 'bottom');
-      cy.realPress('Enter'); // enter edit mode
-      xyTile.getXAxisLabel().should('have.class', 'editing');
-      xyTile.getXAxisInput().should('be.visible');
-    });
+    cy.log('X-axis label exposes the "press Enter to edit" affordance in aria-label');
+    selectGraphTile(); // re-enter trap
+    cy.realPress('Tab'); // → X-axis
+    cy.focused()
+      .should('have.class', 'axis-label')
+      .invoke('attr', 'aria-label')
+      .should('match', /^X-axis label: .*, press Enter to edit$/);
 
-    it('Typing then Enter commits the new label and returns focus to the trigger', function () {
-      selectGraphTile();
-      cy.realPress('Tab'); // → X-axis label
-      cy.realPress('Enter'); // enter edit mode
-      xyTile.getXAxisInput().clear().type('Width');
-      cy.realPress('Enter');
-      xyTile.getXAxisLabel().should('contain.text', 'Width');
-      cy.focused().should('have.class', 'axis-label').and('have.class', 'bottom');
-    });
+    cy.log('Enter opens inline editor; Escape cancels without committing');
+    cy.realPress('Enter');
+    xyTile.getXAxisLabel().should('have.class', 'editing');
+    xyTile.getXAxisInput().should('be.visible');
+    xyTile.getXAxisInput().type('Throwaway');
+    cy.realPress('Escape');
+    xyTile.getXAxisLabel().should('not.have.class', 'editing');
+    xyTile.getXAxisLabel().should('not.contain.text', 'Throwaway');
+    cy.focused().should('have.class', 'axis-label').and('have.class', 'bottom');
 
-    it('Escape during edit cancels and returns focus to the trigger', function () {
-      selectGraphTile();
-      cy.realPress('Tab');
-      cy.realPress('Enter');
-      xyTile.getXAxisInput().type('Throwaway');
-      cy.realPress('Escape');
-      xyTile.getXAxisLabel().should('not.have.class', 'editing');
-      xyTile.getXAxisLabel().should('not.contain.text', 'Throwaway');
-      cy.focused().should('have.class', 'axis-label').and('have.class', 'bottom');
-    });
+    cy.log('Typing then Enter commits the new label and returns focus to the trigger');
+    cy.realPress('Enter'); // re-open editor
+    xyTile.getXAxisInput().clear().type('Width{enter}');
+    xyTile.getXAxisLabel().should('contain.text', 'Width');
+    cy.focused().should('have.class', 'axis-label').and('have.class', 'bottom');
 
-    it('Axis label exposes an aria-label that describes the affordance', function () {
-      selectGraphTile();
-      cy.realPress('Tab');
-      cy.focused()
-        .should('have.class', 'axis-label')
-        .invoke('attr', 'aria-label')
-        .should('match', /^X-axis label: .*, press Enter to edit$/);
-    });
-  });
+    cy.log('Dots-group surrogate and aria-live announcer scaffolding are present');
+    xyTile.getTile()
+      .find('[data-graph-dots-group]')
+      .should('exist')
+      .and('have.attr', 'tabindex', '0')
+      .and('have.attr', 'role', 'group')
+      .invoke('attr', 'aria-label')
+      .should('contain', 'Data points');
+    xyTile.getTile()
+      .find('[data-graph-announcer]')
+      .should('exist')
+      .and('have.attr', 'aria-live', 'polite');
 
-  context('Dots-group surrogate (empty graph)', function () {
-    // In an empty graph (no data linked) the dots-group surrogate's bounding
-    // rect is 0×0, so the trap's visibility filter skips it and Tab goes
-    // directly from Y-axis to the toolbar. The surrogate IS in the DOM with
-    // tabIndex=0, though — that's what these tests pin down. The Tab-from-
-    // Y-axis-into-dots-group routing and arrow navigation through real dots
-    // is exercised in the "Dots-group navigation (with data)" context below.
-    it('Dots-group surrogate is in the DOM with the expected accessibility attributes', function () {
-      xyTile.getTile()
-        .find('[data-graph-dots-group]')
-        .should('exist')
-        .and('have.attr', 'tabindex', '0')
-        .and('have.attr', 'role', 'group')
-        .invoke('attr', 'aria-label')
-        .should('contain', 'Data points');
+    cy.log('Toolbar buttons: aria-label per button; disabled use aria-disabled (not HTML disabled)');
+    const toolbarExpected = [
+      ['link-tile-multiple', 'Add data'],
+      ['fit-all',            'Fit All'],
+      ['toggle-lock',        'Lock Axes'],
+    ];
+    toolbarExpected.forEach(([name, label]) => {
+      cy.get(`button.toolbar-button.${name}`)
+        .invoke('attr', 'aria-label').should('eq', label);
     });
+    cy.get('button.toolbar-button.link-tile-multiple')
+      .invoke('attr', 'aria-disabled').should('eq', 'true');
+    cy.get('button.toolbar-button.link-tile-multiple')
+      .should('not.have.attr', 'disabled');
 
-    it('Aria-live announcer is rendered inside the tile', function () {
-      // The announcer is unconditional and lives as a direct child of
-      // `.graph-wrapper`. The dots-keyboard hook locates it via
-      // `closest('.graph-wrapper') > :scope > [data-graph-announcer]`.
-      xyTile.getTile()
-        .find('[data-graph-announcer]')
-        .should('exist')
-        .and('have.attr', 'aria-live', 'polite');
-    });
+    cy.log('ArrowRight roves within the toolbar; Enter on fit-all activates without throwing');
+    // Currently inside the trap with focus on axis-label.bottom (from the
+    // Width{enter} commit). Tab forward: Y-axis → add-series → toolbar.
+    cy.realPress('Tab'); // → Y-axis
+    cy.realPress('Tab'); // → add-series (palette)
+    cy.realPress('Tab'); // → first toolbar button (link-tile-multiple)
+    cy.focused().should('have.class', 'link-tile-multiple');
+    cy.realPress('ArrowRight'); // roving → fit-all
+    cy.focused().should('have.class', 'toolbar-button').and('have.class', 'fit-all');
+    // fit-all is an immediate-action button — no observable side effect on an
+    // empty graph (no data to scale), but the activation should not throw.
+    cy.realPress('Enter');
+    cy.focused().should('have.class', 'toolbar-button').and('have.class', 'fit-all');
+
+    cy.log('toggle-lock flips aria-pressed when activated');
+    cy.get('button.toolbar-button.toggle-lock')
+      .invoke('attr', 'aria-pressed').should('eq', 'false');
+    cy.get('button.toolbar-button.toggle-lock').click();
+    cy.get('button.toolbar-button.toggle-lock')
+      .invoke('attr', 'aria-pressed').should('eq', 'true');
   });
 
   context('Dots-group navigation (with data)', function () {
     // Link a Table tile with three rows so the dots-group is sized and the
     // trap's visibility filter accepts it as a tab stop. Three distinct dots
-    // are enough to verify the contract of useGraphDotsKeyboard: arrow keys
-    // move focus among them, ArrowRight/ArrowLeft are inverses, and Home/End
-    // land on different extremes. The exact reading-order is deliberately not
-    // pinned down here — that's verified at the unit level for the sort
-    // routine in use-graph-dots-keyboard.
+    // suffice to verify the useGraphDotsKeyboard contract: arrow keys move
+    // focus among them, ArrowRight/ArrowLeft are inverses, and Home/End land
+    // on different extremes. The exact reading-order is deliberately not
+    // pinned down here — the sort routine is covered at the unit level.
     beforeEach(function () {
       clueCanvas.addTile('table');
       tableToolTile.fillTable(tableToolTile.getTableTile(), [
@@ -180,100 +172,73 @@ context('XY Plot keyboard accessibility (CLUE-502)', function () {
       xyTile.getGraphDot().should('have.length', 3);
     });
 
-    function tabToDotsGroup() {
-      // Cycle from title: → X-axis → Y-axis → dots-group surrogate.
-      // (With data linked, the dots-group is now sized & visible, so the trap
-      // doesn't skip it — Tab from Y-axis lands here rather than on the legend.)
-      selectGraphTile();
-      cy.realPress('Tab');
-      cy.realPress('Tab');
-      cy.realPress('Tab');
-    }
-
-    // Identify a dot by its (X, Y) coordinate slice of buildDotAriaLabel's output,
+    // Identify a dot by its (X, Y) slice of buildDotAriaLabel's output,
     // independent of trailing suffixes like ", Series: ..." or ", Selected".
     const pointFromLabel = label => /X=\d+, Y=\d+/.exec(label || '')?.[0];
 
-    it('Tab from the Y-axis label routes into the dots-group surrogate', function () {
-      tabToDotsGroup();
-      cy.focused().then($el => {
-        const insideDotsGroup = $el.closest('[data-graph-dots-group]').length > 0;
-        expect(insideDotsGroup, 'focused element is inside the dots-group').to.be.true;
-      });
-    });
+    it('Dots-group keyboard contract (tab routing, arrow nav, Home/End, Enter, announcer)', function () {
+      selectGraphTile();
+      cy.realPress('Tab'); // → X-axis
+      cy.realPress('Tab'); // → Y-axis
+      cy.realPress('Tab'); // → dots-group surrogate (sized now that data is linked)
 
-    it('Initial focus into the dots-group lands on a child .graph-dot', function () {
-      tabToDotsGroup();
+      cy.log('Tab from Y-axis routes focus into the dots-group (or its child .graph-dot)');
+      cy.focused().then($el => {
+        expect($el.closest('[data-graph-dots-group]').length,
+          'focused element is inside the dots-group').to.be.greaterThan(0);
+      });
+
+      cy.log('Initial focus lands on a child .graph-dot whose aria-label starts with "Point: X=…"');
       cy.focused()
         .should('have.class', 'graph-dot')
         .invoke('attr', 'aria-label')
-        .should('match', /^Point: X=\d/);
-    });
+        .then(initialLabel => {
+          expect(initialLabel).to.match(/^Point: X=\d/);
+          const initialPoint = pointFromLabel(initialLabel);
 
-    it('ArrowRight moves focus to a different dot', function () {
-      tabToDotsGroup();
-      cy.focused().invoke('attr', 'aria-label').then(initialLabel => {
-        const initialPoint = pointFromLabel(initialLabel);
-        cy.realPress('ArrowRight');
-        cy.focused()
-          .should('have.class', 'graph-dot')
-          .invoke('attr', 'aria-label')
-          .then(newLabel => {
-            expect(pointFromLabel(newLabel), 'arrow moved focus to a different dot')
-              .to.not.equal(initialPoint);
-          });
-      });
-    });
+          cy.log('ArrowRight moves focus to a different dot, ArrowLeft returns to the original');
+          cy.realPress('ArrowRight');
+          cy.focused()
+            .should('have.class', 'graph-dot')
+            .invoke('attr', 'aria-label')
+            .then(newLabel => {
+              expect(pointFromLabel(newLabel),
+                'ArrowRight moved focus to a different dot').to.not.equal(initialPoint);
+              cy.realPress('ArrowLeft');
+              cy.focused()
+                .invoke('attr', 'aria-label')
+                .then(returnedLabel => {
+                  expect(pointFromLabel(returnedLabel),
+                    'ArrowLeft returned to the original dot').to.equal(initialPoint);
+                });
+            });
+        });
 
-    it('ArrowRight followed by ArrowLeft returns focus to the original dot', function () {
-      tabToDotsGroup();
-      cy.focused().invoke('attr', 'aria-label').then(initialLabel => {
-        const initialPoint = pointFromLabel(initialLabel);
-        cy.realPress('ArrowRight');
-        cy.realPress('ArrowLeft');
-        cy.focused()
-          .invoke('attr', 'aria-label')
-          .then(returnedLabel => {
-            expect(pointFromLabel(returnedLabel), 'ArrowLeft returned to the original dot')
-              .to.equal(initialPoint);
-          });
-      });
-    });
-
-    it('Home and End focus dots at the extremes of the reading order', function () {
-      tabToDotsGroup();
+      cy.log('Home and End focus distinct dots (the extremes of the reading order)');
       cy.realPress('End');
       cy.focused().invoke('attr', 'aria-label').then(endLabel => {
         const endPoint = pointFromLabel(endLabel);
         cy.realPress('Home');
-        cy.focused()
-          .invoke('attr', 'aria-label')
-          .then(homeLabel => {
-            // The beforeEach links 3 rows, so the extremes must be distinct dots.
-            expect(pointFromLabel(homeLabel), 'Home and End focus different dots')
-              .to.not.equal(endPoint);
-          });
+        cy.focused().invoke('attr', 'aria-label').then(homeLabel => {
+          expect(pointFromLabel(homeLabel),
+            'Home and End focus different dots').to.not.equal(endPoint);
+        });
       });
-    });
 
-    it('Enter on a focused dot leaves it in the selected state', function () {
-      // Enter mirrors `handleClickOnDot`: select if unselected, no-op if already
+      cy.log('Enter on a focused dot leaves it in the selected state (mirrors handleClickOnDot)');
+      // Enter mirrors handleClickOnDot: select if unselected, no-op if already
       // selected (Shift+Enter is required to deselect). The click in
       // selectGraphTile() may pre-select the dot at the tile centre, so we can
       // only assert the post-Enter state, not a state change.
-      tabToDotsGroup();
       cy.realPress('Enter');
       cy.focused()
         .should('have.class', 'graph-dot')
         .invoke('attr', 'aria-label')
         .should('match', /, Selected$/);
-    });
 
-    it('Aria-live announcer text mirrors the focused dot after Enter', function () {
-      tabToDotsGroup();
-      cy.realPress('Enter');
-      // After Enter, the hook re-reads the dot's aria-label and routes it to
-      // the announcer via a double-rAF debounce. The two strings should match.
+      cy.log('Aria-live announcer text mirrors the focused dot after Enter');
+      // The hook re-reads the dot's aria-label and routes it to the announcer
+      // via a double-rAF debounce; Cypress's auto-retry synchronises us with it.
       cy.focused().invoke('attr', 'aria-label').then(dotLabel => {
         xyTile.getTile()
           .find('[data-graph-announcer]')
@@ -282,86 +247,10 @@ context('XY Plot keyboard accessibility (CLUE-502)', function () {
     });
   });
 
-  context('Toolbar', function () {
-    it('Tab past the legend lands on the first toolbar button', function () {
-      // Cycle in an empty CLUE-legend graph: title → X-axis → Y-axis →
-      // add-series (legend's only palette stop) → first toolbar button.
-      selectGraphTile();
-      cy.realPress('Tab'); // → X-axis label
-      cy.realPress('Tab'); // → Y-axis label
-      cy.realPress('Tab'); // → add-series-button (legend / palette slot)
-      cy.realPress('Tab'); // → first toolbar button (link-tile-multiple in qa unit)
-      cy.focused()
-        .should('have.class', 'toolbar-button')
-        .and('have.class', 'link-tile-multiple');
-    });
-
-    it('Each registered toolbar button exposes an aria-label', function () {
-      selectGraphTile();
-      // qa unit registers ['link-tile-multiple', 'fit-all', 'toggle-lock'].
-      const expected = [
-        ['link-tile-multiple', 'Add data'],
-        ['fit-all',            'Fit All'],
-        ['toggle-lock',        'Lock Axes'],
-      ];
-      expected.forEach(([name, label]) => {
-        cy.get(`button.toolbar-button.${name}`)
-          .invoke('attr', 'aria-label')
-          .should('eq', label);
-      });
-    });
-
-    it('Disabled toolbar buttons use aria-disabled (still focusable)', function () {
-      selectGraphTile();
-      // link-tile-multiple is disabled until a dataset is linkable. In a fresh
-      // empty graph it's disabled — verify aria-disabled is used (no HTML disabled).
-      cy.get('button.toolbar-button.link-tile-multiple')
-        .invoke('attr', 'aria-disabled')
-        .should('eq', 'true');
-      cy.get('button.toolbar-button.link-tile-multiple')
-        .should('not.have.attr', 'disabled');
-    });
-
-    it('Enter on a focused fit-all button activates it (no exception thrown)', function () {
-      selectGraphTile();
-      // The toolbar is a single Tab stop with arrow-key roving (useRovingTabindex).
-      // Cycle: X-axis → Y-axis → add-series (palette) → toolbar (first button),
-      // then ArrowRight to reach fit-all. In qa unit's tools array
-      // ['link-tile-multiple', 'fit-all', 'toggle-lock'], one ArrowRight from
-      // link-tile-multiple → fit-all.
-      cy.realPress('Tab'); // → X-axis
-      cy.realPress('Tab'); // → Y-axis
-      cy.realPress('Tab'); // → add-series-button (palette)
-      cy.realPress('Tab'); // → toolbar (first button)
-      cy.focused().should('have.class', 'link-tile-multiple');
-      cy.realPress('ArrowRight'); // → fit-all (roving inside toolbar)
-      cy.focused().should('have.class', 'toolbar-button').and('have.class', 'fit-all');
-      // fit-all is an immediate-action button. Pressing Enter triggers
-      // controller.autoscaleAllAxes() — no observable side effect on an empty
-      // graph (no data to scale), but the click should not throw.
-      cy.realPress('Enter');
-      // Focus remains on the toolbar button after activation.
-      cy.focused().should('have.class', 'toolbar-button').and('have.class', 'fit-all');
-    });
-
-    it('toggle-lock flips aria-pressed when activated', function () {
-      selectGraphTile();
-      cy.get('button.toolbar-button.toggle-lock')
-        .invoke('attr', 'aria-pressed')
-        .should('eq', 'false');
-      cy.get('button.toolbar-button.toggle-lock').click();
-      cy.get('button.toolbar-button.toggle-lock')
-        .invoke('attr', 'aria-pressed')
-        .should('eq', 'true');
-    });
-  });
-
   context('Read-only mode', function () {
-    // The `/editor/` route renders three workspaces side-by-side:
-    //  - the primary (editable) workspace,
-    //  - `.read-only-local-workspace` — a read-only view of the same content,
-    //  - `.read-only-remote-workspace` — a read-only view of a remote copy.
-    // We exercise the type:"region" path via `.read-only-local-workspace`.
+    // The `/editor/` route renders the editable workspace plus
+    // `.read-only-local-workspace` (a read-only view of the same content). We
+    // exercise the type:"region" path via the read-only workspace.
     beforeEach(function () {
       cy.visit('/editor/?appMode=qa&unit=./demo/units/qa/content.json');
       cy.get('.editable-document-content', { timeout: 60000 });
@@ -372,38 +261,31 @@ context('XY Plot keyboard accessibility (CLUE-502)', function () {
       return cy.get('.read-only-local-workspace .graph-tool-tile');
     }
 
-    it('Axis labels are focusable with read-only aria-label (no "press Enter to edit" suffix)', function () {
+    it('Read-only XY Plot exposes accessible scaffold without editing affordances', function () {
+      cy.log('Axis labels are focusable; aria-label omits the "press Enter to edit" suffix');
       readOnlyTile()
         .find('.axis-label.bottom')
         .should('have.attr', 'tabindex', '0')
         .invoke('attr', 'aria-label')
         .should('match', /^X-axis label: /)
         .and('not.match', /press Enter to edit/);
-
       readOnlyTile()
         .find('.axis-label.left')
         .should('have.attr', 'tabindex', '0')
         .invoke('attr', 'aria-label')
         .and('not.match', /press Enter to edit/);
-    });
 
-    it('Pressing Enter on a focused read-only axis label does NOT open the editor', function () {
-      readOnlyTile()
-        .find('.axis-label.bottom')
-        .focus();
+      cy.log('Enter on a focused read-only axis label does NOT open the inline editor');
+      readOnlyTile().find('.axis-label.bottom').focus();
       cy.realPress('Enter');
       readOnlyTile().find('.axis-label.bottom .input-textbox').should('not.exist');
-    });
 
-    it('Dots-group surrogate is present and tab-focusable in read-only mode', function () {
+      cy.log('Dots-group surrogate and aria-live announcer are still rendered');
       readOnlyTile()
         .find('[data-graph-dots-group]')
         .should('exist')
         .and('have.attr', 'tabindex', '0')
         .and('have.attr', 'role', 'group');
-    });
-
-    it('Aria-live announcer container is rendered in read-only mode', function () {
       readOnlyTile()
         .find('[data-graph-announcer]')
         .should('exist')
@@ -412,39 +294,31 @@ context('XY Plot keyboard accessibility (CLUE-502)', function () {
   });
 
   context('Link-tile dialog focus management', function () {
-    // The link-tile button is enabled when ANY linkable shared model
-    // (SharedDataSet, SharedVariables) is registered in the document.
-    // A Table tile registers a SharedDataSet on mount, so adding the tile
-    // alone — without populating any cells — is sufficient to enable the
-    // graph's link button (see `useProviderTileLinking.isLinkEnabled`).
+    // The link-tile button is enabled when any linkable shared model
+    // (SharedDataSet, SharedVariables) is registered in the document. A Table
+    // tile registers a SharedDataSet on mount, so adding the tile alone —
+    // without populating cells — is enough to enable the graph's link button.
     beforeEach(function () {
       clueCanvas.addTile('table');
       tableToolTile.getTableTile().should('be.visible');
     });
 
-    it('Enter on the link-tile button opens the link dialog and moves focus inside', function () {
+    it('Link-tile dialog opens with focus inside and closes on Escape', function () {
       // qa unit's tools array is ['link-tile-multiple', 'fit-all', 'toggle-lock'],
-      // so the first toolbar button is `link-tile-multiple`. Both link-tile and
-      // link-tile-multiple call into `useProviderTileLinking → showLinkTileDialog`
+      // so the first toolbar button is link-tile-multiple. Both link-tile and
+      // link-tile-multiple call into useProviderTileLinking → showLinkTileDialog
       // and open the same dialog.
+      cy.log('Enter on the link-tile button opens the dialog and moves focus inside');
       xyTile.getTile().click();
       cy.get('button.toolbar-button.link-tile-multiple').focus();
       cy.realPress('Enter');
-
-      // The dialog mounts as `.custom-modal.link-tile`. Focus should be inside it.
       xyTile.getCustomModal().should('be.visible');
       cy.focused().then($el => {
-        expect($el.closest('.custom-modal').length, 'focused element is inside the dialog')
-          .to.be.greaterThan(0);
+        expect($el.closest('.custom-modal').length,
+          'focused element is inside the dialog').to.be.greaterThan(0);
       });
-    });
 
-    it('Escape closes the link-tile dialog', function () {
-      xyTile.getTile().click();
-      cy.get('button.toolbar-button.link-tile-multiple').focus();
-      cy.realPress('Enter');
-      xyTile.getCustomModal().should('be.visible');
-
+      cy.log('Escape closes the dialog');
       cy.realPress('Escape');
       xyTile.getCustomModal().should('not.exist');
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@chakra-ui/react": "^1.8.9",
         "@codemirror/lang-json": "^6.0.2",
-        "@concord-consortium/accessibility-tools": "0.0.1-pre.1",
+        "@concord-consortium/accessibility-tools": "0.1.0-pre.1",
         "@concord-consortium/codap-formulas-react17": "^1.1.0",
         "@concord-consortium/compute-engine": "^0.12.3-cc.2",
         "@concord-consortium/diagram-view": "1.0.2",
@@ -254,7 +254,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
       "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -264,7 +264,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
@@ -295,12 +295,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@babel/core/node_modules/debug": {
       "version": "4.3.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.1.2"
@@ -318,7 +318,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -366,7 +366,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
       "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.28.6",
@@ -383,7 +383,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
@@ -393,7 +393,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -402,7 +402,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
@@ -560,7 +560,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
       "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.28.6",
@@ -682,7 +682,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
       "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -706,7 +706,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
       "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.28.6",
@@ -2911,9 +2911,9 @@
       }
     },
     "node_modules/@concord-consortium/accessibility-tools": {
-      "version": "0.0.1-pre.1",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/accessibility-tools/-/accessibility-tools-0.0.1-pre.1.tgz",
-      "integrity": "sha512-EcINxZBnpzbzBzE+eCJFJN7tbu9e+Qqavq/x5IZ/9JSjsMXTFFLyR7zoanLO3n+OMTsZ7S/OXVEVATYI1RdrEg==",
+      "version": "0.1.0-pre.1",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/accessibility-tools/-/accessibility-tools-0.1.0-pre.1.tgz",
+      "integrity": "sha512-tqL5JTWjKnmdeSbpUnjk97onq+IzkxrrF7yw2mekRB5bUhlgzV8D5h/KoaT+t7inacmyKjqwJstd4CGNHW9BJw==",
       "license": "MIT",
       "dependencies": {
         "@heroicons/react": "^2.2.0",
@@ -4231,7 +4231,6 @@
     },
     "node_modules/@firebase/app-types": {
       "version": "0.7.0",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/app/node_modules/@firebase/app-types": {
@@ -6507,7 +6506,7 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -10685,7 +10684,7 @@
       "version": "2.9.19",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
       "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
@@ -10870,7 +10869,7 @@
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
       "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -11056,7 +11055,7 @@
       "version": "1.0.30001767",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001767.tgz",
       "integrity": "sha512-34+zUAMhSH+r+9eKmYG+k2Rpt8XttfE4yXAjoZvkAPs15xcYQhyBYdalJ65BzivAvGRMViEjy6oKr/S91loekQ==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -13207,7 +13206,7 @@
       "version": "1.5.286",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
       "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/element-resize-detector": {
@@ -15183,7 +15182,7 @@
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -20195,7 +20194,7 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -21576,7 +21575,7 @@
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/normalize-path": {
@@ -27732,7 +27731,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -28988,13 +28987,13 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
       "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
-      "dev": true
+      "devOptional": true
     },
     "@babel/core": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -29017,11 +29016,11 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
           "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-          "dev": true
+          "devOptional": true
         },
         "debug": {
           "version": "4.3.2",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "ms": "2.1.2"
           }
@@ -29030,7 +29029,7 @@
           "version": "6.3.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
           "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-          "dev": true
+          "devOptional": true
         }
       }
     },
@@ -29065,7 +29064,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
       "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/compat-data": "^7.28.6",
         "@babel/helper-validator-option": "^7.27.1",
@@ -29078,7 +29077,7 @@
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
           "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "yallist": "^3.0.2"
           }
@@ -29087,13 +29086,13 @@
           "version": "6.3.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
           "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-          "dev": true
+          "devOptional": true
         },
         "yallist": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
           "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-          "dev": true
+          "devOptional": true
         }
       }
     },
@@ -29196,7 +29195,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
       "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/helper-module-imports": "^7.28.6",
         "@babel/helper-validator-identifier": "^7.28.5",
@@ -29272,7 +29271,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
       "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
-      "dev": true
+      "devOptional": true
     },
     "@babel/helper-wrap-function": {
       "version": "7.18.11",
@@ -29288,7 +29287,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
       "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@babel/template": "^7.28.6",
         "@babel/types": "^7.28.6"
@@ -30162,7 +30161,8 @@
       }
     },
     "@chakra-ui/css-reset": {
-      "version": "1.1.3"
+      "version": "1.1.3",
+      "requires": {}
     },
     "@chakra-ui/descendant": {
       "version": "2.1.4",
@@ -30660,9 +30660,9 @@
       }
     },
     "@concord-consortium/accessibility-tools": {
-      "version": "0.0.1-pre.1",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/accessibility-tools/-/accessibility-tools-0.0.1-pre.1.tgz",
-      "integrity": "sha512-EcINxZBnpzbzBzE+eCJFJN7tbu9e+Qqavq/x5IZ/9JSjsMXTFFLyR7zoanLO3n+OMTsZ7S/OXVEVATYI1RdrEg==",
+      "version": "0.1.0-pre.1",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/accessibility-tools/-/accessibility-tools-0.1.0-pre.1.tgz",
+      "integrity": "sha512-tqL5JTWjKnmdeSbpUnjk97onq+IzkxrrF7yw2mekRB5bUhlgzV8D5h/KoaT+t7inacmyKjqwJstd4CGNHW9BJw==",
       "requires": {
         "@heroicons/react": "^2.2.0",
         "dom-accessibility-api": "^0.7.1",
@@ -30740,7 +30740,8 @@
             "use-sync-external-store": {
               "version": "1.5.0",
               "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
-              "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A=="
+              "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+              "requires": {}
             }
           }
         },
@@ -30840,12 +30841,14 @@
     "@concord-consortium/log-monitor": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@concord-consortium/log-monitor/-/log-monitor-1.0.0.tgz",
-      "integrity": "sha512-3eGS2jkil8MdEYMSaW/lJV2OYaW+kQsPoRUx086D+XaYdC3sRwIGq+Laqh7/qPCApnL+tj/ZA27bWZ5u4oSF9w=="
+      "integrity": "sha512-3eGS2jkil8MdEYMSaW/lJV2OYaW+kQsPoRUx086D+XaYdC3sRwIGq+Laqh7/qPCApnL+tj/ZA27bWZ5u4oSF9w==",
+      "requires": {}
     },
     "@concord-consortium/mobx-state-tree": {
       "version": "6.0.0-cc.1",
       "resolved": "https://registry.npmjs.org/@concord-consortium/mobx-state-tree/-/mobx-state-tree-6.0.0-cc.1.tgz",
-      "integrity": "sha512-dfzSe4ba2dNreouI3YXsUv1tmNlyx2Lj3oa5QoEi2WQazMgCqQY/mCMM87z1HfflYlCnLFoDu8KP2XTp3ljTvg=="
+      "integrity": "sha512-dfzSe4ba2dNreouI3YXsUv1tmNlyx2Lj3oa5QoEi2WQazMgCqQY/mCMM87z1HfflYlCnLFoDu8KP2XTp3ljTvg==",
+      "requires": {}
     },
     "@concord-consortium/react-components": {
       "version": "1.0.0",
@@ -30856,7 +30859,8 @@
       }
     },
     "@concord-consortium/react-modal-hook": {
-      "version": "3.0.0-cc.1"
+      "version": "3.0.0-cc.1",
+      "requires": {}
     },
     "@concord-consortium/slate-editor": {
       "version": "0.10.1",
@@ -30922,7 +30926,8 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
       "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@csstools/css-color-parser": {
       "version": "3.1.0",
@@ -30938,7 +30943,8 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
       "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@csstools/css-tokenizer": {
       "version": "3.0.4",
@@ -31355,7 +31361,8 @@
     "@emotion/use-insertion-effect-with-fallbacks": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
-      "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg=="
+      "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
+      "requires": {}
     },
     "@emotion/utils": {
       "version": "1.4.2",
@@ -31556,8 +31563,7 @@
       }
     },
     "@firebase/app-types": {
-      "version": "0.7.0",
-      "dev": true
+      "version": "0.7.0"
     },
     "@firebase/auth": {
       "version": "0.16.8",
@@ -31566,10 +31572,12 @@
       }
     },
     "@firebase/auth-interop-types": {
-      "version": "0.1.6"
+      "version": "0.1.6",
+      "requires": {}
     },
     "@firebase/auth-types": {
-      "version": "0.10.3"
+      "version": "0.10.3",
+      "requires": {}
     },
     "@firebase/component": {
       "version": "0.5.6",
@@ -31709,7 +31717,8 @@
       }
     },
     "@firebase/firestore-types": {
-      "version": "2.4.0"
+      "version": "2.4.0",
+      "requires": {}
     },
     "@firebase/functions": {
       "version": "0.6.16",
@@ -31764,7 +31773,8 @@
       }
     },
     "@firebase/installations-types": {
-      "version": "0.3.4"
+      "version": "0.3.4",
+      "requires": {}
     },
     "@firebase/logger": {
       "version": "0.2.6"
@@ -31781,7 +31791,8 @@
       }
     },
     "@firebase/messaging-types": {
-      "version": "0.5.0"
+      "version": "0.5.0",
+      "requires": {}
     },
     "@firebase/performance": {
       "version": "0.4.18",
@@ -31864,7 +31875,8 @@
       }
     },
     "@firebase/storage-types": {
-      "version": "0.5.0"
+      "version": "0.5.0",
+      "requires": {}
     },
     "@firebase/util": {
       "version": "1.3.0",
@@ -32119,7 +32131,8 @@
     "@icons/material": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",
-      "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
+      "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==",
+      "requires": {}
     },
     "@isaacs/cliui": {
       "version": "8.0.2",
@@ -33133,7 +33146,7 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -33490,35 +33503,43 @@
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "6.3.1",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@svgr/babel-plugin-remove-jsx-attribute": {
       "version": "6.3.1",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@svgr/babel-plugin-remove-jsx-empty-expression": {
       "version": "6.3.1",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@svgr/babel-plugin-replace-jsx-attribute-value": {
       "version": "6.3.1",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@svgr/babel-plugin-svg-dynamic-title": {
       "version": "6.3.1",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@svgr/babel-plugin-svg-em-dimensions": {
       "version": "6.3.1",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@svgr/babel-plugin-transform-react-native-svg": {
       "version": "6.3.1",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@svgr/babel-plugin-transform-svg-component": {
       "version": "6.3.1",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@svgr/babel-preset": {
       "version": "6.3.1",
@@ -33740,7 +33761,8 @@
     "@tensorflow/tfjs-converter": {
       "version": "4.22.0",
       "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-converter/-/tfjs-converter-4.22.0.tgz",
-      "integrity": "sha512-PT43MGlnzIo+YfbsjM79Lxk9lOq6uUwZuCc8rrp0hfpLjF6Jv8jS84u2jFb+WpUeuF4K33ZDNx8CjiYrGQ2trQ=="
+      "integrity": "sha512-PT43MGlnzIo+YfbsjM79Lxk9lOq6uUwZuCc8rrp0hfpLjF6Jv8jS84u2jFb+WpUeuF4K33ZDNx8CjiYrGQ2trQ==",
+      "requires": {}
     },
     "@tensorflow/tfjs-core": {
       "version": "4.22.0",
@@ -33832,7 +33854,8 @@
     "@tensorflow/tfjs-layers": {
       "version": "4.22.0",
       "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-layers/-/tfjs-layers-4.22.0.tgz",
-      "integrity": "sha512-lybPj4ZNj9iIAPUj7a8ZW1hg8KQGfqWLlCZDi9eM/oNKCCAgchiyzx8OrYoWmRrB+AM6VNEeIT+2gZKg5ReihA=="
+      "integrity": "sha512-lybPj4ZNj9iIAPUj7a8ZW1hg8KQGfqWLlCZDi9eM/oNKCCAgchiyzx8OrYoWmRrB+AM6VNEeIT+2gZKg5ReihA==",
+      "requires": {}
     },
     "@testing-library/cypress": {
       "version": "10.0.1",
@@ -34056,7 +34079,8 @@
       "version": "14.6.1",
       "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
       "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@tootallnate/once": {
       "version": "2.0.0",
@@ -34848,7 +34872,8 @@
       "version": "8.59.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.2.tgz",
       "integrity": "sha512-BKK4alN7oi4C/zv4VqHQ+uRU+lTa6JGIZ7s1juw7b3RHo9OfKB+bKX3u0iVZetdsUCBBkSbdWbarJbmN0fTeSw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@typescript-eslint/type-utils": {
       "version": "8.59.2",
@@ -35484,7 +35509,8 @@
     },
     "@webpack-cli/configtest": {
       "version": "1.2.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@webpack-cli/info": {
       "version": "1.5.0",
@@ -35495,7 +35521,8 @@
     },
     "@webpack-cli/serve": {
       "version": "1.7.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -35531,13 +35558,15 @@
     },
     "acorn-import-assertions": {
       "version": "1.8.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "agent-base": {
       "version": "6.0.2",
@@ -35598,7 +35627,8 @@
     },
     "ajv-keywords": {
       "version": "3.5.2",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ansi-colors": {
       "version": "4.1.1",
@@ -36008,7 +36038,7 @@
       "version": "2.9.19",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
       "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
-      "dev": true
+      "devOptional": true
     },
     "batch": {
       "version": "0.6.1",
@@ -36141,7 +36171,7 @@
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
       "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -36249,7 +36279,7 @@
       "version": "1.0.30001767",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001767.tgz",
       "integrity": "sha512-34+zUAMhSH+r+9eKmYG+k2Rpt8XttfE4yXAjoZvkAPs15xcYQhyBYdalJ65BzivAvGRMViEjy6oKr/S91loekQ==",
-      "dev": true
+      "devOptional": true
     },
     "caseless": {
       "version": "0.12.0",
@@ -36991,13 +37021,15 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/cypress-file-upload/-/cypress-file-upload-5.0.8.tgz",
       "integrity": "sha512-+8VzNabRk3zG6x8f8BWArF/xA/W0VK4IZNx3MV0jFWrJS/qKn8eHfa5nU73P9fOQAgwHFJx7zjg4lwOnljMO8g==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "cypress-real-events": {
       "version": "1.14.0",
       "resolved": "https://registry.npmjs.org/cypress-real-events/-/cypress-real-events-1.14.0.tgz",
       "integrity": "sha512-XmI8y3OZLh6cjRroPalzzS++iv+pGCaD9G9kfIbtspgv7GVsDt30dkZvSXfgZb4rAN+3pOkMVB7e0j4oXydW7Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "cypress-terminal-report": {
       "version": "4.1.2",
@@ -37351,7 +37383,8 @@
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.1.tgz",
       "integrity": "sha512-9JmrhGZpOlEgOLdQgSm0zxFaYoQon408V1v49aqTWuXENVlnCuY9JBZcXZiCsZQWDjTm5Qf/nIvAy77mXDAjEg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "deep-equal": {
       "version": "2.2.2",
@@ -37692,7 +37725,7 @@
       "version": "1.5.286",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
       "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
-      "dev": true
+      "devOptional": true
     },
     "element-resize-detector": {
       "version": "1.2.3",
@@ -38077,7 +38110,8 @@
     },
     "eslint-plugin-chai-friendly": {
       "version": "0.7.2",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-cypress": {
       "version": "2.12.1",
@@ -38194,13 +38228,15 @@
     },
     "eslint-plugin-react-hooks": {
       "version": "4.6.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-unused-imports": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-4.4.1.tgz",
       "integrity": "sha512-oZGYUz1X3sRMGUB+0cZyK2VcvRX5lm/vB56PgNNcU+7ficUCKm66oZWKUubXWnOuPjQ8PvmXtCViXBMONPe7tQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-scope": {
       "version": "5.1.1",
@@ -38975,7 +39011,7 @@
     },
     "gensync": {
       "version": "1.0.0-beta.2",
-      "dev": true
+      "devOptional": true
     },
     "get-caller-file": {
       "version": "2.0.5"
@@ -39642,7 +39678,8 @@
     },
     "icss-utils": {
       "version": "5.1.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "idb": {
       "version": "3.0.2"
@@ -41274,7 +41311,8 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "28.0.2",
@@ -42308,7 +42346,7 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true
+      "devOptional": true
     },
     "json5-loader": {
       "version": "4.0.1",
@@ -42854,7 +42892,8 @@
     "markdown-to-jsx": {
       "version": "7.7.13",
       "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.7.13.tgz",
-      "integrity": "sha512-DiueEq2bttFcSxUs85GJcQVrOr0+VVsPfj9AEUPqmExJ3f8P/iQNvZHltV4tm1XVhu1kl0vWBZWT3l99izRMaA=="
+      "integrity": "sha512-DiueEq2bttFcSxUs85GJcQVrOr0+VVsPfj9AEUPqmExJ3f8P/iQNvZHltV4tm1XVhu1kl0vWBZWT3l99izRMaA==",
+      "requires": {}
     },
     "match-sorter": {
       "version": "6.3.1",
@@ -43069,12 +43108,14 @@
       }
     },
     "mobx-react-lite": {
-      "version": "3.4.0"
+      "version": "3.4.0",
+      "requires": {}
     },
     "mobx-state-tree": {
       "version": "npm:@concord-consortium/mobx-state-tree@6.0.0-cc.1",
       "resolved": "https://registry.npmjs.org/@concord-consortium/mobx-state-tree/-/mobx-state-tree-6.0.0-cc.1.tgz",
-      "integrity": "sha512-dfzSe4ba2dNreouI3YXsUv1tmNlyx2Lj3oa5QoEi2WQazMgCqQY/mCMM87z1HfflYlCnLFoDu8KP2XTp3ljTvg=="
+      "integrity": "sha512-dfzSe4ba2dNreouI3YXsUv1tmNlyx2Lj3oa5QoEi2WQazMgCqQY/mCMM87z1HfflYlCnLFoDu8KP2XTp3ljTvg==",
+      "requires": {}
     },
     "moment": {
       "version": "2.29.4"
@@ -43201,7 +43242,7 @@
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
-      "dev": true
+      "devOptional": true
     },
     "normalize-path": {
       "version": "3.0.0",
@@ -43840,7 +43881,8 @@
     "popsicle-content-encoding": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/popsicle-content-encoding/-/popsicle-content-encoding-1.0.0.tgz",
-      "integrity": "sha512-4Df+vTfM8wCCJVTzPujiI6eOl3SiWQkcZg0AMrOkD1enMXsF3glIkFUZGvour1Sj7jOWCsNSEhBxpbbhclHhzw=="
+      "integrity": "sha512-4Df+vTfM8wCCJVTzPujiI6eOl3SiWQkcZg0AMrOkD1enMXsF3glIkFUZGvour1Sj7jOWCsNSEhBxpbbhclHhzw==",
+      "requires": {}
     },
     "popsicle-cookie-jar": {
       "version": "1.0.1",
@@ -43854,7 +43896,8 @@
     "popsicle-redirects": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/popsicle-redirects/-/popsicle-redirects-1.1.1.tgz",
-      "integrity": "sha512-mC2HrKjdTAWDalOjGxlXw9j6Qxrz/Yd2ui6bPxpi2IQDYWpF4gUAMxbA8EpSWJhLi0PuWKDwTHHPrUPGutAoIA=="
+      "integrity": "sha512-mC2HrKjdTAWDalOjGxlXw9j6Qxrz/Yd2ui6bPxpi2IQDYWpF4gUAMxbA8EpSWJhLi0PuWKDwTHHPrUPGutAoIA==",
+      "requires": {}
     },
     "popsicle-transport-http": {
       "version": "1.2.1",
@@ -43867,12 +43910,14 @@
     "popsicle-transport-xhr": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/popsicle-transport-xhr/-/popsicle-transport-xhr-2.0.0.tgz",
-      "integrity": "sha512-5Sbud4Widngf1dodJE5cjEYXkzEUIl8CzyYRYR57t6vpy9a9KPGQX6KBKdPjmBZlR5A06pOBXuJnVr23l27rtA=="
+      "integrity": "sha512-5Sbud4Widngf1dodJE5cjEYXkzEUIl8CzyYRYR57t6vpy9a9KPGQX6KBKdPjmBZlR5A06pOBXuJnVr23l27rtA==",
+      "requires": {}
     },
     "popsicle-user-agent": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/popsicle-user-agent/-/popsicle-user-agent-1.0.0.tgz",
-      "integrity": "sha512-epKaq3TTfTzXcxBxjpoKYMcTTcAX8Rykus6QZu77XNhJuRHSRxMd+JJrbX/3PFI0opFGSN0BabbAYCbGxbu0mA=="
+      "integrity": "sha512-epKaq3TTfTzXcxBxjpoKYMcTTcAX8Rykus6QZu77XNhJuRHSRxMd+JJrbX/3PFI0opFGSN0BabbAYCbGxbu0mA==",
+      "requires": {}
     },
     "postcss": {
       "version": "8.4.31",
@@ -43906,7 +43951,8 @@
     },
     "postcss-modules-extract-imports": {
       "version": "3.0.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -44270,7 +44316,8 @@
     "react-hook-form": {
       "version": "7.63.0",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.63.0.tgz",
-      "integrity": "sha512-ZwueDMvUeucovM2VjkCf7zIHcs1aAlDimZu2Hvel5C5907gUzMpm4xCrQXtRzCvsBqFjonB4m3x4LzCFI1ZKWA=="
+      "integrity": "sha512-ZwueDMvUeucovM2VjkCf7zIHcs1aAlDimZu2Hvel5C5907gUzMpm4xCrQXtRzCvsBqFjonB4m3x4LzCFI1ZKWA==",
+      "requires": {}
     },
     "react-is": {
       "version": "16.13.1"
@@ -44678,7 +44725,8 @@
     "rete-structures": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/rete-structures/-/rete-structures-2.0.1.tgz",
-      "integrity": "sha512-8S7zkoHLnDOz7T9L4qfwp6efdp790wk3sZBF2qsHLtHJIyAxC8lDNNngy7R2Eh762nadgfcn/ItHpLPmpXQGeQ=="
+      "integrity": "sha512-8S7zkoHLnDOz7T9L4qfwp6efdp790wk3sZBF2qsHLtHJIyAxC8lDNNngy7R2Eh762nadgfcn/ItHpLPmpXQGeQ==",
+      "requires": {}
     },
     "retry": {
       "version": "0.13.1",
@@ -45529,7 +45577,8 @@
     },
     "style-loader": {
       "version": "3.3.1",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "style-mod": {
       "version": "4.1.2",
@@ -45883,7 +45932,8 @@
           "version": "6.5.0",
           "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
           "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "picomatch": {
           "version": "4.0.4",
@@ -45969,7 +46019,8 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
       "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ts-expect": {
       "version": "1.3.0",
@@ -47322,7 +47373,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "escalade": "^3.2.0",
         "picocolors": "^1.1.1"
@@ -47376,17 +47427,20 @@
     "use-composed-ref": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.3.0.tgz",
-      "integrity": "sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ=="
+      "integrity": "sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ==",
+      "requires": {}
     },
     "use-immer": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/use-immer/-/use-immer-0.11.0.tgz",
-      "integrity": "sha512-RNAqi3GqsWJ4bcCd4LMBgdzvPmTABam24DUaFiKfX9s3MSorNRz9RDZYJkllJoMHUxVLMDetwAuCDeyWNrp1yA=="
+      "integrity": "sha512-RNAqi3GqsWJ4bcCd4LMBgdzvPmTABam24DUaFiKfX9s3MSorNRz9RDZYJkllJoMHUxVLMDetwAuCDeyWNrp1yA==",
+      "requires": {}
     },
     "use-isomorphic-layout-effect": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.0.tgz",
-      "integrity": "sha512-q6ayo8DWoPZT0VdG4u3D3uxcgONP3Mevx2i2b0434cwWBoL+aelL1DzkXI6w3PhTZzUeR2kaVlZn70iCiseP6w=="
+      "integrity": "sha512-q6ayo8DWoPZT0VdG4u3D3uxcgONP3Mevx2i2b0434cwWBoL+aelL1DzkXI6w3PhTZzUeR2kaVlZn70iCiseP6w==",
+      "requires": {}
     },
     "use-latest": {
       "version": "1.2.1",
@@ -47397,7 +47451,8 @@
       }
     },
     "use-memo-one": {
-      "version": "1.1.3"
+      "version": "1.1.3",
+      "requires": {}
     },
     "use-resize-observer": {
       "version": "9.0.2",
@@ -47413,7 +47468,8 @@
       }
     },
     "use-sync-external-store": {
-      "version": "1.2.0"
+      "version": "1.2.0",
+      "requires": {}
     },
     "usehooks-ts": {
       "version": "2.16.0",
@@ -48006,7 +48062,8 @@
       "version": "8.19.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "xhr-mock": {
       "version": "2.5.1",

--- a/package.json
+++ b/package.json
@@ -250,7 +250,7 @@
   "dependencies": {
     "@chakra-ui/react": "^1.8.9",
     "@codemirror/lang-json": "^6.0.2",
-    "@concord-consortium/accessibility-tools": "0.0.1-pre.1",
+    "@concord-consortium/accessibility-tools": "0.1.0-pre.1",
     "@concord-consortium/codap-formulas-react17": "^1.1.0",
     "@concord-consortium/compute-engine": "^0.12.3-cc.2",
     "@concord-consortium/diagram-view": "1.0.2",

--- a/src/components/tiles/tile-api.tsx
+++ b/src/components/tiles/tile-api.tsx
@@ -1,6 +1,7 @@
 import { createContext, ReactElement } from "react";
 import { action, makeObservable, observable } from "mobx";
 import { Optional } from "utility-types";
+import type { EscapeHandlerResult, FocusContentContext } from "@concord-consortium/accessibility-tools/hooks";
 import { IOffsetModel, ObjectBoundingBox } from "../../models/annotations/clue-object";
 import { ITileExportOptions } from "../../models/tiles/tile-content-info";
 import { ITileModel } from "../../models/tiles/tile-model";
@@ -20,7 +21,10 @@ interface IGetObjectButtonSVGParams {
 export interface ITileFocusableElements {
   contentElement?: HTMLElement;  // main content area (editor, grid, canvas, etc.)
   titleElement?: HTMLElement;    // tile title input if visible
-  focusContent?: () => boolean;  // custom focus method for content (e.g., Slate's ReactEditor.focus)
+  // Custom focus method for content (e.g., Slate's ReactEditor.focus). The
+  // FocusContentContext carries entryMode so direction-aware implementations
+  // (e.g. XY Plot's reverse-Tab targeting the dots-group) can pick the right end.
+  focusContent?: (context: FocusContentContext) => boolean;
   // Optional secondary controls bar above the main content (e.g. dataflow's
   // Sampling Rate / Record area). Visited as its own slot between title and
   // content. Walked focusable-by-focusable like content (in tabWithinSlots).
@@ -29,6 +33,17 @@ export interface ITileFocusableElements {
   // as its own slot in the trap cycle, between content and the standard floating
   // toolbar, so its internal roving-tabindex is a single tab stop with arrow nav.
   paletteElement?: HTMLElement;
+  // Optional per-tile override for which slots have Tab routed within them.
+  // The outer FocusTrapController (in tile-component.tsx) reads this back from
+  // the tile's registered API and applies it to its own strategy, so the inner
+  // tile can opt slots into within-slot Tab routing (e.g. XY Plot opts palette in
+  // because its CLUE legend has many heterogeneous controls).
+  tabWithinSlots?: string[];
+  // Optional per-slot Escape interceptors. Return "handled" to suppress the
+  // trap's default exit (e.g. when an inline editor is open and Escape should
+  // cancel the edit rather than exit the trap). Return "exit" or omit to let
+  // the trap exit normally.
+  escapeHandlers?: Record<string, (e: KeyboardEvent) => EscapeHandlerResult>;
 }
 
 export interface ITileApi {

--- a/src/components/tiles/tile-component.tsx
+++ b/src/components/tiles/tile-component.tsx
@@ -522,6 +522,7 @@ class InternalTileComponent extends BaseComponent<IProps, IState> {
   // Builds a FocusTrapStrategy from the current tile's elements.
   private buildFocusTrapStrategy() {
     const { model } = this.props;
+    const tabWithinSlots = this.getFocusTrapElements().tabWithinSlots;
     const strategy = createClueTileStrategy({
       onRegisterTileApi: () => {}, // Not used here — individual tiles handle registration
       onUnregisterTileApi: () => {},
@@ -532,8 +533,14 @@ class InternalTileComponent extends BaseComponent<IProps, IState> {
       getTopbarElement: () => this.getFocusTrapElements().topbarElement ?? undefined,
       getPaletteElement: () => this.getFocusTrapElements().paletteElement ?? undefined,
       getResizeElement: () => this.resizeElement ?? undefined,
-      focusContent: () => this.getFocusTrapElements().focusContent?.() ?? false,
+      focusContent: (context) => this.getFocusTrapElements().focusContent?.(context) ?? false,
       onTabWhenInactive: (e, reverse) => this.navigateToSiblingTile(e, reverse),
+      tabWithinSlots,
+      // Dynamic forward: the inner tile may register/unregister content-slot
+      // Escape interceptors between strategy builds, so resolve at call time.
+      escapeHandlers: {
+        content: (e) => this.getFocusTrapElements().escapeHandlers?.content?.(e) ?? "exit",
+      },
     });
     // Deselect the tile when the controller exits (Escape, setEnabled(false))
     strategy.onExit = () => {
@@ -587,6 +594,8 @@ class InternalTileComponent extends BaseComponent<IProps, IState> {
       focusContent: focusable?.focusContent || null,
       topbarElement: focusable?.topbarElement || null,
       paletteElement: focusable?.paletteElement || null,
+      tabWithinSlots: focusable?.tabWithinSlots,
+      escapeHandlers: focusable?.escapeHandlers,
       resizeHandle: this.resizeElement,
     };
   }

--- a/src/components/toolbar/tile-toolbar.tsx
+++ b/src/components/toolbar/tile-toolbar.tsx
@@ -116,9 +116,11 @@ export const TileToolbar = observer(
             ".tool-tile-resize-handle-wrapper"
           ) as HTMLElement | null;
 
-          // Helper to focus content, preferring tile's custom focus method (e.g., Slate)
-          const tryFocusContent = () => {
-            if (focusContentFn?.()) return true;
+          // Helper to focus content, preferring tile's custom focus method (e.g., Slate).
+          // entryMode propagates Tab direction so direction-aware tiles (e.g. XY Plot's
+          // dots-group on reverse entry) can pick the right end.
+          const tryFocusContent = (entryMode: "forward" | "reverse") => {
+            if (focusContentFn?.({ entryMode })) return true;
             if (contentElement) {
               contentElement.focus();
               return document.activeElement === contentElement;
@@ -162,7 +164,7 @@ export const TileToolbar = observer(
                 return false;
               })();
               if (!focusedLastChild) {
-                if (!tryFocusContent()) {
+                if (!tryFocusContent("reverse")) {
                   if (titleElement) { titleElement.focus(); }
                   if (document.activeElement !== titleElement) {
                     if (!tryFocusResize()) { tileElement.focus(); }
@@ -175,7 +177,7 @@ export const TileToolbar = observer(
             if (!tryFocusResize()) {
               if (titleElement) { titleElement.focus(); }
               if (document.activeElement !== titleElement) {
-                if (!tryFocusContent()) { tileElement.focus(); }
+                if (!tryFocusContent("forward")) { tileElement.focus(); }
               }
             }
           }

--- a/src/components/utilities/__tests__/editable-label-with-button.test.tsx
+++ b/src/components/utilities/__tests__/editable-label-with-button.test.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { fireEvent, render } from "@testing-library/react";
+
+import { EditableLabelWithButton } from "../editable-label-with-button";
+
+describe("EditableLabelWithButton — keyboard accessibility", () => {
+  it("preview is not focusable by default", () => {
+    render(<EditableLabelWithButton defaultValue="Cats" onSubmit={() => undefined} />);
+    // When isPreviewFocusable is false (the default), Chakra renders the preview
+    // with no tabindex (or -1), so it isn't part of the natural Tab order.
+    const preview = document.querySelector(".chakra-editable__preview") as HTMLElement;
+    expect(preview).not.toBeNull();
+    expect(preview.getAttribute("tabindex")).not.toBe("0");
+  });
+
+  it("preview becomes a tab stop when enterToEdit is opted into", () => {
+    render(<EditableLabelWithButton defaultValue="Cats" enterToEdit onSubmit={() => undefined} />);
+    const preview = document.querySelector(".chakra-editable__preview") as HTMLElement;
+    expect(preview.getAttribute("tabindex")).toBe("0");
+  });
+
+  it("Enter on a focused preview switches into edit mode (input becomes visible)", () => {
+    render(<EditableLabelWithButton defaultValue="Cats" enterToEdit onSubmit={() => undefined} />);
+    const preview = document.querySelector(".chakra-editable__preview") as HTMLElement;
+    preview.focus();
+    fireEvent.keyDown(preview, { key: "Enter" });
+    // Chakra's Editable hides the preview and shows the input in edit mode.
+    // The input is always in the DOM; in view mode it has tabindex=-1 / hidden.
+    const input = document.querySelector("input.chakra-editable__input") as HTMLInputElement;
+    expect(input).not.toBeNull();
+    expect(input.hasAttribute("hidden")).toBe(false);
+  });
+
+  it("applies aria-label to the preview and input when provided", () => {
+    render(
+      <EditableLabelWithButton
+        defaultValue="Cats"
+        enterToEdit
+        ariaLabel="Dataset name: Cats, press Enter to edit"
+        onSubmit={() => undefined}
+      />
+    );
+    const preview = document.querySelector(".chakra-editable__preview") as HTMLElement;
+    const input = document.querySelector("input.chakra-editable__input") as HTMLInputElement;
+    expect(preview.getAttribute("aria-label")).toBe("Dataset name: Cats, press Enter to edit");
+    expect(input.getAttribute("aria-label")).toBe("Dataset name: Cats, press Enter to edit");
+  });
+});

--- a/src/components/utilities/editable-label-with-button.scss
+++ b/src/components/utilities/editable-label-with-button.scss
@@ -1,14 +1,23 @@
 @import "../vars";
+@import "../mixins";
 
 .chakra-editable {
   .chakra-editable__preview[hidden] {
     display: none;
   }
 
+  // When `enterToEdit` is on, Chakra makes the preview focusable. Give it a
+  // visible focus ring so keyboard users see where focus has landed.
+  .chakra-editable__preview {
+    @include focus-ring(2px);
+  }
+
   button {
     background: inherit;
     border: none;
     cursor: pointer;
+
+    @include focus-ring(2px);
 
     &:hover {
       background-color: $workspace-teal-light-6;

--- a/src/components/utilities/editable-label-with-button.tsx
+++ b/src/components/utilities/editable-label-with-button.tsx
@@ -8,6 +8,9 @@ import "./editable-label-with-button.scss";
 
 interface IProps {
   defaultValue: string|undefined;
+  enterToEdit?: boolean;
+  ariaLabel?: string;
+  editButtonAriaLabel?: string;
   onSubmit: (value:string) => void;
 }
 
@@ -17,17 +20,19 @@ interface IProps {
  * Differs from stock <Editable> in that there's an explicit edit button rather
  * than invoking edit mode by clicking on the label text itself.
  */
-export const EditableLabelWithButton = observer(function EditableDataSetName({defaultValue, onSubmit}: IProps) {
+export const EditableLabelWithButton = observer(function EditableDataSetName({
+  defaultValue, enterToEdit, ariaLabel, editButtonAriaLabel, onSubmit
+}: IProps) {
 
   return (
     <Editable
       defaultValue={defaultValue}
-      isPreviewFocusable={false}
+      isPreviewFocusable={!!enterToEdit}
       onSubmit={onSubmit}
     >
-      <EditablePreview />
-      <EditableInput onKeyDown={handleKeyDown}/>
-      <EditButton />
+      <EditablePreview aria-label={ariaLabel} />
+      <EditableInput aria-label={ariaLabel} onKeyDown={handleKeyDown}/>
+      <EditButton ariaLabel={editButtonAriaLabel} />
     </Editable>
   );
 });
@@ -39,11 +44,11 @@ function handleKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
   e.stopPropagation();
 }
 
-function EditButton() {
+function EditButton({ ariaLabel }: { ariaLabel?: string }) {
   const { isEditing, getEditButtonProps } = useEditableControls();
   if (!isEditing) {
     return (
-      <button aria-label="Edit name" {...getEditButtonProps()}>
+      <button aria-label={ariaLabel ?? "Edit name"} {...getEditButtonProps()}>
         <EditIcon/>
       </button>
     );

--- a/src/hooks/create-clue-tile-strategy.ts
+++ b/src/hooks/create-clue-tile-strategy.ts
@@ -41,7 +41,12 @@ export function createClueTileStrategy(config: ClueFocusTrapConfig): FocusTrapSt
     // with internal arrow nav. findNextSlot skips slots whose elements are
     // undefined, so tiles that don't provide topbar/palette are unaffected.
     cycleOrder: ["title", "topbar", "content", "palette", "toolbar", "resize"],
-    tabWithinSlots: ["topbar", "content"],
+    // Default `tabWithinSlots`: topbar + content. Tiles that want Tab to walk
+    // through each focusable inside their palette (e.g. the XY Plot's legend,
+    // with many native controls) can opt palette in via the config. Tiles that
+    // treat palette as a single tab stop with arrow-roving inside (e.g.
+    // dataflow's Add-block panel) leave it out — the default keeps that working.
+    tabWithinSlots: config.tabWithinSlots ?? ["topbar", "content"],
     announceEnter: ariaLabels.announce.editingTile(config.tileType),
     announceExit: ariaLabels.announce.exitedTile(config.tileType),
     getExternalElements: () => {
@@ -49,5 +54,6 @@ export function createClueTileStrategy(config: ClueFocusTrapConfig): FocusTrapSt
       return toolbar ? [toolbar] : [];
     },
     onTabWhenInactive: config.onTabWhenInactive,
+    escapeHandlers: config.escapeHandlers,
   };
 }

--- a/src/hooks/use-clue-accessibility.test.tsx
+++ b/src/hooks/use-clue-accessibility.test.tsx
@@ -225,8 +225,14 @@ describe("useClueAccessibility", () => {
 
     const registeredApi: ITileApi = onRegister.mock.calls[0][0];
 
-    // additionalApi methods are present
-    expect(registeredApi.exportContentAsTileJson).toBe(exportFn);
+    // additionalApi methods are present and delegate to the caller's impl.
+    // (The registered method is a proxy — calling it must reach exportFn, but
+    // it is intentionally not the same function reference, so the proxy can
+    // pick up later dependency-driven updates to the underlying impl.)
+    expect(registeredApi.exportContentAsTileJson).toBeDefined();
+    const exportResult = registeredApi.exportContentAsTileJson?.();
+    expect(exportFn).toHaveBeenCalled();
+    expect(exportResult).toBe("{}");
 
     // getFocusableElements is NOT the rogue version
     expect(registeredApi.getFocusableElements).not.toBe(rogue);
@@ -234,6 +240,44 @@ describe("useClueAccessibility", () => {
     // Calling it should work (not throw) and not call the rogue
     registeredApi.getFocusableElements?.();
     expect(rogue).not.toHaveBeenCalled();
+  });
+
+  it("additionalApi methods pick up dependency-driven updates without re-registration", () => {
+    // Regression for the graph tile: `getDotCenter` returns undefined until
+    // the graph is data-linked (xAttrType / yAttrType change from undefined to
+    // "numeric"). The annotation system looks up `getObjectBoundingBox` etc.
+    // through the registered tile API at call time, so the registered method
+    // must always reach the *current* underlying impl — not the impl captured
+    // at mount time.
+    const onRegister = jest.fn();
+    const exportV1 = jest.fn(() => "v1");
+    const exportV2 = jest.fn(() => "v2");
+
+    const { rerender } = render(
+      <TileHarness
+        onRegisterTileApi={onRegister}
+        onUnregisterTileApi={jest.fn()}
+        additionalApi={{ exportContentAsTileJson: exportV1 }}
+      />
+    );
+
+    // Re-render with a fresh additionalApi (different inner impl)
+    rerender(
+      <TileHarness
+        onRegisterTileApi={onRegister}
+        onUnregisterTileApi={jest.fn()}
+        additionalApi={{ exportContentAsTileJson: exportV2 }}
+      />
+    );
+
+    // Still only one registration — but calling through the registered proxy
+    // hits the latest impl.
+    expect(onRegister).toHaveBeenCalledTimes(1);
+    const registeredApi: ITileApi = onRegister.mock.calls[0][0];
+    const result = registeredApi.exportContentAsTileJson?.();
+    expect(result).toBe("v2");
+    expect(exportV2).toHaveBeenCalledTimes(1);
+    expect(exportV1).not.toHaveBeenCalled();
   });
 
   it("does not register tile API for region type", () => {

--- a/src/hooks/use-clue-accessibility.ts
+++ b/src/hooks/use-clue-accessibility.ts
@@ -2,7 +2,8 @@ import { RefObject, useEffect, useRef } from "react";
 import {
   AccessibilityResult,
   AnnouncementsConfig,
-  FocusTrapResult,
+  EscapeHandlerResult,
+  FocusContentContext,
   NavigationConfig,
   ResizableConfig,
   useAccessibility,
@@ -19,16 +20,14 @@ export interface ClueFocusTrapConfig {
   onUnregisterTileApi: (facet?: string) => void;
   tileType: string;
 
-  // Container element — the .tool-tile wrapper that the focus trap attaches to
-  containerRef?: RefObject<HTMLElement | null>;
-  getContainerElement?: () => HTMLElement | undefined;
-
   // Content element — provide a ref (function components) or getter (class components)
   contentRef?: RefObject<HTMLElement | null>;
   getContentElement?: () => HTMLElement | undefined;
 
-  // Custom focus function for complex editors (Slate, CodeMirror, etc.)
-  focusContent?: () => boolean;
+  // Custom focus function for complex editors (Slate, CodeMirror, etc.). The
+  // FocusContentContext carries entryMode so direction-aware implementations
+  // can pick the right tab stop on reverse entry.
+  focusContent?: (context: FocusContentContext) => boolean;
 
   // Title element
   titleRef?: RefObject<HTMLElement | null>;
@@ -58,6 +57,22 @@ export interface ClueFocusTrapConfig {
 
   // Called when Tab is pressed but the trap is not active (for inter-tile navigation)
   onTabWhenInactive?: (e: KeyboardEvent, reverse: boolean) => boolean;
+
+  /**
+   * Optional override for which slot names should have Tab routed within the
+   * slot (vs treating the whole slot as a single Tab stop). The default in
+   * `createClueTileStrategy` is `["topbar", "content"]`. Tiles whose palette
+   * contains heterogeneous native focusables (e.g. XY Plot's legend) can opt
+   * the palette in with `["topbar", "content", "palette"]`.
+   */
+  tabWithinSlots?: string[];
+
+  /**
+   * Optional per-slot Escape interceptors. Return "handled" to suppress the
+   * trap's default exit (the React keydown handler downstream gets to see the
+   * event during bubble); return "exit" to let the trap exit normally.
+   */
+  escapeHandlers?: Record<string, (e: KeyboardEvent) => EscapeHandlerResult>;
 }
 
 interface ClueTileOptions {
@@ -84,41 +99,18 @@ export type ClueAccessibilityOptions = ClueTileOptions | ClueRegionOptions;
 /**
  * CLUE-specific wrapper around useAccessibility from @concord-consortium/accessibility-tools.
  *
- * For `type: "tile"`: builds a FocusTrapStrategy from CLUE tile concepts, registers
- * the tile API, and wires useFocusTrap for keyboard Tab/Enter/Escape handling.
+ * For `type: "tile"`: registers the tile API. Each call to the registered
+ * `getFocusableElements()` builds a fresh FocusTrapStrategy from the latest
+ * options, so tile-component.tsx's FocusTrapController always reads the
+ * current render's element getters.
  *
  * For `type: "region"`: passes through navigation/announcements/resize config without
- * any focus trap registration.
+ * any tile API registration.
  */
 export function useClueAccessibility(options: ClueAccessibilityOptions): AccessibilityResult {
   // Capture latest options in a ref so the mount-only effect always sees current values
   const optionsRef = useRef(options);
   optionsRef.current = options;
-
-  // Build a stable containerRef for the focus trap.
-  // Updated on each render so it reflects the latest DOM element.
-  // Note: current function-component tiles (bar-graph, drawing, etc.) don't pass containerRef
-  // or getContainerElement because tile-component.tsx's FocusTrapController handles their
-  // focus trap. This wiring exists for future tiles that manage their own trap.
-  const containerRef = useRef<HTMLElement | null>(null);
-  if (options.type === "tile") {
-    const config = options.focusTrap;
-    if (config.containerRef) {
-      containerRef.current = config.containerRef.current;
-    } else if (config.getContainerElement) {
-      containerRef.current = config.getContainerElement() ?? null;
-    }
-  }
-
-  // Build the strategy once and keep it stable across renders.
-  // The strategy captures getter functions from the initial options.focusTrap,
-  // but those getters read from stable React refs (contentRef, titleRef, etc.)
-  // or close over stable refs, so .current always yields the live element.
-  // Keeping the strategy object itself stable avoids churning useFocusTrap's effect.
-  const strategyRef = useRef<ReturnType<typeof createClueTileStrategy> | undefined>(undefined);
-  if (options.type === "tile" && !strategyRef.current) {
-    strategyRef.current = createClueTileStrategy(options.focusTrap);
-  }
 
   // Register tile API on mount, unregister on unmount
   useEffect(() => {
@@ -137,7 +129,6 @@ export function useClueAccessibility(options: ClueAccessibilityOptions): Accessi
         if (currentOpts.type !== "tile") return undefined;
         // Create a fresh strategy from the latest options so element getters
         // reflect the current render (not stale closures from mount time).
-        // This is separate from strategyRef which stays stable for useFocusTrap.
         const strategy = createClueTileStrategy(currentOpts.focusTrap);
         const elements = strategy.getElements();
         return {
@@ -146,6 +137,8 @@ export function useClueAccessibility(options: ClueAccessibilityOptions): Accessi
           focusContent: strategy.focusContent,
           topbarElement: elements.topbar,
           paletteElement: elements.palette,
+          tabWithinSlots: strategy.tabWithinSlots,
+          escapeHandlers: strategy.escapeHandlers,
         };
       },
     };
@@ -154,21 +147,15 @@ export function useClueAccessibility(options: ClueAccessibilityOptions): Accessi
     return () => config.onUnregisterTileApi();
   }, []); // mount/unmount lifecycle matches componentDidMount/componentWillUnmount
 
-  // Delegate to generic useAccessibility with focus trap wired.
-  // Only pass focusTrap when a container element exists — without one, useFocusTrap
-  // can't attach listeners and would just allocate no-op hooks on every render.
-  const hasFocusTrapContainer = options.type === "tile" && containerRef.current != null;
-  const result = useAccessibility({
-    focusTrap: hasFocusTrapContainer && strategyRef.current ? {
-      containerRef,
-      strategy: strategyRef.current,
-    } : undefined,
+  // Delegate to generic useAccessibility for the navigation / announcements /
+  // resize hooks. Focus trapping is owned by tile-component.tsx's
+  // FocusTrapController, which reads the tile's getFocusableElements() (registered
+  // above) — no focus-trap wiring is needed here.
+  return useAccessibility({
     navigation: options.navigation,
     announcements: options.announcements,
     resize: options.resize,
   });
-
-  return result;
 }
 
 // ---------------------------------------------------------------------------
@@ -178,25 +165,11 @@ export function useClueAccessibility(options: ClueAccessibilityOptions): Accessi
 /**
  * Renderless bridge that lets class components use useClueAccessibility.
  * Render as a child — it returns null and only runs the hook.
- *
- * The onFocusTrapReady callback provides imperative control (enterTrap/exitTrap)
- * so the class component can wire Enter/Escape to trap activation.
  */
-export function ClueTileAccessibilityBridge(props: ClueFocusTrapConfig & {
-  onFocusTrapReady?: (trap: FocusTrapResult) => void;
-}) {
-  const { onFocusTrapReady, ...focusTrapConfig } = props;
-  const result = useClueAccessibility({
+export function ClueTileAccessibilityBridge(props: ClueFocusTrapConfig) {
+  useClueAccessibility({
     type: "tile",
-    focusTrap: focusTrapConfig,
+    focusTrap: props,
   });
-
-  // Expose the trap controller to the class component
-  useEffect(() => {
-    if (result.focusTrap && onFocusTrapReady) {
-      onFocusTrapReady(result.focusTrap);
-    }
-  }, [result.focusTrap, onFocusTrapReady]);
-
   return null;
 }

--- a/src/hooks/use-clue-accessibility.ts
+++ b/src/hooks/use-clue-accessibility.ts
@@ -119,28 +119,39 @@ export function useClueAccessibility(options: ClueAccessibilityOptions): Accessi
 
     const { focusTrap: config } = opts;
 
-    // Delegate through optionsRef so the registered API always uses the latest
-    // callbacks/refs even if the component re-renders after mount.
-    // Spread additionalApi first so getFocusableElements below always wins
-    const tileApi: ITileApi = {
-      ...config.additionalApi,
-      getFocusableElements: () => {
+    // Build the tile API once. Every additionalApi method registered here is a
+    // proxy that delegates to the *current* additionalApi at call time, so
+    // dependency-driven updates inside the caller (e.g. XY Plot's `getDotCenter`
+    // becoming usable after a table is linked) are reflected without needing
+    // to re-register the tile API. The mount-only registration matches the
+    // componentDidMount / componentWillUnmount lifecycle the API registry
+    // expects, while preserving reactivity for the methods themselves.
+    const tileApi: ITileApi = {};
+    for (const key of Object.keys(config.additionalApi ?? {}) as Array<keyof ITileApi>) {
+      (tileApi as Record<string, unknown>)[key] = (...args: unknown[]) => {
         const currentOpts = optionsRef.current;
         if (currentOpts.type !== "tile") return undefined;
-        // Create a fresh strategy from the latest options so element getters
-        // reflect the current render (not stale closures from mount time).
-        const strategy = createClueTileStrategy(currentOpts.focusTrap);
-        const elements = strategy.getElements();
-        return {
-          contentElement: elements.content,
-          titleElement: elements.title,
-          focusContent: strategy.focusContent,
-          topbarElement: elements.topbar,
-          paletteElement: elements.palette,
-          tabWithinSlots: strategy.tabWithinSlots,
-          escapeHandlers: strategy.escapeHandlers,
-        };
-      },
+        const fn = (currentOpts.focusTrap.additionalApi as Record<string, unknown> | undefined)?.[key];
+        return typeof fn === "function" ? fn(...args) : undefined;
+      };
+    }
+    // getFocusableElements always wins — overwrite any same-named proxy above.
+    tileApi.getFocusableElements = () => {
+      const currentOpts = optionsRef.current;
+      if (currentOpts.type !== "tile") return undefined;
+      // Create a fresh strategy from the latest options so element getters
+      // reflect the current render (not stale closures from mount time).
+      const strategy = createClueTileStrategy(currentOpts.focusTrap);
+      const elements = strategy.getElements();
+      return {
+        contentElement: elements.content,
+        titleElement: elements.title,
+        focusContent: strategy.focusContent,
+        topbarElement: elements.topbar,
+        paletteElement: elements.palette,
+        tabWithinSlots: strategy.tabWithinSlots,
+        escapeHandlers: strategy.escapeHandlers,
+      };
     };
 
     config.onRegisterTileApi(tileApi);

--- a/src/plugins/bar-graph/bar-graph-tile.tsx
+++ b/src/plugins/bar-graph/bar-graph-tile.tsx
@@ -65,18 +65,19 @@ export const BarGraphComponent: React.FC<ITileProps> = observer((props: ITilePro
         return getEditableTitleElement(tile);
       },
       getContentElement: () => containerRef.current ?? undefined,
-      focusContent: () => {
-        const container = containerRef.current;
+      focusContent: ({ entryMode }) => {
+        const container = containerRef.current as HTMLElement | null;
         if (!container) return false;
-        // Focus the first bar, or fall back to the first focusable element in the content area
-        const firstFocusable = container.querySelector(
+        // Focus the first/last bar (or other focusable in the content area) based on direction.
+        const focusables = container.querySelectorAll(
           '.visx-bar[tabindex], [role="button"][tabindex], button, [tabindex="0"]'
-        ) as HTMLElement | null;
-        if (firstFocusable) {
-          firstFocusable.focus();
-          return document.activeElement === firstFocusable;
-        }
-        return false;
+        ) as NodeListOf<HTMLElement>;
+        if (focusables.length === 0) return false;
+        const target = entryMode === "reverse"
+          ? focusables[focusables.length - 1]
+          : focusables[0];
+        target.focus();
+        return document.activeElement === target;
       },
     },
   });

--- a/src/plugins/drawing/components/drawing-tile.tsx
+++ b/src/plugins/drawing/components/drawing-tile.tsx
@@ -145,15 +145,16 @@ const DrawingToolComponent: React.FC<IDrawingTileProps> = observer(function Draw
         return getEditableTitleElement(tile);
       },
       getContentElement: () => drawingToolElement.current ?? undefined,
-      focusContent: () => {
+      focusContent: ({ entryMode }) => {
         const container = drawingToolElement.current;
         if (!container) return false;
         const focusables = getVisibleFocusables(container);
-        if (focusables.length > 0) {
-          focusables[0].focus();
-          return document.activeElement === focusables[0];
-        }
-        return false;
+        if (focusables.length === 0) return false;
+        const target = entryMode === "reverse"
+          ? focusables[focusables.length - 1]
+          : focusables[0];
+        target.focus();
+        return document.activeElement === target;
       },
       additionalApi: tileAdditionalApi,
     },

--- a/src/plugins/graph/components/__tests__/attribute-label.test.tsx
+++ b/src/plugins/graph/components/__tests__/attribute-label.test.tsx
@@ -1,0 +1,238 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { AttributeLabel, buildAxisAriaLabel } from "../attribute-label";
+import { DataConfigurationContext } from "../../hooks/use-data-configuration-context";
+import { GraphModelContext } from "../../hooks/use-graph-model-context";
+import { GraphSettingsContext, kDefaultGraphSettings } from "../../hooks/use-graph-settings-context";
+import { GraphLayoutContext, GraphLayout } from "../../models/graph-layout";
+import { ReadOnlyContext } from "../../../../components/document/read-only-context";
+import { GraphPlace } from "../../imports/components/axis-graph-shared";
+
+// --- buildAxisAriaLabel helper ---------------------------------------------------
+
+describe("buildAxisAriaLabel", () => {
+  it("formats X-axis label with edit affordance when attribute is selected", () => {
+    expect(buildAxisAriaLabel("bottom", "Height (cm)", false, true))
+      .toBe("X-axis label: Height (cm), press Enter to edit");
+  });
+
+  it("formats Y-axis label with edit affordance when attribute is selected", () => {
+    expect(buildAxisAriaLabel("left", "Mass", false, true))
+      .toBe("Y-axis label: Mass, press Enter to edit");
+  });
+
+  it("omits the 'press Enter to edit' suffix in read-only mode", () => {
+    expect(buildAxisAriaLabel("bottom", "Height (cm)", true, true))
+      .toBe("X-axis label: Height (cm)");
+  });
+
+  it("describes the cue affordance when no attribute is selected (editable)", () => {
+    expect(buildAxisAriaLabel("bottom", "Click to add...", false, false))
+      .toBe("X-axis: no attribute selected, press Enter to choose");
+  });
+
+  it("describes the cue state without affordance in read-only mode", () => {
+    expect(buildAxisAriaLabel("left", "", true, false))
+      .toBe("Y-axis: no attribute selected");
+  });
+});
+
+// --- AttributeLabel render + keyboard --------------------------------------------
+
+interface IRenderOptions {
+  readOnly?: boolean;
+  /** When false, drops into CODAP-legend mode so `useClickHereCue` can fire. */
+  defaultSeriesLegend?: boolean;
+  /** Whether the data configuration reports an attribute mapped to the place. */
+  hasAttribute?: boolean;
+  xAttributeLabel?: string;
+  place?: GraphPlace;
+  onChangeAttribute?: () => void;
+  onTreatAttributeAs?: () => void;
+  onRemoveAttribute?: () => void;
+}
+
+function renderAttributeLabel(opts: IRenderOptions = {}) {
+  const {
+    readOnly = false,
+    defaultSeriesLegend = true,
+    hasAttribute = true,
+    xAttributeLabel = "X",
+    place = "bottom",
+    onChangeAttribute,
+    onTreatAttributeAs,
+    onRemoveAttribute,
+  } = opts;
+
+  // Minimal fake data configuration covering the surface AttributeLabel + (when
+  // CODAP-legend mode renders it) AxisOrLegendAttributeMenu use.
+  const dataConfig = {
+    placeCanShowClickHereCue: () => !hasAttribute,
+    attributeID: () => (hasAttribute ? "att1" : ""),
+    yAttributeDescriptionsExcludingY2: [],
+    yAttributeDescriptions: [],
+    attributeTypeForID: () => "numeric",
+    onAction: () => undefined,
+    dataset: hasAttribute
+      ? {
+          attrFromID: () => ({ name: xAttributeLabel, id: "att1" }),
+          attributes: [{ id: "att1", name: xAttributeLabel }],
+        }
+      : { attrFromID: () => undefined, attributes: [] },
+  } as any;
+
+  // Minimal graph model fake. plotType="scatterPlot" exercises the multi-Y branch
+  // in `getAttributeIDs`, but yAttributeDescriptionsExcludingY2 is empty so the
+  // mapping ends up the same — single attribute.
+  const graphModel = {
+    plotType: "scatterPlot",
+    xAttributeLabel,
+    yAttributeLabel: xAttributeLabel,
+    setXAttributeLabel: jest.fn(),
+    setYAttributeLabel: jest.fn(),
+  } as any;
+
+  const settings = {
+    ...kDefaultGraphSettings,
+    defaultSeriesLegend,
+  };
+
+  const layout = new GraphLayout();
+
+  // Wrap in a `.graph-plot` parent so AttributeLabel's `positioningParentElt`
+  // lookup (`labelElt.closest('.graph-plot')`) resolves, which is required for
+  // the CODAP-legend AxisOrLegendAttributeMenu portal to render.
+  return render(
+    <GraphLayoutContext.Provider value={layout}>
+      <GraphSettingsContext.Provider value={settings}>
+        <GraphModelContext.Provider value={graphModel}>
+          <DataConfigurationContext.Provider value={dataConfig}>
+            <ReadOnlyContext.Provider value={readOnly}>
+              <div className="graph-plot">
+                <svg>
+                  <AttributeLabel
+                    place={place}
+                    onChangeAttribute={onChangeAttribute}
+                    onTreatAttributeAs={onTreatAttributeAs}
+                    onRemoveAttribute={onRemoveAttribute}
+                  />
+                </svg>
+              </div>
+            </ReadOnlyContext.Provider>
+          </DataConfigurationContext.Provider>
+        </GraphModelContext.Provider>
+      </GraphSettingsContext.Provider>
+    </GraphLayoutContext.Provider>
+  );
+}
+
+describe("AttributeLabel — keyboard behaviour (CLUE-502 Phase 2)", () => {
+  it("is rendered as a button with aria-label and tabIndex=0", () => {
+    renderAttributeLabel({ xAttributeLabel: "Height" });
+    const trigger = screen.getByRole("button", { name: /X-axis label: Height/ });
+    expect(trigger).toBeInTheDocument();
+    expect(trigger).toHaveAttribute("tabindex", "0");
+    expect(trigger).toHaveAttribute("aria-label", "X-axis label: Height, press Enter to edit");
+  });
+
+  it("starts editing on Enter when an attribute is selected", () => {
+    renderAttributeLabel({ xAttributeLabel: "Height" });
+    const trigger = screen.getByRole("button", { name: /X-axis label: Height/ });
+    expect(trigger.querySelector("input.input-textbox")).toBeNull();
+
+    fireEvent.keyDown(trigger, { key: "Enter" });
+
+    expect(trigger.querySelector("input.input-textbox")).not.toBeNull();
+  });
+
+  it("starts editing on Space", () => {
+    renderAttributeLabel({ xAttributeLabel: "Height" });
+    const trigger = screen.getByRole("button", { name: /X-axis label: Height/ });
+    fireEvent.keyDown(trigger, { key: " " });
+    expect(trigger.querySelector("input.input-textbox")).not.toBeNull();
+  });
+
+  it("is focusable in read-only mode but Enter does not start editing", () => {
+    renderAttributeLabel({ xAttributeLabel: "Height", readOnly: true });
+    const trigger = screen.getByRole("button", { name: /X-axis label: Height/ });
+    expect(trigger).toHaveAttribute("tabindex", "0");
+
+    fireEvent.keyDown(trigger, { key: "Enter" });
+
+    expect(trigger.querySelector("input.input-textbox")).toBeNull();
+  });
+
+  it("aria-label omits 'press Enter to edit' suffix in read-only mode", () => {
+    renderAttributeLabel({ xAttributeLabel: "Height", readOnly: true });
+    const trigger = screen.getByRole("button", { name: /X-axis label: Height/ });
+    expect(trigger).toHaveAttribute("aria-label", "X-axis label: Height");
+  });
+
+  it("commits the edited label on Enter and returns focus to the axis-label trigger", () => {
+    renderAttributeLabel({ xAttributeLabel: "Height" });
+    const trigger = screen.getByRole("button", { name: /X-axis label: Height/ });
+
+    fireEvent.keyDown(trigger, { key: "Enter" });
+    const input = trigger.querySelector("input.input-textbox") as HTMLInputElement;
+    expect(input).not.toBeNull();
+    input.focus();
+    fireEvent.change(input, { target: { value: "Width" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(trigger.querySelector("input.input-textbox")).toBeNull();
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it("cancels the edit on Escape and returns focus to the axis-label trigger", () => {
+    renderAttributeLabel({ xAttributeLabel: "Height" });
+    const trigger = screen.getByRole("button", { name: /X-axis label: Height/ });
+
+    fireEvent.keyDown(trigger, { key: "Enter" });
+    const input = trigger.querySelector("input.input-textbox") as HTMLInputElement;
+    expect(input).not.toBeNull();
+    input.focus();
+    fireEvent.keyDown(input, { key: "Escape" });
+
+    expect(trigger.querySelector("input.input-textbox")).toBeNull();
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it("aria-label describes the cue affordance when no attribute is selected (CODAP mode)", () => {
+    renderAttributeLabel({
+      defaultSeriesLegend: false,
+      hasAttribute: false,
+      onChangeAttribute: jest.fn(),
+      onTreatAttributeAs: jest.fn(),
+      onRemoveAttribute: jest.fn(),
+    });
+    const trigger = screen.getByRole("button", { name: /X-axis: no attribute selected/ });
+    expect(trigger).toHaveAttribute("aria-label", "X-axis: no attribute selected, press Enter to choose");
+  });
+
+  it("opens the attribute menu on Enter when the empty-graph cue is showing", () => {
+    renderAttributeLabel({
+      defaultSeriesLegend: false,
+      hasAttribute: false,
+      onChangeAttribute: jest.fn(),
+      onTreatAttributeAs: jest.fn(),
+      onRemoveAttribute: jest.fn(),
+    });
+    const trigger = screen.getByRole("button", { name: /X-axis: no attribute selected/ });
+
+    // Locate the portaled MenuButton tagged with our data-axis-menu-place attribute
+    // and assert that pressing Enter on the trigger clicks it (and so opens the menu).
+    const menuButton = document.querySelector(
+      '[data-axis-menu-place="bottom"]'
+    ) as HTMLButtonElement | null;
+    expect(menuButton).not.toBeNull();
+    const clickSpy = jest.spyOn(menuButton!, "click");
+
+    fireEvent.keyDown(trigger, { key: "Enter" });
+
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+
+    // Edit mode is NOT entered (the cue case opens the menu instead).
+    expect(trigger.querySelector("input.input-textbox")).toBeNull();
+  });
+});

--- a/src/plugins/graph/components/__tests__/graph-toolbar.test.tsx
+++ b/src/plugins/graph/components/__tests__/graph-toolbar.test.tsx
@@ -1,0 +1,123 @@
+import React from "react";
+import { render, fireEvent, screen } from "@testing-library/react";
+import { Provider } from "mobx-react";
+import { ModalProvider } from "react-modal-hook";
+
+import { GraphControllerContext } from "../../models/graph-controller";
+import { GraphModelContext } from "../../hooks/use-graph-model-context";
+import { TileModelContext } from "../../../../components/tiles/tile-api";
+import { TileModel } from "../../../../models/tiles/tile-model";
+import { specStores } from "../../../../models/stores/spec-stores";
+import { getToolbarButtonInfo } from "../../../../components/toolbar/toolbar-button-manager";
+import { createGraphModel } from "../../models/graph-model";
+import "../graph-toolbar-registration";
+import "../../graph-registration";
+
+function renderToolbarButton(buttonName: string, modelOverrides: any = {}) {
+  const info = getToolbarButtonInfo("graph", buttonName);
+  if (!info) throw new Error(`Toolbar button '${buttonName}' is not registered for tileType 'graph'`);
+  const Component = info.component;
+
+  const stores = specStores();
+  const content = createGraphModel();
+  const model = TileModel.create({ content });
+  // Merge per-test overrides onto the live MST instance so toggle tests can
+  // pre-set things like graph.lockAxes without running through the full action.
+  Object.assign(content, modelOverrides);
+
+  // GraphControllerContext is consumed by FitAllButton. We don't need a real
+  // controller for an aria-label test — a stub with the methods used is fine.
+  const controller = { autoscaleAllAxes: jest.fn() } as any;
+
+  return render(
+    <ModalProvider>
+      <Provider stores={stores}>
+        <TileModelContext.Provider value={model}>
+          <GraphModelContext.Provider value={content}>
+            <GraphControllerContext.Provider value={controller}>
+              <Component name={buttonName} />
+            </GraphControllerContext.Provider>
+          </GraphModelContext.Provider>
+        </TileModelContext.Provider>
+      </Provider>
+    </ModalProvider>
+  );
+}
+
+// --- aria-label parametric audit ------------------------------------------------
+
+const expectedLabels: Array<[string, string]> = [
+  ["link-tile",          "Link data"],
+  ["link-tile-multiple", "Add data"],
+  ["fit-all",            "Fit All"],
+  ["toggle-lock",        "Lock Axes"], // unlocked label (default state)
+  ["movable-line",       "Movable line"],
+  ["add-points-by-hand", "Add points by hand"],
+  ["add-points",         "Add point"],
+  ["move-points",        "Select/Move point"],
+  ["delete",             "Delete"],
+];
+
+describe("Graph toolbar buttons — aria-label audit (CLUE-502 Phase 5)", () => {
+  it.each(expectedLabels)("'%s' button exposes aria-label '%s'", (name, expected) => {
+    renderToolbarButton(name);
+    const button = screen.getByRole("button", { name: expected });
+    expect(button).toBeInTheDocument();
+    expect(button.getAttribute("aria-label")).toBe(expected);
+  });
+
+  it("every registered graph toolbar button has a non-empty aria-label", () => {
+    for (const [name] of expectedLabels) {
+      const { unmount } = renderToolbarButton(name);
+      const buttons = document.querySelectorAll(`button.toolbar-button.${name}`);
+      expect(buttons.length).toBeGreaterThan(0);
+      buttons.forEach(btn => {
+        const label = btn.getAttribute("aria-label");
+        expect(label).toBeTruthy();
+        expect(label?.length).toBeGreaterThan(0);
+      });
+      unmount();
+    }
+  });
+});
+
+// --- aria-pressed on toggle-state buttons ---------------------------------------
+
+describe("Graph toolbar — aria-pressed on toggle buttons (CLUE-502 Phase 5)", () => {
+  it("toggle-lock starts aria-pressed='false' and flips to 'true' after activation", () => {
+    renderToolbarButton("toggle-lock");
+    const button = document.querySelector("button.toolbar-button.toggle-lock") as HTMLButtonElement;
+    expect(button.getAttribute("aria-pressed")).toBe("false");
+    fireEvent.click(button);
+    // After click, MST updated graph.lockAxes; the observer re-renders with
+    // the new label and aria-pressed='true'.
+    const updated = document.querySelector("button.toolbar-button.toggle-lock") as HTMLButtonElement;
+    expect(updated.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("add-points reports aria-pressed='false' when editing mode is not 'add'", () => {
+    renderToolbarButton("add-points");
+    const button = document.querySelector("button.toolbar-button.add-points") as HTMLButtonElement;
+    expect(button.getAttribute("aria-pressed")).toBe("false");
+  });
+
+  it("move-points reports aria-pressed='false' when editing mode is not 'edit'", () => {
+    renderToolbarButton("move-points");
+    const button = document.querySelector("button.toolbar-button.move-points") as HTMLButtonElement;
+    expect(button.getAttribute("aria-pressed")).toBe("false");
+  });
+});
+
+// --- aria-disabled (not HTML disabled) per memory rule --------------------------
+
+describe("Graph toolbar — disabled state uses aria-disabled (CLUE-502 Phase 5)", () => {
+  // The delete button is disabled when nothing is selected. A fresh graph
+  // model has no selection, so it's a convenient default-disabled case.
+  it("delete button uses aria-disabled='true' and remains focusable (no HTML disabled)", () => {
+    renderToolbarButton("delete");
+    const button = document.querySelector("button.toolbar-button.delete") as HTMLButtonElement;
+    expect(button.getAttribute("aria-disabled")).toBe("true");
+    // Native `disabled` would short-circuit focusability — must not be set.
+    expect(button.hasAttribute("disabled")).toBe(false);
+  });
+});

--- a/src/plugins/graph/components/__tests__/graph-wrapper-component.test.tsx
+++ b/src/plugins/graph/components/__tests__/graph-wrapper-component.test.tsx
@@ -1,0 +1,117 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { Provider } from "mobx-react";
+import { ModalProvider } from "react-modal-hook";
+
+import { GraphWrapperComponent } from "../graph-wrapper-component";
+import { ITileApi, TileModelContext } from "../../../../components/tiles/tile-api";
+import { TileModel } from "../../../../models/tiles/tile-model";
+import { specStores } from "../../../../models/stores/spec-stores";
+import { createGraphModel } from "../../models/graph-model";
+
+import "../../graph-registration";
+
+jest.mock("../graph-component", () => ({
+  GraphComponent: () => <div data-testid="graph-component-stub" />,
+}));
+
+function renderWrapper(overrides: Partial<React.ComponentProps<typeof GraphWrapperComponent>> = {}) {
+  const stores = specStores();
+  const content = createGraphModel();
+  const model = TileModel.create({ content });
+  const onRegisterTileApi = jest.fn();
+  const onUnregisterTileApi = jest.fn();
+
+  const defaultProps = {
+    model,
+    tileElt: null as HTMLElement | null,
+    context: "",
+    docId: "",
+    documentContent: null as unknown as HTMLElement,
+    isUserResizable: true,
+    navigatorAllowed: false,
+    readOnly: false,
+    onResizeRow: jest.fn(),
+    onSetCanAcceptDrop: jest.fn(),
+    onRequestRowHeight: jest.fn(),
+    onRegisterTileApi,
+    onUnregisterTileApi,
+  };
+
+  const utils = render(
+    <ModalProvider>
+      <Provider stores={stores}>
+        <TileModelContext.Provider value={model}>
+          <GraphWrapperComponent {...defaultProps} {...overrides} />
+        </TileModelContext.Provider>
+      </Provider>
+    </ModalProvider>
+  );
+
+  return { ...utils, onRegisterTileApi, onUnregisterTileApi, model };
+}
+
+describe("GraphWrapperComponent — focus trap wiring (CLUE-502 Phase 1)", () => {
+  it("registers a tile API with getFocusableElements", () => {
+    const { onRegisterTileApi } = renderWrapper();
+    expect(onRegisterTileApi).toHaveBeenCalled();
+    const registeredApi: ITileApi = onRegisterTileApi.mock.calls[0][0];
+    expect(registeredApi.getFocusableElements).toBeDefined();
+  });
+
+  it("getFocusableElements exposes title and content slot getters", () => {
+    const { onRegisterTileApi } = renderWrapper();
+    const registeredApi: ITileApi = onRegisterTileApi.mock.calls[0][0];
+    const elements = registeredApi.getFocusableElements?.();
+    expect(elements).toHaveProperty("titleElement");
+    expect(elements).toHaveProperty("contentElement");
+    expect(elements).toHaveProperty("paletteElement");
+    expect(elements?.focusContent).toBeInstanceOf(Function);
+  });
+
+  it("registered tile API includes exportContentAsTileJson and annotation methods", () => {
+    const { onRegisterTileApi } = renderWrapper();
+    const registeredApi: ITileApi = onRegisterTileApi.mock.calls[0][0];
+    expect(registeredApi.exportContentAsTileJson).toBeInstanceOf(Function);
+    expect(registeredApi.getObjectBoundingBox).toBeInstanceOf(Function);
+    expect(registeredApi.getObjectButtonSVG).toBeInstanceOf(Function);
+    expect(registeredApi.getObjectDefaultOffsets).toBeInstanceOf(Function);
+    expect(registeredApi.getObjectNodeRadii).toBeInstanceOf(Function);
+  });
+
+  it("does not register a focus trap in read-only mode", () => {
+    const { onRegisterTileApi } = renderWrapper({ readOnly: true });
+    // Read-only graphs still register the annotation / export API directly,
+    // but the registered tile API must NOT carry getFocusableElements — that's
+    // the signal that no focus trap is wired.
+    expect(onRegisterTileApi).toHaveBeenCalled();
+    const registeredApi: ITileApi = onRegisterTileApi.mock.calls[0][0];
+    expect(registeredApi.getFocusableElements).toBeUndefined();
+    // Annotation/export API still present so sparrows and export keep working.
+    expect(registeredApi.exportContentAsTileJson).toBeInstanceOf(Function);
+    expect(registeredApi.getObjectBoundingBox).toBeInstanceOf(Function);
+  });
+
+  it("getFocusableElements paletteElement resolves to the .multi-legend container when present", () => {
+    // GraphComponent is mocked in this file, so MultiLegend doesn't render. We
+    // simulate the legend's presence by passing a tileElt with a child div carrying
+    // the .multi-legend class — the same DOM contract `getPaletteElement` queries.
+    const tileElt = document.createElement("div");
+    const legendDiv = document.createElement("div");
+    legendDiv.className = "multi-legend";
+    tileElt.appendChild(legendDiv);
+
+    const { onRegisterTileApi } = renderWrapper({ tileElt });
+    const registeredApi: ITileApi = onRegisterTileApi.mock.calls[0][0];
+    const elements = registeredApi.getFocusableElements?.();
+    expect(elements?.paletteElement).toBe(legendDiv);
+  });
+
+  it("getFocusableElements paletteElement is undefined when the legend is absent", () => {
+    // No tileElt → no .multi-legend ancestor for the palette getter to query.
+    const { onRegisterTileApi } = renderWrapper();
+    const registeredApi: ITileApi = onRegisterTileApi.mock.calls[0][0];
+    const elements = registeredApi.getFocusableElements?.();
+    expect(elements?.paletteElement).toBeUndefined();
+  });
+});

--- a/src/plugins/graph/components/__tests__/read-only-graph.test.tsx
+++ b/src/plugins/graph/components/__tests__/read-only-graph.test.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { Provider } from "mobx-react";
+import { ModalProvider } from "react-modal-hook";
+
+import { GraphWrapperComponent } from "../graph-wrapper-component";
+import { ITileApi, TileModelContext } from "../../../../components/tiles/tile-api";
+import { TileModel } from "../../../../models/tiles/tile-model";
+import { specStores } from "../../../../models/stores/spec-stores";
+import { createGraphModel } from "../../models/graph-model";
+
+import "../../graph-registration";
+
+jest.mock("../graph-component", () => ({
+  GraphComponent: () => <div data-testid="graph-component-stub" />,
+}));
+
+function renderReadOnlyWrapper(overrides: Partial<React.ComponentProps<typeof GraphWrapperComponent>> = {}) {
+  const stores = specStores();
+  const content = createGraphModel();
+  const model = TileModel.create({ content });
+  const onRegisterTileApi = jest.fn();
+  const onUnregisterTileApi = jest.fn();
+
+  const defaultProps = {
+    model,
+    tileElt: null as HTMLElement | null,
+    context: "",
+    docId: "",
+    documentContent: null as unknown as HTMLElement,
+    isUserResizable: true,
+    navigatorAllowed: false,
+    readOnly: true,
+    onResizeRow: jest.fn(),
+    onSetCanAcceptDrop: jest.fn(),
+    onRequestRowHeight: jest.fn(),
+    onRegisterTileApi,
+    onUnregisterTileApi,
+  };
+
+  const utils = render(
+    <ModalProvider>
+      <Provider stores={stores}>
+        <TileModelContext.Provider value={model}>
+          <GraphWrapperComponent {...defaultProps} {...overrides} />
+        </TileModelContext.Provider>
+      </Provider>
+    </ModalProvider>
+  );
+
+  return { ...utils, onRegisterTileApi, onUnregisterTileApi, model };
+}
+
+describe("Read-only XY Plot — Phase 6 wiring (CLUE-502)", () => {
+  it("does not register a focus trap when readOnly is true", () => {
+    const { onRegisterTileApi } = renderReadOnlyWrapper();
+    expect(onRegisterTileApi).toHaveBeenCalled();
+    const registeredApi: ITileApi = onRegisterTileApi.mock.calls[0][0];
+    // The presence of getFocusableElements is the trap's signature — absent it,
+    // useClueAccessibility took the `type: "region"` branch and did not wire a trap.
+    expect(registeredApi.getFocusableElements).toBeUndefined();
+  });
+
+  it("still registers the annotation / export API in read-only mode (so sparrows + export work)", () => {
+    const { onRegisterTileApi } = renderReadOnlyWrapper();
+    const registeredApi: ITileApi = onRegisterTileApi.mock.calls[0][0];
+    expect(registeredApi.exportContentAsTileJson).toBeInstanceOf(Function);
+    expect(registeredApi.getObjectBoundingBox).toBeInstanceOf(Function);
+    expect(registeredApi.getObjectButtonSVG).toBeInstanceOf(Function);
+  });
+
+  it("renders the aria-live announcer container even in read-only mode", () => {
+    const { container } = renderReadOnlyWrapper();
+    const announcer = container.querySelector("[data-graph-announcer]");
+    expect(announcer).not.toBeNull();
+    expect(announcer?.getAttribute("aria-live")).toBe("polite");
+  });
+});

--- a/src/plugins/graph/components/attribute-label.scss
+++ b/src/plugins/graph/components/attribute-label.scss
@@ -1,3 +1,6 @@
+@import "../../../components/vars";
+@import "../../../components/mixins";
+
 .axis-label {
   align-items: center;
   background-color: white;
@@ -9,6 +12,8 @@
   // Match kAxisLabelHorizontalVerticalPadding and kAxisLabelVerticalPadding in graph-types.ts
   padding: 5px 10px;
   position: absolute;
+
+  @include focus-ring(-2px);
 
   &.vertical.editing {
     justify-content: flex-start;

--- a/src/plugins/graph/components/attribute-label.tsx
+++ b/src/plugins/graph/components/attribute-label.tsx
@@ -22,6 +22,29 @@ import { InputTextbox } from "./input-textbox";
 
 import "./attribute-label.scss";
 
+/**
+ * Builds an accessible label describing an axis-label trigger.
+ *
+ * @param place Axis position. `bottom`/`top` are X-axes, `left`/`rightNumeric` are Y-axes.
+ * @param label The current display text (attribute name when one is assigned; empty/cue text otherwise).
+ * @param readOnly When true, omits the affordance suffix because the trigger can't be activated.
+ * @param hasAttribute When false, the trigger is in the "click to add..." cue state and Enter
+ *   opens the attribute menu rather than starting an inline edit.
+ */
+export function buildAxisAriaLabel(
+  place: GraphPlace, label: string, readOnly: boolean, hasAttribute: boolean
+): string {
+  const axisName = (place === "left" || place === "rightNumeric" || place === "yPlus") ? "Y-axis" : "X-axis";
+  if (!hasAttribute) {
+    return readOnly
+      ? `${axisName}: no attribute selected`
+      : `${axisName}: no attribute selected, press Enter to choose`;
+  }
+  return readOnly
+    ? `${axisName} label: ${label}`
+    : `${axisName} label: ${label}, press Enter to edit`;
+}
+
 interface IAttributeLabelProps {
   place: GraphPlace;
   onChangeAttribute?: (place: GraphPlace, dataSet: IDataSet, attrId: string) => void;
@@ -40,6 +63,7 @@ export const AttributeLabel = observer(
       useClickHereCue = dataConfiguration?.placeCanShowClickHereCue(place) ?? false,
       [editing, setEditing] = useState(false),
       inputRef = useRef<HTMLInputElement | null>(null),
+      labelDivRef = useRef<HTMLDivElement | null>(null),
       [inputWidth, setInputWidth] = useState(0),
       [labelElt, setLabelElt] = useState<HTMLDivElement | null>(null),
       portalParentElt = labelElt?.closest(kGraphPortalClass) as HTMLDivElement ?? null,
@@ -114,15 +138,60 @@ export const AttributeLabel = observer(
     const readyForPortal = positioningParentElt && onChangeAttribute && onTreatAttributeAs && onRemoveAttribute;
     const codapLegend = !defaultSeriesLegend;
 
+    // The "click to add..." cue is only visible in CODAP-legend mode. CLUE-legend tiles
+    // always show a customizable label and treat Enter as "start editing", even when
+    // no attribute is mapped.
+    const cueIsShowing = useClickHereCue && codapLegend;
+    const ariaLabel = buildAxisAriaLabel(place, displayText, readOnly, !cueIsShowing);
+
+    /**
+     * When the cue is showing, opening the attribute menu requires triggering Chakra's
+     * MenuButton, which is portaled into the plot container. We tag that button with
+     * `data-axis-menu-place={place}` (see AxisOrLegendAttributeMenu) and find it via DOM
+     * query. Returns true if a button was found and clicked.
+     */
+    const openAttributeMenuForCue = () => {
+      const menuBtn = positioningParentElt?.querySelector<HTMLButtonElement>(
+        `[data-axis-menu-place="${place}"]`
+      );
+      if (menuBtn) {
+        menuBtn.click();
+        return true;
+      }
+      return false;
+    };
+
+    const handleLabelKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (readOnly) return;
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        e.stopPropagation();
+        if (cueIsShowing) {
+          openAttributeMenuForCue();
+        } else {
+          startEditing?.();
+        }
+      }
+    };
+
+    const setLabelRef = (elt: HTMLDivElement | null) => {
+      labelDivRef.current = elt;
+      setLabelElt(elt);
+    };
+
     const divClassName = classNames("axis-label", place, { vertical, editing });
     return (
       <>
         <foreignObject {...foreignObjectStyle}>
           <div
+            aria-label={ariaLabel}
             className={divClassName}
             onClick={startEditing}
-            ref={(elt) => setLabelElt(elt)}
+            onKeyDown={handleLabelKeyDown}
+            ref={setLabelRef}
+            role="button"
             style={divStyle}
+            tabIndex={0}
           >
             {editing
               ? (
@@ -131,6 +200,7 @@ export const AttributeLabel = observer(
                   finishEditing={() => setEditing(false)}
                   inputRef={inputRef}
                   setWidth={setInputWidth}
+                  triggerRef={labelDivRef}
                   updateValue={updateValue}
                 />
               ) : (

--- a/src/plugins/graph/components/axis-end-components.scss
+++ b/src/plugins/graph/components/axis-end-components.scss
@@ -1,4 +1,5 @@
 @import "../../../components/vars";
+@import "../../../components/mixins";
 
 .graph-plot svg.arrow {
   height: 14px;
@@ -28,6 +29,8 @@
   height: 22px; // Keep in sync with kEditableBoxHeight in axis-end-components.tsx
   padding: 0 3px;
   position: absolute;
+
+  @include focus-ring(-2px);
 
   &.bottom {
     justify-content: center;

--- a/src/plugins/graph/components/axis-end-components.tsx
+++ b/src/plugins/graph/components/axis-end-components.tsx
@@ -42,6 +42,7 @@ export const AxisEndComponents: React.FC<IAxisEndComponentsProps> = observer(fun
   const { value, minOrMax, axis, onValueChange, readOnly, showArrow = true, crossAxisZeroPos } = props;
   const [isEditing, setIsEditing] = useState(false);
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const borderBoxRef = useRef<HTMLDivElement | null>(null);
   const layout = useAxisLayoutContext();
 
   useEffect(() => {
@@ -151,9 +152,17 @@ export const AxisEndComponents: React.FC<IAxisEndComponentsProps> = observer(fun
   };
   const axisExtensionStyle = calculateAxisExtensionStyle();
 
-  const handleClick = () => {
+  const startEditing = () => {
     if (!readOnly && !isEditing) {
       setIsEditing(true);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if ((e.key === "Enter" || e.key === " ") && !readOnly) {
+      e.preventDefault();
+      e.stopPropagation();
+      startEditing();
     }
   };
 
@@ -164,17 +173,32 @@ export const AxisEndComponents: React.FC<IAxisEndComponentsProps> = observer(fun
   };
 
   const borderBoxClasses = classNames("editable-border-box", axis);
+  const axisName = (axis === "left" || axis === "rightNumeric") ? "Y-axis" : "X-axis";
+  const boundName = minOrMax === "min" ? "minimum" : "maximum";
+  const ariaLabel = readOnly
+    ? `${axisName} ${boundName}: ${value}`
+    : `${axisName} ${boundName}: ${value}, press Enter to edit`;
   return (
     <>
       {showArrow && axisExtensionStyle && <div className="axis-extension" style={axisExtensionStyle} />}
       {showArrow && <ArrowSVG className="arrow" style={arrowStyle} />}
-      <div style={borderBoxStyles} className={borderBoxClasses} onClick={handleClick}
-        data-testid={`editable-border-box-${axis}-${minOrMax}`}>
+      <div
+        ref={borderBoxRef}
+        style={borderBoxStyles}
+        className={borderBoxClasses}
+        onClick={startEditing}
+        onKeyDown={handleKeyDown}
+        role="button"
+        tabIndex={0}
+        aria-label={ariaLabel}
+        data-testid={`editable-border-box-${axis}-${minOrMax}`}
+      >
         { isEditing ?
           <InputTextbox
             defaultValue={value.toString()}
             finishEditing={() => setIsEditing(false)}
             inputRef={inputRef}
+            triggerRef={borderBoxRef}
             updateValue={updateValue}
           /> :
           <div>{value}</div>

--- a/src/plugins/graph/components/graph-clue-styles.scss
+++ b/src/plugins/graph/components/graph-clue-styles.scss
@@ -1,4 +1,5 @@
 @import "../../../components/vars";
+@import "../../../components/mixins";
 @import "./legend/legend-vars";
 
 .graph-plot {
@@ -55,6 +56,7 @@
     cursor: pointer;
     padding: 3px 5px;
 
+    @include focus-ring(-2px);
 
     &:hover {
       background: $workspace-teal-light-6;

--- a/src/plugins/graph/components/graph-layer.tsx
+++ b/src/plugins/graph/components/graph-layer.tsx
@@ -1,8 +1,10 @@
 import React, { useEffect, useRef } from "react";
+import { useReadOnlyContext } from "../../../components/document/read-only-context";
 import { DotsElt } from "../d3-types";
 import { PlotProps } from "../graph-types";
 import { DataConfigurationContext } from "../hooks/use-data-configuration-context";
 import { GraphLayerContext } from "../hooks/use-graph-layer-context";
+import { useGraphDotsKeyboard } from "../hooks/use-graph-dots-keyboard";
 import { IGraphLayerModel } from "../models/graph-layer-model";
 import { IGraphModel } from "../models/graph-model";
 import { ChartDots } from "./chartdots";
@@ -27,10 +29,21 @@ export interface GraphLayerProps {
 export const GraphLayer = function GraphLayer({ graphModel, layer, enableAnimation }: GraphLayerProps) {
 
   const dotsRef = useRef<DotsElt>(null);
+  const readOnly = useReadOnlyContext();
 
   useEffect(() => {
     layer.setDotsElt(dotsRef.current);
   }, [layer, dotsRef]);
+
+  // Composite-widget keyboard navigation: the <svg ref={dotsRef}> is the single
+  // tab stop for this layer's dots, and the hook moves focus among individual
+  // dots via arrow keys / Home / End / Enter / Space. The hook locates its
+  // aria-live announcer by walking up to the tile's `[data-graph-announcer]`.
+  useGraphDotsKeyboard({
+    dotsRef,
+    dataConfiguration: layer.config,
+    readOnly,
+  });
 
   const plotProps: PlotProps = {
     enableAnimation,
@@ -45,7 +58,16 @@ export const GraphLayer = function GraphLayer({ graphModel, layer, enableAnimati
   };
 
   return (
-    <svg ref={dotsRef} key={layer.id} data-layer={layer.id} data-config={layer.config.id}>
+    <svg
+      ref={dotsRef}
+      key={layer.id}
+      data-layer={layer.id}
+      data-config={layer.config.id}
+      data-graph-dots-group=""
+      role="group"
+      aria-label="Data points (use arrow keys to navigate)"
+      tabIndex={0}
+    >
       <GraphLayerContext.Provider value={layer}>
         <DataConfigurationContext.Provider value={layer.config}>
           {typeToPlotComponentMap[graphModel.plotType]}

--- a/src/plugins/graph/components/graph-wrapper-component.scss
+++ b/src/plugins/graph/components/graph-wrapper-component.scss
@@ -1,7 +1,14 @@
+@import "../../../components/vars";
+@import "../../../components/mixins";
+
 .graph-wrapper {
   height: 100%;
 
   .graph-size-me {
     height: 100%;
   }
+}
+
+.tile-toolbar.graph-toolbar .toolbar-row button {
+  @include focus-ring(-2px);
 }

--- a/src/plugins/graph/components/graph-wrapper-component.tsx
+++ b/src/plugins/graph/components/graph-wrapper-component.tsx
@@ -293,12 +293,16 @@ export const GraphWrapperComponent: React.FC<ITileProps> = observer(function(pro
 
   // Read-only path: register the annotation/export API directly (the region branch of
   // useClueAccessibility above doesn't touch tile API at all). Mirrors drawing-tile.tsx.
+  // Re-register when tileAdditionalApi changes — its closures depend on axis attribute
+  // types (xAttrType / yAttrType), which start undefined and become "numeric" once data
+  // is linked. A mount-only registration would freeze the no-data closures and break
+  // annotation buttons / object lookup once the read-only view becomes data-linked.
   useEffect(() => {
     if (readOnly) {
       onRegisterTileApi?.(tileAdditionalApi);
       return () => onUnregisterTileApi?.();
     }
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [readOnly, tileAdditionalApi, onRegisterTileApi, onUnregisterTileApi]);
 
   // Capture Delete / Backspace on the .tool-tile container. Previously the wrapper
   // div had `tabIndex={0}` + inline `onKeyDown` to receive these keys, but the focus

--- a/src/plugins/graph/components/graph-wrapper-component.tsx
+++ b/src/plugins/graph/components/graph-wrapper-component.tsx
@@ -11,7 +11,7 @@ import { useClueAccessibility } from "../../../hooks/use-clue-accessibility";
 import { useSettingFromStores, useUIStore } from "../../../hooks/use-stores";
 import { OffsetModel } from "../../../models/annotations/clue-object";
 import { ITileExportOptions } from "../../../models/tiles/tile-content-info";
-import { getEditableTitleElement } from "../../../utilities/dom-utils";
+import { getEditableTitleElement, getVisibleFocusables } from "../../../utilities/dom-utils";
 import { HotKeys } from "../../../utilities/hot-keys";
 import { Point } from "../graph-types";
 import {
@@ -29,44 +29,31 @@ import "./graph-toolbar-registration";
 import "./graph-wrapper-component.scss";
 
 /**
- * Focuses an entry tab stop inside the graph content area.
+ * Focuses an entry tab stop inside the graph content area, using the trap's
+ * own visibility filter so the choice matches what tab-within-content sees:
+ *  - Forward: the first visible focusable (the X-axis label in DOM order).
+ *  - Reverse: the last visible focusable (currently the Y-axis maximum bound
+ *    control, since the `.graph-content-area` wrapper brings min/max into the
+ *    content slot after the axis labels and dots-group in DOM order).
  *
- * Forward: first axis-label tab stop (X-axis).
- * Reverse: dots-group surrogate when it's a real tab stop (has non-zero size,
- *   i.e. data is linked), otherwise the last axis-label tab stop (Y-axis).
+ * Without this override, the trap's default `pickSlotEntryTarget` would
+ * always return the first element with `tabindex="0"` regardless of
+ * direction, so Shift+Tab into content would land on X-label and skip every
+ * focusable after it.
  *
- * Why explicit selectors instead of `getVisibleFocusables(content)[last]`: the
- * graph content also renders CODAP-mode legend triggers inside `.graph-svg`,
- * which would otherwise be considered "after" the dots-group in DOM order and
- * steal the reverse-entry target.
- *
- * @param contentElement The content slot element (the plot area), or null.
- * @param reverse When true, picks the *last* content tab stop; otherwise the first.
  * @returns True when focus landed somewhere inside content.
  */
 function focusContentEntry(contentElement: HTMLElement | null, reverse: boolean): boolean {
   if (!contentElement) return false;
-
-  if (reverse) {
-    const dotsGroups = contentElement.querySelectorAll<SVGElement>('[data-graph-dots-group]');
-    const dotsGroup = dotsGroups[dotsGroups.length - 1];
-    if (dotsGroup) {
-      const { width, height } = dotsGroup.getBoundingClientRect();
-      if (width > 0 && height > 0) {
-        dotsGroup.focus();
-        // useGraphDotsKeyboard re-focuses a child dot on group focus, so accept
-        // either the surrogate or a descendant as a successful landing.
-        const active = document.activeElement;
-        if (active && (active === dotsGroup || dotsGroup.contains(active))) return true;
-      }
-    }
-  }
-
-  const labels = contentElement.querySelectorAll<HTMLElement>('.axis-label[tabindex="0"]');
-  if (labels.length === 0) return false;
-  const target = reverse ? labels[labels.length - 1] : labels[0];
-  target.focus();
-  return document.activeElement === target;
+  const focusables = getVisibleFocusables(contentElement);
+  const target = reverse ? focusables[focusables.length - 1] : focusables[0];
+  if (!target) return false;
+  (target as HTMLElement).focus();
+  // The dots-group surrogate's focus handler (useGraphDotsKeyboard) re-focuses
+  // a child .graph-dot on group focus, so accept any descendant as a
+  // successful landing on the dots-group.
+  const active = document.activeElement;
+  return active === target || (active != null && target.contains(active));
 }
 
 export const GraphWrapperComponent: React.FC<ITileProps> = observer(function(props) {
@@ -86,15 +73,16 @@ export const GraphWrapperComponent: React.FC<ITileProps> = observer(function(pro
   // a ref through three layers. The trap controller calls these getters on
   // every cycle, so they pick up DOM that mounts after the wrapper renders.
   //
-  // Content points at the inner `.graph-svg` rather than the outer `.graph-plot`
-  // div on purpose: `.graph-plot` also contains `.multi-legend` (the palette),
-  // and the trap controller resolves a focused element's slot by DOM containment
-  // walking `cycleOrder` (title → topbar → content → palette → …). If content
-  // matched first, every legend control would be attributed to content (which is
-  // in `tabWithinSlots`), making Tab cycle through legend + content together.
-  // Pointing content at `.graph-svg` keeps the slot boundary correct.
+  // Content points at `.graph-content-area` (a `display: contents` wrapper
+  // around the SVG plus the absolutely-positioned axis min/max border-boxes)
+  // rather than `.graph-plot`, because `.graph-plot` also contains the
+  // `.multi-legend` palette. The trap resolves a focused element's slot by
+  // DOM containment walking `cycleOrder` (title → … → content → palette → …);
+  // if content matched the palette's container, legend controls would all be
+  // attributed to content. Scoping content to `.graph-content-area` keeps the
+  // boundary correct while including the min/max bound controls.
   const getContentElement = useCallback(() => {
-    return tileElt?.querySelector<HTMLElement>(".graph-svg") ?? undefined;
+    return tileElt?.querySelector<HTMLElement>(".graph-content-area") ?? undefined;
   }, [tileElt]);
   const getPaletteElement = useCallback(() => {
     return tileElt?.querySelector<HTMLElement>(".multi-legend") ?? undefined;

--- a/src/plugins/graph/components/graph-wrapper-component.tsx
+++ b/src/plugins/graph/components/graph-wrapper-component.tsx
@@ -1,14 +1,17 @@
-import React, { useCallback, useEffect, useRef } from "react";
+import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import classNames from "classnames";
 import { observer } from "mobx-react-lite";
 import { ScaleLinear } from "d3";
 
 import { kSmallAnnotationNodeRadius } from "../../../components/annotations/annotation-utilities";
 import { BasicEditableTileTitle } from "../../../components/tiles/basic-editable-tile-title";
+import { ITileApi } from "../../../components/tiles/tile-api";
 import { ITileProps } from "../../../components/tiles/tile-component";
+import { useClueAccessibility } from "../../../hooks/use-clue-accessibility";
 import { useSettingFromStores, useUIStore } from "../../../hooks/use-stores";
 import { OffsetModel } from "../../../models/annotations/clue-object";
 import { ITileExportOptions } from "../../../models/tiles/tile-content-info";
+import { getEditableTitleElement } from "../../../utilities/dom-utils";
 import { HotKeys } from "../../../utilities/hot-keys";
 import { Point } from "../graph-types";
 import {
@@ -25,9 +28,49 @@ import "./graph-toolbar-registration";
 
 import "./graph-wrapper-component.scss";
 
+/**
+ * Focuses an entry tab stop inside the graph content area.
+ *
+ * Forward: first axis-label tab stop (X-axis).
+ * Reverse: dots-group surrogate when it's a real tab stop (has non-zero size,
+ *   i.e. data is linked), otherwise the last axis-label tab stop (Y-axis).
+ *
+ * Why explicit selectors instead of `getVisibleFocusables(content)[last]`: the
+ * graph content also renders CODAP-mode legend triggers inside `.graph-svg`,
+ * which would otherwise be considered "after" the dots-group in DOM order and
+ * steal the reverse-entry target.
+ *
+ * @param contentElement The content slot element (the plot area), or null.
+ * @param reverse When true, picks the *last* content tab stop; otherwise the first.
+ * @returns True when focus landed somewhere inside content.
+ */
+function focusContentEntry(contentElement: HTMLElement | null, reverse: boolean): boolean {
+  if (!contentElement) return false;
+
+  if (reverse) {
+    const dotsGroup = contentElement.querySelector<SVGElement>('[data-graph-dots-group]');
+    if (dotsGroup) {
+      const { width, height } = dotsGroup.getBoundingClientRect();
+      if (width > 0 && height > 0) {
+        dotsGroup.focus();
+        // useGraphDotsKeyboard re-focuses a child dot on group focus, so accept
+        // either the surrogate or a descendant as a successful landing.
+        const active = document.activeElement;
+        if (active && (active === dotsGroup || dotsGroup.contains(active))) return true;
+      }
+    }
+  }
+
+  const labels = contentElement.querySelectorAll<HTMLElement>('.axis-label[tabindex="0"]');
+  if (labels.length === 0) return false;
+  const target = reverse ? labels[labels.length - 1] : labels[0];
+  target.focus();
+  return document.activeElement === target;
+}
+
 export const GraphWrapperComponent: React.FC<ITileProps> = observer(function(props) {
   const {
-    model, readOnly, tileElt, onRegisterTileApi, onRequestRowHeight
+    model, readOnly, tileElt, onRegisterTileApi, onUnregisterTileApi, onRequestRowHeight
   } = props;
   const instanceId = useNextInstanceId("graph");
   const ui = useUIStore();
@@ -35,6 +78,26 @@ export const GraphWrapperComponent: React.FC<ITileProps> = observer(function(pro
   const graphSettings: IGraphSettings = { ...kDefaultGraphSettings, ...graphSettingsFromStores };
   const content = model.content as IGraphModel;
   const hotKeys = useRef(new HotKeys());
+
+  // Content and palette elements are queried lazily from `tileElt`. Both live
+  // deep inside GraphComponent → Graph (the plot area) / GraphComponent → Graph
+  // → MultiLegend (the legend container); querying via `tileElt` avoids threading
+  // a ref through three layers. The trap controller calls these getters on
+  // every cycle, so they pick up DOM that mounts after the wrapper renders.
+  //
+  // Content points at the inner `.graph-svg` rather than the outer `.graph-plot`
+  // div on purpose: `.graph-plot` also contains `.multi-legend` (the palette),
+  // and the trap controller resolves a focused element's slot by DOM containment
+  // walking `cycleOrder` (title → topbar → content → palette → …). If content
+  // matched first, every legend control would be attributed to content (which is
+  // in `tabWithinSlots`), making Tab cycle through legend + content together.
+  // Pointing content at `.graph-svg` keeps the slot boundary correct.
+  const getContentElement = useCallback(() => {
+    return tileElt?.querySelector<HTMLElement>(".graph-svg") ?? undefined;
+  }, [tileElt]);
+  const getPaletteElement = useCallback(() => {
+    return tileElt?.querySelector<HTMLElement>(".multi-legend") ?? undefined;
+  }, [tileElt]);
 
   const layout = useInitGraphLayout(content);
   const xAttrType = content.config.attributeType("x");
@@ -111,87 +174,150 @@ export const GraphWrapperComponent: React.FC<ITileProps> = observer(function(pro
     }
   }, [handleDelete, readOnly]);
 
-  useEffect(() => {
-    onRegisterTileApi?.({
-      exportContentAsTileJson: (options?: ITileExportOptions) => {
-        return content.exportJson(options);
-      },
-      getObjectBoundingBox: (objectId: string, objectType?: string) => {
-        let coords;
-        const annotationLocationCache = content.annotationLocationCaches.get(instanceId);
-        const annotationSizesCache = content.annotationSizesCaches.get(instanceId);
-        if (objectType === "dot") {
-          coords = getDotCenter(objectId);
-        // Check location cache
-        } else if (annotationLocationCache && annotationSizesCache && annotationLocationCache.has(objectId)){
-          const location = annotationLocationCache.get(objectId);
-          if (location) {
-            const size = annotationSizesCache.get(objectId);
-            if (size) { // This is a rectangle of defined width & height
-              const bbox = {
-                left: location.x + layout.getComputedBounds("plot").left,
-                top: location.y + layout.getComputedBounds("plot").top,
-                ...size };
-              return bbox;
-            }
-            return boundingBoxForPoint(location);
+  const tileAdditionalApi = useMemo<Partial<ITileApi>>(() => ({
+    exportContentAsTileJson: (options?: ITileExportOptions) => {
+      return content.exportJson(options);
+    },
+    getObjectBoundingBox: (objectId: string, objectType?: string) => {
+      let coords;
+      const annotationLocationCache = content.annotationLocationCaches.get(instanceId);
+      const annotationSizesCache = content.annotationSizesCaches.get(instanceId);
+      if (objectType === "dot") {
+        coords = getDotCenter(objectId);
+      // Check location cache
+      } else if (annotationLocationCache && annotationSizesCache && annotationLocationCache.has(objectId)){
+        const location = annotationLocationCache.get(objectId);
+        if (location) {
+          const size = annotationSizesCache.get(objectId);
+          if (size) { // This is a rectangle of defined width & height
+            const bbox = {
+              left: location.x + layout.getComputedBounds("plot").left,
+              top: location.y + layout.getComputedBounds("plot").top,
+              ...size };
+            return bbox;
           }
-        } else {
-          // Maybe one of our adornments knows about this object
-          const pos = objectType && getPositionFromAdornment(objectType, objectId);
-          coords = pos && getScaledPosition(pos);
+          return boundingBoxForPoint(location);
         }
-        if (coords) {
-          return boundingBoxForPoint(coords);
-        }
-      },
-      getObjectButtonSVG: ({ classes, handleClick, objectId, objectType }) => {
-        let coords;
-        const annotationLocationCache = content.annotationLocationCaches.get(instanceId);
-        if (objectType === "dot") {
-          // Native graph object
-          coords = getDotCenter(objectId);
-        } else if (content.annotationSizesCaches.get(instanceId)?.has(objectId)) {
-          // Adornment object with rectangle shape; do not return SVG
-          return undefined;
-        } else if (annotationLocationCache?.has(objectId)) {
-          // Adornment object with dot shape
-          coords = annotationLocationCache.get(objectId);
-        } else if (objectType) {
-          const pos = getPositionFromAdornment(objectType, objectId);
-          coords = pos && getScaledPosition(pos);
-        }
-        if (!coords) return;
-        const { x, y } = coords;
-        const cx = x + layout.getComputedBounds("left").width;
-        const radius = content.getPointRadius("hover-drag");
-
-        // Return a circle at the center point
-        return (
-          <circle
-            className={classes}
-            cx={cx}
-            cy={y}
-            onClick={handleClick}
-            r={radius}
-          />
-        );
-      },
-      getObjectDefaultOffsets: (objectId: string, objectType?: string) => {
-        const offsets = OffsetModel.create({});
-        offsets.setDy(-kSmallAnnotationNodeRadius);
-        return offsets;
-      },
-      getObjectNodeRadii: (objectId: string, objectType?: string) => {
-        return {
-          centerRadius: kSmallAnnotationNodeRadius / 2,
-          highlightRadius: kSmallAnnotationNodeRadius
-        };
+      } else {
+        // Maybe one of our adornments knows about this object
+        const pos = objectType && getPositionFromAdornment(objectType, objectId);
+        coords = pos && getScaledPosition(pos);
       }
-    });
-    // xDomain and yDomain are included to force updating the sparrow locations when they change
-  }, [getDotCenter, content, layout, onRegisterTileApi, getPositionFromAdornment,
-    boundingBoxForPoint, getScaledPosition]);
+      if (coords) {
+        return boundingBoxForPoint(coords);
+      }
+    },
+    getObjectButtonSVG: ({ classes, handleClick, objectId, objectType }) => {
+      let coords;
+      const annotationLocationCache = content.annotationLocationCaches.get(instanceId);
+      if (objectType === "dot") {
+        // Native graph object
+        coords = getDotCenter(objectId);
+      } else if (content.annotationSizesCaches.get(instanceId)?.has(objectId)) {
+        // Adornment object with rectangle shape; do not return SVG
+        return undefined;
+      } else if (annotationLocationCache?.has(objectId)) {
+        // Adornment object with dot shape
+        coords = annotationLocationCache.get(objectId);
+      } else if (objectType) {
+        const pos = getPositionFromAdornment(objectType, objectId);
+        coords = pos && getScaledPosition(pos);
+      }
+      if (!coords) return;
+      const { x, y } = coords;
+      const cx = x + layout.getComputedBounds("left").width;
+      const radius = content.getPointRadius("hover-drag");
+
+      // Return a circle at the center point
+      return (
+        <circle
+          className={classes}
+          cx={cx}
+          cy={y}
+          onClick={handleClick}
+          r={radius}
+        />
+      );
+    },
+    getObjectDefaultOffsets: (objectId: string, objectType?: string) => {
+      const offsets = OffsetModel.create({});
+      offsets.setDy(-kSmallAnnotationNodeRadius);
+      return offsets;
+    },
+    getObjectNodeRadii: (objectId: string, objectType?: string) => {
+      return {
+        centerRadius: kSmallAnnotationNodeRadius / 2,
+        highlightRadius: kSmallAnnotationNodeRadius
+      };
+    }
+  }), [content, instanceId, layout, getDotCenter, getPositionFromAdornment, boundingBoxForPoint, getScaledPosition]);
+
+  // Editable tiles register the tile API (including focus-trap getFocusableElements)
+  // through useClueAccessibility. Read-only tiles use `type: "region"`, which does
+  // not register a tile API — so we register `tileAdditionalApi` directly below for
+  // read-only graphs so annotation lookup and export still work.
+  useClueAccessibility(readOnly ? { type: "region" } : {
+    type: "tile",
+    focusTrap: {
+      tileType: "graph",
+      onRegisterTileApi,
+      onUnregisterTileApi,
+      getTitleElement: () => getEditableTitleElement(tileElt ?? undefined),
+      getContentElement,
+      getPaletteElement,
+      focusContent: ({ entryMode }) => focusContentEntry(getContentElement() ?? null, entryMode === "reverse"),
+      additionalApi: tileAdditionalApi,
+      // The graph's CLUE-legend palette has many heterogeneous native controls
+      // (unlink button, dataset-name edit pencil, color picker, attribute menu
+      // triggers, add-series button) and users expect Tab to step through them
+      // individually rather than treating the whole legend as one tab stop.
+      // Opt palette into the trap's within-slot Tab routing.
+      tabWithinSlots: ["topbar", "content", "palette"],
+      // While an inline axis-label editor (InputTextbox) is focused, Escape
+      // should cancel the edit and return focus to the trigger — not exit the
+      // trap. Returning "handled" tells the trap not to exit and not to
+      // stopPropagation, so the InputTextbox's React onKeyDown sees the same
+      // Escape during the bubble phase and performs the cancel.
+      escapeHandlers: {
+        content: () => {
+          const active = document.activeElement;
+          if (active instanceof HTMLElement && active.classList.contains("input-textbox")) {
+            return "handled";
+          }
+          return "exit";
+        },
+      },
+    },
+  });
+
+
+  // Read-only path: register the annotation/export API directly (the region branch of
+  // useClueAccessibility above doesn't touch tile API at all). Mirrors drawing-tile.tsx.
+  useEffect(() => {
+    if (readOnly) {
+      onRegisterTileApi?.(tileAdditionalApi);
+      return () => onUnregisterTileApi?.();
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Capture Delete / Backspace on the .tool-tile container. Previously the wrapper
+  // div had `tabIndex={0}` + inline `onKeyDown` to receive these keys, but the focus
+  // trap requires the wrapper not to be its own tab stop. The .tool-tile element is
+  // the focus-trap root, so attaching the listener there gives us the same coverage
+  // without adding a stray tab stop. Gated on selected + editable, mirroring the
+  // original behavior.
+  useEffect(() => {
+    if (!tileElt || readOnly) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (!ui.isSelectedTile(model)) return;
+      // HotKeys.dispatch is typed for React.KeyboardEvent but only reads modifier-key
+      // flags, `keyCode`, and the preventDefault/stopPropagation methods — all present
+      // on the native KeyboardEvent. Cast through unknown to satisfy the signature.
+      hotKeys.current.dispatch(e as unknown as React.KeyboardEvent);
+    };
+    tileElt.addEventListener("keydown", handleKeyDown);
+    return () => tileElt.removeEventListener("keydown", handleKeyDown);
+  }, [tileElt, readOnly, ui, model]);
 
   useEffect(function cleanup() {
     return () => {
@@ -208,11 +334,7 @@ export const GraphWrapperComponent: React.FC<ITileProps> = observer(function(pro
   return (
     <InstanceIdContext.Provider value={instanceId}>
       <GraphSettingsContext.Provider value={graphSettings}>
-        <div
-          className={wrapperClasses}
-          onKeyDown={(e) => hotKeys.current.dispatch(e)}
-          tabIndex={0} // must be able to take focus so that it can receive keyDown events
-        >
+        <div className={wrapperClasses}>
           <BasicEditableTileTitle />
           <GraphComponent
             layout={layout}
@@ -220,6 +342,13 @@ export const GraphWrapperComponent: React.FC<ITileProps> = observer(function(pro
             tileElt={tileElt}
             onRequestRowHeight={onRequestRowHeight}
             readOnly={readOnly}
+          />
+          {/* Aria-live region for dot-selection announcements. Walked up to by
+              useGraphDotsKeyboard via the `data-graph-announcer` marker. */}
+          <div
+            aria-live="polite"
+            className="visually-hidden"
+            data-graph-announcer=""
           />
         </div>
       </GraphSettingsContext.Provider>

--- a/src/plugins/graph/components/graph-wrapper-component.tsx
+++ b/src/plugins/graph/components/graph-wrapper-component.tsx
@@ -48,7 +48,8 @@ function focusContentEntry(contentElement: HTMLElement | null, reverse: boolean)
   if (!contentElement) return false;
 
   if (reverse) {
-    const dotsGroup = contentElement.querySelector<SVGElement>('[data-graph-dots-group]');
+    const dotsGroups = contentElement.querySelectorAll<SVGElement>('[data-graph-dots-group]');
+    const dotsGroup = dotsGroups[dotsGroups.length - 1];
     if (dotsGroup) {
       const { width, height } = dotsGroup.getBoundingClientRect();
       if (width > 0 && height > 0) {

--- a/src/plugins/graph/components/graph.scss
+++ b/src/plugins/graph/components/graph.scss
@@ -1,3 +1,6 @@
+@import "../../../components/vars";
+@import "../../../components/mixins";
+
 $graph-label-font: italic 14px Lato, sans-serif;
 $graph-empty-label-font: 12px Montserrat-Regular, sans-serif;
 $graph-background-fill: #fff;
@@ -85,6 +88,23 @@ $graph-background-fill: #fff;
 
 .graph-dot {
   cursor: pointer;
+
+  &:focus-visible,
+  &.keyboard-focused {
+    outline: none;
+  }
+
+  &:focus-visible .inner-circle,
+  &.keyboard-focused .inner-circle {
+    outline: 2px solid $focus-ring-color;
+    outline-offset: 2px;
+  }
+}
+
+// The dots-group surrogate (one <svg> per layer) is the single tab stop for the
+// layer's points. Arrow keys then rove individual dots.
+[data-graph-dots-group] {
+  @include focus-ring(2px);
 }
 
 .graph-dot line.connector {

--- a/src/plugins/graph/components/graph.scss
+++ b/src/plugins/graph/components/graph.scss
@@ -16,6 +16,14 @@ $graph-background-fill: #fff;
   height: 100%;
   background-color: $graph-background-fill;
 
+  // Pure DOM grouping so the focus trap's content slot includes the
+  // absolutely-positioned axis min/max border-boxes which live in DOM after
+  // the SVG, not inside it. (`display: contents` makes the wrapper invisible
+  // to layout.)
+  > .graph-content-area {
+    display: contents;
+  }
+
   .attribute-label {
     fill: blue;
     text-decoration: underline;

--- a/src/plugins/graph/components/graph.scss
+++ b/src/plugins/graph/components/graph.scss
@@ -97,7 +97,7 @@ $graph-background-fill: #fff;
 .graph-dot {
   cursor: pointer;
 
-  &:focus-visible,
+  &:focus,
   &.keyboard-focused {
     outline: none;
   }

--- a/src/plugins/graph/components/graph.tsx
+++ b/src/plugins/graph/components/graph.tsx
@@ -225,6 +225,7 @@ export const Graph = observer(
   return (
     <DataConfigurationContext.Provider value={graphModel.config}>
       <div className={kGraphClass} ref={graphRef} data-testid="graph">
+        <div className="graph-content-area">
         <svg className='graph-svg' ref={svgRef}>
           <Background
             marqueeState={marqueeState}
@@ -258,14 +259,6 @@ export const Graph = observer(
         </svg>
         {!disableAttributeDnD && renderDroppableAddAttributes()}
         <Adornments/>
-        {defaultSeriesLegend &&
-          <MultiLegend
-            onChangeAttribute={handleChangeAttribute}
-            onRemoveAttribute={handleRemoveAttribute}
-            onTreatAttributeAs={handleTreatAttrAs}
-            onRequestRowHeight={onRequestRowHeight}
-          />
-        }
         {
           axes.map((axis: AxisPlace, idx) => {
             const axisModel = graphModel?.getAxis(axis);
@@ -324,6 +317,15 @@ export const Graph = observer(
               );
             }
           })
+        }
+        </div>
+        {defaultSeriesLegend &&
+          <MultiLegend
+            onChangeAttribute={handleChangeAttribute}
+            onRemoveAttribute={handleRemoveAttribute}
+            onTreatAttributeAs={handleTreatAttrAs}
+            onRequestRowHeight={onRequestRowHeight}
+          />
         }
       </div>
     </DataConfigurationContext.Provider>

--- a/src/plugins/graph/components/input-textbox.tsx
+++ b/src/plugins/graph/components/input-textbox.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { measureText } from "../../../components/tiles/hooks/use-measure-text";
 
 interface IInputTextboxProps {
@@ -6,10 +6,14 @@ interface IInputTextboxProps {
   finishEditing: () => void;
   inputRef?: React.MutableRefObject<HTMLInputElement | null>;
   setWidth?: (width: number) => void;
+  triggerRef?: React.RefObject<HTMLElement | null>;
   updateValue: (val: string) => void;
 }
-export function InputTextbox({ defaultValue, finishEditing, inputRef, setWidth, updateValue }: IInputTextboxProps) {
+export function InputTextbox({
+  defaultValue, finishEditing, inputRef, setWidth, triggerRef, updateValue
+}: IInputTextboxProps) {
   const [inputValue, setInputValue] = useState(defaultValue);
+  const cancellingRef = useRef(false);
 
   const width = measureText(inputValue) + 2 * 5;
   const inputStyle = { width: `${width}px` };
@@ -18,22 +22,26 @@ export function InputTextbox({ defaultValue, finishEditing, inputRef, setWidth, 
     setWidth?.(width);
   }, [setWidth, width]);
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     const { key } = e;
-    switch (key) {
-      case "Enter": {
-        updateValue((e.target as HTMLInputElement).value);
-        finishEditing();
-        break;
-      }
-      case "Escape":
-        finishEditing();
-        break;
+    if (key === "Enter") {
+      updateValue((e.target as HTMLInputElement).value);
+      finishEditing();
+      triggerRef?.current?.focus();
+    } else if (key === "Escape") {
+      e.preventDefault();
+      cancellingRef.current = true;
+      finishEditing();
+      triggerRef?.current?.focus();
     }
     e.stopPropagation();
   };
 
   const handleBlur: React.FocusEventHandler<HTMLInputElement> = e => {
+    if (cancellingRef.current) {
+      cancellingRef.current = false;
+      return;
+    }
     updateValue(e.target.value);
     finishEditing();
   };

--- a/src/plugins/graph/components/legend/__tests__/legend-accessibility.test.tsx
+++ b/src/plugins/graph/components/legend/__tests__/legend-accessibility.test.tsx
@@ -1,0 +1,132 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import { AddSeriesButton } from "../add-series-button";
+import { LegendDropdown } from "../legend-dropdown";
+import { SimpleAttributeLabel } from "../../simple-attribute-label";
+import { DataConfigurationContext } from "../../../hooks/use-data-configuration-context";
+import { GraphModelContext } from "../../../hooks/use-graph-model-context";
+import { GraphSettingsContext, kDefaultGraphSettings } from "../../../hooks/use-graph-settings-context";
+import { ReadOnlyContext } from "../../../../../components/document/read-only-context";
+
+// --- AddSeriesButton ------------------------------------------------------------
+
+describe("AddSeriesButton — aria contract (CLUE-502 Phase 4)", () => {
+  function renderAddSeries(hasUnplottedAttribute: boolean) {
+    const dataConfig = {
+      dataset: hasUnplottedAttribute
+        ? { attributes: [{ id: "att1" }, { id: "att2" }] }
+        : { attributes: [{ id: "att1" }] },
+      _attributeDescriptions: new Map([["x", { attributeID: "att1" }]]),
+      yAttributeDescriptions: [],
+      addYAttribute: jest.fn(),
+    } as any;
+
+    return render(
+      <DataConfigurationContext.Provider value={dataConfig}>
+        <AddSeriesButton />
+      </DataConfigurationContext.Provider>
+    );
+  }
+
+  it("exposes aria-label='Add Y attribute'", () => {
+    renderAddSeries(true);
+    const button = screen.getByRole("button", { name: "Add Y attribute" });
+    expect(button).toBeInTheDocument();
+  });
+
+  it("uses aria-disabled='true' rather than HTML disabled when no attribute can be added", () => {
+    renderAddSeries(false);
+    const button = screen.getByRole("button", { name: "Add Y attribute" });
+    expect(button).toHaveAttribute("aria-disabled", "true");
+    // The control remains focusable (no native `disabled` attribute).
+    expect(button).not.toHaveAttribute("disabled");
+  });
+
+  it("is not aria-disabled when an unplotted attribute is available", () => {
+    renderAddSeries(true);
+    const button = screen.getByRole("button", { name: "Add Y attribute" });
+    expect(button).toHaveAttribute("aria-disabled", "false");
+  });
+});
+
+// --- SimpleAttributeLabel (uses AxisOrLegendAttributeMenu target=null) ----------
+
+describe("SimpleAttributeLabel — legend-case aria-label (CLUE-502 Phase 4)", () => {
+  function renderSimpleAttributeLabel(attrName = "Height", readOnly = false) {
+    const dataConfig = {
+      dataset: {
+        attrFromID: (id: string) => id === "att1" ? { name: attrName, id: "att1" } : undefined,
+        attributes: [{ id: "att1", name: attrName }],
+        isAttributeSelected: () => false,
+      },
+      attributeID: () => "att1",
+      yAttributeDescriptions: [],
+      attributeTypeForID: () => "numeric",
+      onAction: () => undefined,
+    } as any;
+    const graphModel = {
+      getColorForId: () => "#000000",
+    } as any;
+    return render(
+      <GraphSettingsContext.Provider value={kDefaultGraphSettings}>
+        <GraphModelContext.Provider value={graphModel}>
+          <DataConfigurationContext.Provider value={dataConfig}>
+            <ReadOnlyContext.Provider value={readOnly}>
+              <SimpleAttributeLabel
+                attrId="att1"
+                place="left"
+                onChangeAttribute={jest.fn()}
+                onRemoveAttribute={jest.fn()}
+                onTreatAttributeAs={jest.fn()}
+              />
+            </ReadOnlyContext.Provider>
+          </DataConfigurationContext.Provider>
+        </GraphModelContext.Provider>
+      </GraphSettingsContext.Provider>
+    );
+  }
+
+  it("legend-case MenuButton has aria-label that includes the attribute name", () => {
+    renderSimpleAttributeLabel("Height");
+    const button = screen.getByRole("button", { name: /Attribute: Height, press Enter for options/ });
+    expect(button).toBeInTheDocument();
+  });
+
+  it("uses aria-disabled rather than HTML disabled when read-only", () => {
+    renderSimpleAttributeLabel("Height", true);
+    const button = screen.getByRole("button", { name: /Attribute: Height, press Enter for options/ });
+    expect(button).toHaveAttribute("aria-disabled", "true");
+    expect(button).not.toHaveAttribute("disabled");
+  });
+
+  it("does not open the attribute menu when activated in read-only mode", () => {
+    renderSimpleAttributeLabel("Height", true);
+    const button = screen.getByRole("button", { name: /Attribute: Height, press Enter for options/ });
+    button.click();
+    // Chakra menu items are only rendered when the menu is open; in read-only
+    // mode the click is intercepted and no menuitems should appear.
+    expect(screen.queryAllByRole("menuitem")).toHaveLength(0);
+  });
+});
+
+// --- LegendDropdown (color picker) ----------------------------------------------
+
+describe("LegendDropdown — aria contract (CLUE-502 Phase 4)", () => {
+  it("MenuButton exposes the buttonAriaLabel as its accessible name", () => {
+    render(
+      <ReadOnlyContext.Provider value={false}>
+        <LegendDropdown
+          buttonAriaLabel="Color: blue"
+          buttonLabel={<span>swatch</span>}
+          menuItems={[
+            { ariaLabel: "blue", key: "#0000ff", label: "blue" },
+            { ariaLabel: "red",  key: "#ff0000", label: "red" },
+          ]}
+        />
+      </ReadOnlyContext.Provider>
+    );
+    const button = screen.getByRole("button", { name: "Color: blue" });
+    expect(button).toBeInTheDocument();
+  });
+});

--- a/src/plugins/graph/components/legend/add-series-button.tsx
+++ b/src/plugins/graph/components/legend/add-series-button.tsx
@@ -28,7 +28,12 @@ export const AddSeriesButton = observer(function AddSeriesButton() {
   const disabled = !findUnplottedAttribute();
   const classes = classNames("add-series-button", { disabled });
   return (
-    <button disabled={disabled} onClick={handleClick} className={classes}>
+    <button
+      aria-disabled={disabled}
+      aria-label="Add Y attribute"
+      className={classes}
+      onClick={disabled ? undefined : handleClick}
+    >
       <div className="legend-icon">
         <AddSeriesIcon/>
       </div>
@@ -38,5 +43,3 @@ export const AddSeriesButton = observer(function AddSeriesButton() {
     </button>
   );
 });
-
-

--- a/src/plugins/graph/components/legend/add-series-button.tsx
+++ b/src/plugins/graph/components/legend/add-series-button.tsx
@@ -32,6 +32,7 @@ export const AddSeriesButton = observer(function AddSeriesButton() {
       aria-disabled={disabled}
       aria-label="Add Y attribute"
       className={classes}
+      type="button"
       onClick={disabled ? undefined : handleClick}
     >
       <div className="legend-icon">

--- a/src/plugins/graph/components/legend/layer-legend.tsx
+++ b/src/plugins/graph/components/legend/layer-legend.tsx
@@ -87,7 +87,12 @@ const SingleLayerLegend = observer(function SingleLayerLegend(props: ILegendPart
   const layerName =
   <span className="layer-name">
     {layer.editable
-      ? <EditableLabelWithButton defaultValue={dataSetName} onSubmit={handleSetDataSetName}/>
+      ? <EditableLabelWithButton
+          defaultValue={dataSetName}
+          ariaLabel={`Dataset name: ${dataSetName}`}
+          editButtonAriaLabel={`Edit dataset name ${dataSetName}`}
+          onSubmit={handleSetDataSetName}
+        />
       : dataSetName
     }
   </span>;

--- a/src/plugins/graph/components/legend/legend-dropdown.scss
+++ b/src/plugins/graph/components/legend/legend-dropdown.scss
@@ -1,3 +1,5 @@
+@import "../../../../components/vars";
+@import "../../../../components/mixins";
 @import "./legend-vars";
 
 .legend-dropdown {
@@ -12,6 +14,8 @@
       padding: 0;
       text-align: start;
       width: 100%;
+
+      @include focus-ring(2px);
 
       .button-content {
         align-items: center;

--- a/src/plugins/graph/components/legend/multi-legend.scss
+++ b/src/plugins/graph/components/legend/multi-legend.scss
@@ -1,4 +1,5 @@
 @import "../../../../components/vars";
+@import "../../../../components/mixins";
 @import "./legend-vars";
 
 .multi-legend {
@@ -55,6 +56,8 @@
     padding: 1px;
     width: 27px;
 
+    @include focus-ring(2px);
+
     &:hover {
       background-color: $workspace-teal-light-6;
     }
@@ -95,7 +98,10 @@
     padding: 0 8px 0 0;
     text-align: left;
 
+    @include focus-ring(2px);
+
     &.disabled {
+      cursor: not-allowed;
       opacity: .3;
 
       &:hover {
@@ -179,6 +185,8 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+
+  @include focus-ring(2px);
 
   &.highlighted {
     background-color: $highlight-linked-header;

--- a/src/plugins/graph/hooks/__tests__/use-graph-dots-keyboard.test.tsx
+++ b/src/plugins/graph/hooks/__tests__/use-graph-dots-keyboard.test.tsx
@@ -1,0 +1,448 @@
+import React, { useEffect, useRef } from "react";
+import { fireEvent, render, waitFor } from "@testing-library/react";
+
+import { useGraphDotsKeyboard } from "../use-graph-dots-keyboard";
+import { activateDotSelection, buildDotAriaLabel } from "../../utilities/graph-utils";
+import { CaseData, DotsElt } from "../../d3-types";
+
+// --- buildDotAriaLabel ----------------------------------------------------------
+
+describe("buildDotAriaLabel", () => {
+  const makeDataConfig = (overrides: Record<string, any> = {}) => ({
+    dataset: {
+      getNumeric: (caseID: string, attrID: string) => {
+        if (attrID === "ax") return 12;
+        if (attrID === "ay") return 43.5;
+        return undefined;
+      },
+      attrFromID: (id: string) => id === "ay" ? { name: "Distance" } : undefined,
+      isCaseSelected: () => false,
+      isAttributeSelected: () => false,
+      isCellSelected: () => false,
+    },
+    attributeID: (role: string) => role === "x" ? "ax" : "",
+    xAttributeID: "ax",
+    yAttributeIDs: ["ay"],
+    yAttributeID: () => "ay",
+    ...overrides,
+  } as any);
+
+  const caseData: CaseData = { dataConfigID: "dc1", plotNum: 0, caseID: "c1" };
+
+  it("formats X and Y values for a single-series scatter plot", () => {
+    const cfg = makeDataConfig();
+    expect(buildDotAriaLabel(caseData, cfg)).toBe("Point: X=12, Y=43.5");
+  });
+
+  it("appends Series when more than one Y attribute is mapped", () => {
+    const cfg = makeDataConfig({ yAttributeIDs: ["ay", "ay2"] });
+    expect(buildDotAriaLabel(caseData, cfg)).toBe("Point: X=12, Y=43.5, Series: Distance");
+  });
+
+  it("appends ', Selected' when the case is selected", () => {
+    const cfg = makeDataConfig({
+      dataset: {
+        getNumeric: (caseID: string, attrID: string) => attrID === "ax" ? 12 : 43.5,
+        attrFromID: () => undefined,
+        isCaseSelected: () => true,
+        isAttributeSelected: () => false,
+        isCellSelected: () => false,
+      },
+    });
+    expect(buildDotAriaLabel(caseData, cfg)).toBe("Point: X=12, Y=43.5, Selected");
+  });
+
+  it("returns 'Point' alone when no data configuration is available", () => {
+    expect(buildDotAriaLabel(caseData, undefined)).toBe("Point");
+  });
+
+  it("appends Color when a legend attribute is mapped (CLUE-502 Phase 7)", () => {
+    // Mimic a CODAP-legend graph where the legend attribute provides category
+    // colors. The legend attribute's value for this case is "dog".
+    const cfg = makeDataConfig({
+      dataset: {
+        getNumeric: (_caseID: string, attrID: string) => attrID === "ax" ? 12 : 43.5,
+        getValue: (_caseID: string, attrID: string) => attrID === "leg" ? "dog" : undefined,
+        attrFromID: () => undefined,
+        isCaseSelected: () => false,
+        isAttributeSelected: () => false,
+        isCellSelected: () => false,
+      },
+      // Override attributeID so the helper can locate the legend mapping.
+      attributeID: (role: string) => {
+        if (role === "x") return "ax";
+        if (role === "legend") return "leg";
+        return "";
+      },
+    });
+    expect(buildDotAriaLabel(caseData, cfg)).toBe("Point: X=12, Y=43.5, Color: dog");
+  });
+
+  it("aria-label updates when the case's X value changes", () => {
+    // Simulates setPointCoordinates re-running after the underlying dataset has
+    // changed: the dot's bound CaseData is unchanged, but `getNumeric` returns
+    // a new X value, and the aria-label re-derived from the helper reflects it.
+    let currentX = 12;
+    const cfg = makeDataConfig({
+      dataset: {
+        getNumeric: (caseID: string, attrID: string) => {
+          if (attrID === "ax") return currentX;
+          if (attrID === "ay") return 43.5;
+          return undefined;
+        },
+        attrFromID: () => undefined,
+        isCaseSelected: () => false,
+        isAttributeSelected: () => false,
+        isCellSelected: () => false,
+      },
+    });
+    expect(buildDotAriaLabel(caseData, cfg)).toBe("Point: X=12, Y=43.5");
+    currentX = 99;
+    expect(buildDotAriaLabel(caseData, cfg)).toBe("Point: X=99, Y=43.5");
+  });
+});
+
+// --- activateDotSelection ---------------------------------------------------------
+
+describe("activateDotSelection", () => {
+  const caseData: CaseData = { dataConfigID: "dc1", plotNum: 0, caseID: "c1" };
+
+  it("sets the y-cell as the sole selection on first activation", () => {
+    const setSelectedCells = jest.fn();
+    const cfg = {
+      dataset: {
+        isCellSelected: () => false,
+        selectCells: jest.fn(),
+        setSelectedCells,
+      },
+      yAttributeID: () => "ay",
+    } as any;
+    activateDotSelection(caseData, cfg);
+    expect(setSelectedCells).toHaveBeenCalledWith([{ attributeId: "ay", caseId: "c1" }]);
+  });
+
+  it("extends the existing selection when extendSelection is true", () => {
+    const selectCells = jest.fn();
+    const cfg = {
+      dataset: {
+        isCellSelected: () => false,
+        selectCells,
+        setSelectedCells: jest.fn(),
+      },
+      yAttributeID: () => "ay",
+    } as any;
+    activateDotSelection(caseData, cfg, true);
+    expect(selectCells).toHaveBeenCalledWith([{ attributeId: "ay", caseId: "c1" }]);
+  });
+
+  it("deselects an already-selected case when extendSelection is true", () => {
+    const selectCells = jest.fn();
+    const cfg = {
+      dataset: {
+        isCellSelected: () => true,
+        selectCells,
+        setSelectedCells: jest.fn(),
+      },
+      yAttributeID: () => "ay",
+    } as any;
+    activateDotSelection(caseData, cfg, true);
+    expect(selectCells).toHaveBeenCalledWith([{ attributeId: "ay", caseId: "c1" }], false);
+  });
+
+  it("no-ops when dataConfiguration is undefined", () => {
+    expect(() => activateDotSelection(caseData, undefined)).not.toThrow();
+  });
+});
+
+// --- useGraphDotsKeyboard hook --------------------------------------------------
+
+interface IFakeDot { caseID: string; x: number; y: number; }
+
+/**
+ * Test harness component that mounts the hook against an SVG dots-group surrogate.
+ * Lets each test assert focus / aria behaviour after dispatching keyboard events.
+ */
+function HookHarness(props: {
+  dots: IFakeDot[];
+  readOnly?: boolean;
+  dataConfiguration?: any;
+}) {
+  const { dots, readOnly = false, dataConfiguration } = props;
+  const ref = useRef<DotsElt>(null);
+
+  useGraphDotsKeyboard({
+    dotsRef: ref,
+    dataConfiguration,
+    readOnly,
+  });
+
+  // Manually attach __data__ to each <g> after mount so the hook can read the
+  // CaseData binding (D3 does this in production via .datum()).
+  useEffect(() => {
+    const container = ref.current;
+    if (!container) return;
+    Array.from(container.querySelectorAll<SVGGElement>("g.graph-dot")).forEach(g => {
+      const id = g.getAttribute("data-case-id") ?? "";
+      const caseData: CaseData = { dataConfigID: "dc1", plotNum: 0, caseID: id };
+      (g as unknown as { __data__: CaseData }).__data__ = caseData;
+    });
+  }, [dots]);
+
+  return (
+    <div className="graph-wrapper">
+      <div data-graph-announcer="" data-testid="announcer" aria-live="polite" />
+      <svg
+        ref={ref}
+        data-graph-dots-group=""
+        role="group"
+        aria-label="Data points"
+        tabIndex={0}
+      >
+        {dots.map(dot => (
+          <g
+            key={dot.caseID}
+            className="graph-dot"
+            role="button"
+            tabIndex={-1}
+            transform={`translate(${dot.x} ${dot.y})`}
+            aria-pressed="false"
+            aria-label={`Point: X=${dot.x}, Y=${dot.y}`}
+            data-case-id={dot.caseID}
+            data-testid={`dot-${dot.caseID}`}
+          />
+        ))}
+      </svg>
+    </div>
+  );
+}
+
+
+describe("useGraphDotsKeyboard", () => {
+  // Default fake data configuration: knows about selection state and exposes the
+  // surfaces buildDotAriaLabel / activateDotSelection read.
+  function makeFakeConfig(selected: Set<string> = new Set()) {
+    return {
+      dataset: {
+        getNumeric: () => 0,
+        attrFromID: () => undefined,
+        isCellSelected: (cell: { caseId: string }) => selected.has(cell.caseId),
+        isCaseSelected: (caseId: string) => selected.has(caseId),
+        isAttributeSelected: () => false,
+        selectCells: jest.fn(),
+        setSelectedCells: jest.fn((cells: Array<{ caseId: string }>) => {
+          selected.clear();
+          cells.forEach(c => selected.add(c.caseId));
+        }),
+      },
+      attributeID: () => "",
+      yAttributeIDs: [],
+      yAttributeID: () => "ay",
+    } as any;
+  }
+
+  it("focuses the first data point in reading order when the dots group receives focus", () => {
+    const dots: IFakeDot[] = [
+      { caseID: "c3", x: 300, y: 50 },
+      { caseID: "c1", x: 100, y: 50 },
+      { caseID: "c2", x: 200, y: 50 },
+    ];
+    const { getByRole, getByTestId } = render(
+      <HookHarness dots={dots} dataConfiguration={makeFakeConfig()} />
+    );
+    const group = getByRole("group");
+    group.focus();
+    fireEvent.focus(group);
+    expect(document.activeElement).toBe(getByTestId("dot-c1"));
+  });
+
+  it("ArrowRight moves focus to the next dot in screen-X order", () => {
+    const dots: IFakeDot[] = [
+      { caseID: "c1", x: 100, y: 50 },
+      { caseID: "c2", x: 200, y: 50 },
+      { caseID: "c3", x: 300, y: 50 },
+    ];
+    const { getByRole, getByTestId } = render(
+      <HookHarness dots={dots} dataConfiguration={makeFakeConfig()} />
+    );
+    const group = getByRole("group");
+    group.focus();
+    fireEvent.focus(group);
+    fireEvent.keyDown(group, { key: "ArrowRight" });
+    expect(document.activeElement).toBe(getByTestId("dot-c2"));
+    fireEvent.keyDown(group, { key: "ArrowRight" });
+    expect(document.activeElement).toBe(getByTestId("dot-c3"));
+  });
+
+  it("ArrowLeft wraps from first to last", () => {
+    const dots: IFakeDot[] = [
+      { caseID: "c1", x: 100, y: 50 },
+      { caseID: "c2", x: 200, y: 50 },
+    ];
+    const { getByRole, getByTestId } = render(
+      <HookHarness dots={dots} dataConfiguration={makeFakeConfig()} />
+    );
+    const group = getByRole("group");
+    group.focus();
+    fireEvent.focus(group);
+    fireEvent.keyDown(group, { key: "ArrowLeft" });
+    expect(document.activeElement).toBe(getByTestId("dot-c2"));
+  });
+
+  it("sorts by screen-Y when screen-X is tied", () => {
+    const dots: IFakeDot[] = [
+      { caseID: "c-bottom", x: 100, y: 200 },
+      { caseID: "c-top",    x: 100, y: 50 },
+    ];
+    const { getByRole, getByTestId } = render(
+      <HookHarness dots={dots} dataConfiguration={makeFakeConfig()} />
+    );
+    const group = getByRole("group");
+    group.focus();
+    fireEvent.focus(group);
+    // First dot in reading order should be the lower screen-Y (top of plot).
+    expect(document.activeElement).toBe(getByTestId("dot-c-top"));
+  });
+
+  it("Home jumps to first dot, End jumps to last", () => {
+    const dots: IFakeDot[] = [
+      { caseID: "c1", x: 100, y: 50 },
+      { caseID: "c2", x: 200, y: 50 },
+      { caseID: "c3", x: 300, y: 50 },
+    ];
+    const { getByRole, getByTestId } = render(
+      <HookHarness dots={dots} dataConfiguration={makeFakeConfig()} />
+    );
+    const group = getByRole("group");
+    group.focus();
+    fireEvent.focus(group);
+    fireEvent.keyDown(group, { key: "End" });
+    expect(document.activeElement).toBe(getByTestId("dot-c3"));
+    fireEvent.keyDown(group, { key: "Home" });
+    expect(document.activeElement).toBe(getByTestId("dot-c1"));
+  });
+
+  it("Enter toggles selection of the focused dot via the dataset action", () => {
+    const dots: IFakeDot[] = [{ caseID: "c1", x: 100, y: 50 }];
+    const selected = new Set<string>();
+    const cfg = makeFakeConfig(selected);
+    const { getByRole } = render(<HookHarness dots={dots} dataConfiguration={cfg} />);
+    const group = getByRole("group");
+    group.focus();
+    fireEvent.focus(group);
+    fireEvent.keyDown(group, { key: "Enter" });
+    expect(cfg.dataset.setSelectedCells).toHaveBeenCalledWith([{ attributeId: "ay", caseId: "c1" }]);
+  });
+
+  it("does not toggle selection on Enter in read-only mode", () => {
+    const dots: IFakeDot[] = [{ caseID: "c1", x: 100, y: 50 }];
+    const cfg = makeFakeConfig();
+    const { getByRole } = render(<HookHarness dots={dots} dataConfiguration={cfg} readOnly />);
+    const group = getByRole("group");
+    group.focus();
+    fireEvent.focus(group);
+    fireEvent.keyDown(group, { key: "Enter" });
+    expect(cfg.dataset.setSelectedCells).not.toHaveBeenCalled();
+    expect(cfg.dataset.selectCells).not.toHaveBeenCalled();
+  });
+
+  // A data configuration whose `buildDotAriaLabel` output varies per caseID, so
+  // tests can verify that the announcer receives the *focused* dot's label.
+  function makeConfigWithDistinctLabels() {
+    return {
+      dataset: {
+        getNumeric: (caseID: string, attrID: string) => {
+          if (caseID === "c1") return attrID === "ax" ? 10 : 100;
+          if (caseID === "c2") return attrID === "ax" ? 20 : 200;
+          if (caseID === "c3") return attrID === "ax" ? 30 : 300;
+          return undefined;
+        },
+        attrFromID: () => undefined,
+        isCellSelected: () => false,
+        isCaseSelected: () => false,
+        isAttributeSelected: () => false,
+        selectCells: jest.fn(),
+        setSelectedCells: jest.fn(),
+      },
+      attributeID: (role: string) => role === "x" ? "ax" : role === "y" ? "ay" : "",
+      xAttributeID: "ax",
+      yAttributeIDs: ["ay"],
+      yAttributeID: () => "ay",
+    } as any;
+  }
+
+  it("announces the focused dot's label on ArrowRight", async () => {
+    const dots: IFakeDot[] = [
+      { caseID: "c1", x: 100, y: 50 },
+      { caseID: "c2", x: 200, y: 50 },
+    ];
+    const { getByRole, getByTestId } = render(
+      <HookHarness dots={dots} dataConfiguration={makeConfigWithDistinctLabels()} />
+    );
+    const group = getByRole("group");
+    const announcer = getByTestId("announcer");
+    group.focus();
+    fireEvent.focus(group);
+    fireEvent.keyDown(group, { key: "ArrowRight" });
+    await waitFor(() => {
+      expect(announcer.textContent).toBe("Point: X=20, Y=200");
+    });
+  });
+
+  it("announces the focused dot's label on Home and End", async () => {
+    const dots: IFakeDot[] = [
+      { caseID: "c1", x: 100, y: 50 },
+      { caseID: "c2", x: 200, y: 50 },
+      { caseID: "c3", x: 300, y: 50 },
+    ];
+    const { getByRole, getByTestId } = render(
+      <HookHarness dots={dots} dataConfiguration={makeConfigWithDistinctLabels()} />
+    );
+    const group = getByRole("group");
+    const announcer = getByTestId("announcer");
+    group.focus();
+    fireEvent.focus(group);
+    fireEvent.keyDown(group, { key: "End" });
+    await waitFor(() => {
+      expect(announcer.textContent).toBe("Point: X=30, Y=300");
+    });
+    fireEvent.keyDown(group, { key: "Home" });
+    await waitFor(() => {
+      expect(announcer.textContent).toBe("Point: X=10, Y=100");
+    });
+  });
+
+  it("does not announce on initial focus (lets the browser read the focused dot)", async () => {
+    const dots: IFakeDot[] = [{ caseID: "c1", x: 100, y: 50 }];
+    const { getByRole, getByTestId } = render(
+      <HookHarness dots={dots} dataConfiguration={makeConfigWithDistinctLabels()} />
+    );
+    const group = getByRole("group");
+    const announcer = getByTestId("announcer");
+    group.focus();
+    fireEvent.focus(group);
+    // Wait long enough for any double-rAF announce to have flushed.
+    await new Promise(resolve => setTimeout(resolve, 50));
+    expect(announcer.textContent).toBe("");
+  });
+
+  it("remembers the focused dot's caseID when focus returns to the group", () => {
+    const dots: IFakeDot[] = [
+      { caseID: "c1", x: 100, y: 50 },
+      { caseID: "c2", x: 200, y: 50 },
+      { caseID: "c3", x: 300, y: 50 },
+    ];
+    const { getByRole, getByTestId } = render(
+      <HookHarness dots={dots} dataConfiguration={makeFakeConfig()} />
+    );
+    const group = getByRole("group");
+    group.focus();
+    fireEvent.focus(group);
+    fireEvent.keyDown(group, { key: "ArrowRight" });
+    fireEvent.keyDown(group, { key: "ArrowRight" });
+    expect(document.activeElement).toBe(getByTestId("dot-c3"));
+    // Simulate a Tab-out and Tab-back-in by re-focusing the group.
+    group.focus();
+    fireEvent.focus(group);
+    expect(document.activeElement).toBe(getByTestId("dot-c3"));
+  });
+});

--- a/src/plugins/graph/hooks/use-graph-dots-keyboard.ts
+++ b/src/plugins/graph/hooks/use-graph-dots-keyboard.ts
@@ -1,0 +1,243 @@
+import React, { useCallback, useEffect, useRef } from "react";
+import { CaseData, DotsElt, graphDotSelector } from "../d3-types";
+import { IDataConfigurationModel } from "../models/data-configuration-model";
+import { activateDotSelection, buildDotAriaLabel } from "../utilities/graph-utils";
+
+interface IUseGraphDotsKeyboardProps {
+  dotsRef: React.MutableRefObject<DotsElt>;
+  dataConfiguration: IDataConfigurationModel | undefined;
+  readOnly: boolean;
+}
+
+/**
+ * Finds the aria-live announcer element for the graph tile containing `start`.
+ *
+ * The announcer is rendered as a direct child of `.graph-wrapper`. We anchor
+ * on the nearest `.graph-wrapper` ancestor and use `:scope >` so the query
+ * only matches that direct child — never descendants. That keeps the lookup
+ * correct in nested-tile setups (e.g. a graph tile inside a question tile
+ * that contains another graph), where a plain descendant query could match
+ * the wrong announcer.
+ */
+function findAnnouncer(start: Element | null): HTMLElement | null {
+  if (!start) return null;
+  const wrapper = start.closest(".graph-wrapper");
+  return wrapper?.querySelector<HTMLElement>(":scope > [data-graph-announcer]") ?? null;
+}
+
+interface IDotEntry {
+  element: SVGGElement;
+  caseData: CaseData;
+  screenX: number;
+  screenY: number;
+}
+
+/**
+ * Reads the dot's current screen position from its `transform="translate(x y)"`
+ * attribute (set by `setPointCoordinates`). Returns Infinity coordinates for dots
+ * that don't have a transform yet so they sort to the end.
+ */
+function readDotPosition(g: SVGGElement): { x: number; y: number } {
+  const transform = g.getAttribute("transform");
+  if (!transform) return { x: Infinity, y: Infinity };
+  // setPointCoordinates writes `translate(x y)` (space-separated, no comma).
+  const match = /translate\(([-\d.]+)\s+([-\d.]+)\)/.exec(transform);
+  if (!match) return { x: Infinity, y: Infinity };
+  return { x: parseFloat(match[1]), y: parseFloat(match[2]) };
+}
+
+/**
+ * Roving-tabindex keyboard navigation over the data points in a single graph layer.
+ *
+ * Bind by passing a ref to the layer's dots-group surrogate (the `<svg ref={dotsRef}>`
+ * element created by GraphLayer) and the layer's data configuration. The hook
+ * attaches `focus` and `keydown` handlers that:
+ * - On group focus: focus the previously-roved dot (by case ID), or the first dot.
+ * - Arrow keys (Left/Right/Up/Down): move focus among dots in screen-reading order
+ *   (screen X first, then screen Y, with case ID as a stability tiebreak).
+ * - Home / End: jump to first / last dot.
+ * - Enter / Space: toggle the case's selection (Shift extends the existing selection).
+ *   Read-only graphs no-op selection silently.
+ *
+ * The hook tracks the focused dot by **case ID** (not array index) so that dot
+ * drags or data updates that reorder the sorted list don't strand focus on the
+ * wrong case.
+ *
+ * Selection-change announcements are routed to the nearest tile's `[data-graph-announcer]`
+ * aria-live region (located via DOM walk from `dotsRef.current`) — debounced via
+ * requestAnimationFrame so rapid arrow + Enter sequences don't overlap.
+ *
+ * @param props.dotsRef Layer's dots-group surrogate, where `.graph-dot` children live.
+ * @param props.dataConfiguration Layer data configuration (for selection toggling
+ *   and aria-label refresh).
+ * @param props.readOnly When true, Enter / Space silently no-op on selection.
+ */
+export function useGraphDotsKeyboard(props: IUseGraphDotsKeyboardProps) {
+  const { dotsRef, dataConfiguration, readOnly } = props;
+
+  // Track the focused dot's case ID across re-renders. Tracking by ID rather than
+  // index keeps focus stable when point positions shift.
+  const focusedCaseIdRef = useRef<string | null>(null);
+
+  // Dev-mode stability guard: warn if the dots-group container identity changes
+  // between effect runs, which would invalidate D3-attached event handlers.
+  const lastContainerRef = useRef<DotsElt>(null);
+
+  /**
+   * Collects dots in reading order (screen X first, then screen Y, then caseID).
+   * Recomputed on every key event because dot positions can change between events.
+   */
+  const collectSortedDots = useCallback((): IDotEntry[] => {
+    const container = dotsRef.current;
+    if (!container) return [];
+    const elements = Array.from(
+      container.querySelectorAll<SVGGElement>(graphDotSelector)
+    );
+    const entries: IDotEntry[] = elements
+      .map(element => {
+        // D3 attaches the bound datum under __data__.
+        const datum = (element as unknown as { __data__?: CaseData }).__data__;
+        if (!datum) return undefined;
+        const { x, y } = readDotPosition(element);
+        return { element, caseData: datum, screenX: x, screenY: y };
+      })
+      .filter((entry): entry is IDotEntry => entry !== undefined);
+    entries.sort((a, b) => {
+      if (a.screenX !== b.screenX) return a.screenX - b.screenX;
+      if (a.screenY !== b.screenY) return a.screenY - b.screenY;
+      return a.caseData.caseID.localeCompare(b.caseData.caseID);
+    });
+    return entries;
+  }, [dotsRef]);
+
+  const focusEntry = useCallback((entry: IDotEntry | undefined) => {
+    if (!entry) return;
+    // `.keyboard-focused` is a fallback for Safari, whose `:focus-visible`
+    // doesn't fire reliably on programmatically-focused SVG elements. Pair it
+    // with `.focus()` so the focus ring appears across all supported browsers.
+    const container = dotsRef.current;
+    container?.querySelectorAll<SVGGElement>(".graph-dot.keyboard-focused")
+      .forEach(el => el.classList.remove("keyboard-focused"));
+    focusedCaseIdRef.current = entry.caseData.caseID;
+    entry.element.classList.add("keyboard-focused");
+    entry.element.focus();
+  }, [dotsRef]);
+
+  const announce = useCallback((message: string) => {
+    const region = findAnnouncer(dotsRef.current);
+    if (!region) return;
+    // Debounce via requestAnimationFrame so rapid arrow-key + Enter sequences don't
+    // produce overlapping announcements. Setting textContent to '' first forces
+    // screen readers to re-announce identical messages.
+    requestAnimationFrame(() => {
+      region.textContent = "";
+      requestAnimationFrame(() => {
+        region.textContent = message;
+      });
+    });
+  }, [dotsRef]);
+
+  useEffect(() => {
+    const container = dotsRef.current;
+    if (!container) return;
+
+    if (process.env.NODE_ENV !== "production"
+        && lastContainerRef.current
+        && lastContainerRef.current !== container) {
+      console.warn(
+        "[useGraphDotsKeyboard] dots-group container identity changed between renders; "
+        + "this can break D3-attached event handlers."
+      );
+    }
+    lastContainerRef.current = container;
+
+    const handleFocus = (e: FocusEvent) => {
+      // Only respond when the group surrogate itself receives focus (not a dot
+      // bubbling up). When Tab enters the group, focus the previously-roved dot
+      // or fall back to the first dot in reading order.
+      if (e.target !== container) return;
+      const entries = collectSortedDots();
+      if (entries.length === 0) return;
+      const remembered = focusedCaseIdRef.current
+        ? entries.find(entry => entry.caseData.caseID === focusedCaseIdRef.current)
+        : undefined;
+      focusEntry(remembered ?? entries[0]);
+    };
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const entries = collectSortedDots();
+      if (entries.length === 0) return;
+      const currentIndex = focusedCaseIdRef.current
+        ? entries.findIndex(entry => entry.caseData.caseID === focusedCaseIdRef.current)
+        : -1;
+      const lastIndex = entries.length - 1;
+
+      let nextIndex: number | undefined;
+      let consume = false;
+
+      switch (e.key) {
+        case "ArrowRight":
+        case "ArrowDown":
+          nextIndex = currentIndex < 0 ? 0 : (currentIndex + 1) % entries.length;
+          consume = true;
+          break;
+        case "ArrowLeft":
+        case "ArrowUp":
+          nextIndex = currentIndex < 0 ? lastIndex : (currentIndex - 1 + entries.length) % entries.length;
+          consume = true;
+          break;
+        case "Home":
+          nextIndex = 0;
+          consume = true;
+          break;
+        case "End":
+          nextIndex = lastIndex;
+          consume = true;
+          break;
+        case "Enter":
+        case " ": {
+          consume = true;
+          if (readOnly) break;
+          const focusedEntry = currentIndex >= 0 ? entries[currentIndex] : entries[0];
+          if (!focusedEntry) break;
+          activateDotSelection(focusedEntry.caseData, dataConfiguration, e.shiftKey);
+          // Re-read the aria-label so the announcement reflects the post-activation state.
+          const label = buildDotAriaLabel(focusedEntry.caseData, dataConfiguration);
+          announce(label);
+          break;
+        }
+        default:
+          return;
+      }
+
+      if (consume) {
+        e.preventDefault();
+        e.stopPropagation();
+      }
+      if (nextIndex !== undefined) {
+        const nextEntry = entries[nextIndex];
+        focusEntry(nextEntry);
+        announce(buildDotAriaLabel(nextEntry.caseData, dataConfiguration));
+      }
+    };
+
+    // Clear the `.keyboard-focused` ring fallback (see focusEntry) when focus
+    // leaves the dots group entirely. focusout bubbles, so we get notified
+    // whether the user tabs away from the group or from a focused child dot.
+    const handleFocusOut = (e: FocusEvent) => {
+      const next = e.relatedTarget as Node | null;
+      if (next && container.contains(next)) return;
+      container.querySelectorAll<SVGGElement>(".graph-dot.keyboard-focused")
+        .forEach(el => el.classList.remove("keyboard-focused"));
+    };
+
+    container.addEventListener("focus", handleFocus);
+    container.addEventListener("keydown", handleKeyDown);
+    container.addEventListener("focusout", handleFocusOut);
+    return () => {
+      container.removeEventListener("focus", handleFocus);
+      container.removeEventListener("keydown", handleKeyDown);
+      container.removeEventListener("focusout", handleFocusOut);
+    };
+  }, [dotsRef, collectSortedDots, dataConfiguration, focusEntry, readOnly, announce]);
+}

--- a/src/plugins/graph/hooks/use-graph-dots-keyboard.ts
+++ b/src/plugins/graph/hooks/use-graph-dots-keyboard.ts
@@ -1,7 +1,8 @@
 import React, { useCallback, useEffect, useRef } from "react";
+import { ICell } from "../../../models/data/data-types";
 import { CaseData, DotsElt, graphDotSelector } from "../d3-types";
 import { IDataConfigurationModel } from "../models/data-configuration-model";
-import { activateDotSelection, buildDotAriaLabel } from "../utilities/graph-utils";
+import { activateDotSelection, buildDotAriaLabel, isDotKeyActivated } from "../utilities/graph-utils";
 
 interface IUseGraphDotsKeyboardProps {
   dotsRef: React.MutableRefObject<DotsElt>;
@@ -200,7 +201,26 @@ export function useGraphDotsKeyboard(props: IUseGraphDotsKeyboardProps) {
           if (readOnly) break;
           const focusedEntry = currentIndex >= 0 ? entries[currentIndex] : entries[0];
           if (!focusedEntry) break;
-          activateDotSelection(focusedEntry.caseData, dataConfiguration, e.shiftKey);
+          if (!e.shiftKey && isDotKeyActivated(focusedEntry.caseData, dataConfiguration)) {
+            // Toggle off: clear the case + X/Y-cell selections that aria-pressed
+            // tracks, so a single Enter on a pressed dot flips aria-pressed to
+            // false (matching aria toggle-button semantics). Leave attribute
+            // (column-header) selection alone — that's column-wide and can't
+            // be un-toggled by a single dot.
+            const dataset = dataConfiguration?.dataset;
+            const caseId = focusedEntry.caseData.caseID;
+            const xAttributeId = dataConfiguration?.xAttributeID;
+            const yAttributeId = dataConfiguration?.yAttributeID(focusedEntry.caseData.plotNum);
+            const cells: ICell[] = [];
+            if (xAttributeId) cells.push({ attributeId: xAttributeId, caseId });
+            if (yAttributeId) cells.push({ attributeId: yAttributeId, caseId });
+            if (cells.length > 0) dataset?.selectCells(cells, false);
+            dataset?.selectCases([caseId], false);
+          } else {
+            // Otherwise fall through to the click-mirroring activation
+            // (select-if-unselected; Shift+Enter extends).
+            activateDotSelection(focusedEntry.caseData, dataConfiguration, e.shiftKey);
+          }
           // Re-read the aria-label so the announcement reflects the post-activation state.
           const label = buildDotAriaLabel(focusedEntry.caseData, dataConfiguration);
           announce(label);

--- a/src/plugins/graph/imports/components/axis/components/axis-or-legend-attribute-menu.tsx
+++ b/src/plugins/graph/imports/components/axis/components/axis-or-legend-attribute-menu.tsx
@@ -94,15 +94,27 @@ export const AxisOrLegendAttributeMenu = ({
     });
   }, [attribute?.name, data?.attributes, dataConfig, labelText, setLabelText, attrId]);
 
+  const legendAriaLabel = attribute?.name
+    ? `Attribute: ${attribute.name}, press Enter for options`
+    : "Choose attribute, press Enter for options";
+
   const getButtonPart = (isOpen: boolean) => {
     return target
-    ? <MenuButton style={buttonStyle}>{attribute?.name}</MenuButton>
+    ? <MenuButton
+        style={buttonStyle}
+        data-axis-menu-place={place}
+        aria-disabled={readOnly || undefined}
+      >
+        {attribute?.name}
+      </MenuButton>
     : (
       <MenuButton
+        aria-label={legendAriaLabel}
         className={classNames(
           "graph-legend-label normal-dropdown-label simple-attribute-label",
           {"target-open": isOpen, "target-closed": !isOpen}
         )}
+        aria-disabled={readOnly || undefined}
       >
         <div className={classNames("styled-button", { highlighted })}>
           <div className="symbol-title">
@@ -163,9 +175,20 @@ export const AxisOrLegendAttributeMenu = ({
     </>
   );
 
+  const [menuOpen, setMenuOpen] = useState(false);
+  const handleMenuOpen = () => {
+    if (!readOnly) setMenuOpen(true);
+  };
+  const handleMenuClose = () => setMenuOpen(false);
+
   return (
     <div className={`axis-legend-attribute-menu ${place}`} >
-      <Menu boundary="scrollParent">
+      <Menu
+        boundary="scrollParent"
+        isOpen={menuOpen}
+        onOpen={handleMenuOpen}
+        onClose={handleMenuClose}
+      >
         {({ onClose, isOpen }) => {
           onCloseRef.current = onClose;
           const menuButtonAndPortal = getMenuButtonAndPortal(isOpen);

--- a/src/plugins/graph/utilities/graph-utils.ts
+++ b/src/plugins/graph/utilities/graph-utils.ts
@@ -156,6 +156,91 @@ export function getPointTipText(caseID: string, attributeIDs: (string|undefined)
   return Array.from(new Set(attrArray)).filter(anEntry => anEntry !== '').join('<br>');
 }
 
+/**
+ * Builds an accessible label for a single data point. Form:
+ *   "Point: X=<x>, Y=<y>[, Series: <yAttributeName>][, Color: <legendValueName>][, Selected]"
+ *
+ * The series suffix is included only when more than one Y attribute is mapped, so
+ * single-series scatter plots don't include redundant noise. The color suffix is
+ * included only when a legend attribute is mapped (CODAP-legend mode); it carries
+ * the case's legend-category value so SR users can correlate dot colors with the
+ * legend without relying on visual color perception.
+ *
+ * @param caseData The CaseData bound to the dot's `<g>` via D3.
+ * @param dataConfiguration Layer data configuration for attribute lookup.
+ */
+export function buildDotAriaLabel(
+  caseData: CaseData,
+  dataConfiguration: IDataConfigurationModel | undefined
+): string {
+  if (!dataConfiguration) return "Point";
+  const dataset = dataConfiguration.dataset;
+  const caseID = caseData.caseID;
+  const xAttrID = dataConfiguration.attributeID("x") || "";
+  const yAttrIDs = dataConfiguration.yAttributeIDs || [];
+  const yAttrID = yAttrIDs[caseData.plotNum] || "";
+
+  const xValue = dataset?.getNumeric(caseID, xAttrID);
+  const yValue = dataset?.getNumeric(caseID, yAttrID);
+
+  let label = "Point";
+  if (xValue !== undefined && isFinite(xValue)) label += `: X=${xValue}`;
+  else label += ":";
+  if (yValue !== undefined && isFinite(yValue)) label += `, Y=${yValue}`;
+
+  if (yAttrIDs.length > 1) {
+    const seriesName = dataset?.attrFromID(yAttrID)?.name;
+    if (seriesName) label += `, Series: ${seriesName}`;
+  }
+
+  const legendAttrID = dataConfiguration.attributeID("legend");
+  if (legendAttrID) {
+    const legendValue = dataset?.getValue(caseID, legendAttrID);
+    if (legendValue) label += `, Color: ${legendValue}`;
+  }
+
+  if (isCircleSelected(caseData, dataConfiguration)) {
+    label += ", Selected";
+  }
+  return label;
+}
+
+/**
+ * Applies the selection action for a keyboard-activated data point. Mirrors
+ * the case-toggling branch of {@link handleClickOnDot} so Enter / Space on a
+ * focused dot produces the same selection behaviour as a click:
+ *  - Plain activation on an unselected dot makes it the sole selection.
+ *  - Shift-activation on an unselected dot adds it to the selection.
+ *  - Shift-activation on an already-selected dot removes it from the selection.
+ *  - Plain activation on an already-selected dot is a no-op (matches click).
+ *
+ * @param caseData The CaseData bound to the focused dot.
+ * @param dataConfiguration Layer data configuration owning the dataset.
+ * @param extendSelection When true (e.g. Shift+Enter), the dot is added to or
+ *   removed from the existing selection. When false, the dot becomes the sole
+ *   selected case.
+ */
+export function activateDotSelection(
+  caseData: CaseData,
+  dataConfiguration: IDataConfigurationModel | undefined,
+  extendSelection = false
+) {
+  if (!dataConfiguration) return;
+  const dataset = dataConfiguration.dataset;
+  const yAttributeId = dataConfiguration.yAttributeID(caseData.plotNum);
+  const yCell = { attributeId: yAttributeId, caseId: caseData.caseID };
+  const cellIsSelected = dataset?.isCellSelected(yCell);
+  if (!cellIsSelected) {
+    if (extendSelection) {
+      dataset?.selectCells([yCell]);
+    } else {
+      dataset?.setSelectedCells([yCell]);
+    }
+  } else if (extendSelection) {
+    dataset?.selectCells([yCell], false);
+  }
+}
+
 export function handleClickOnDot(event: MouseEvent, caseData: CaseData, dataConfiguration?: IDataConfigurationModel) {
   if (!dataConfiguration) return;
   event.stopPropagation();
@@ -628,6 +713,19 @@ export function setPointCoordinates(props: ISetPointCoordinates) {
   const outerCircles = selectOuterCircles(dotsRef.current);
   if (outerCircles) applySelectedClassToCircles(outerCircles, dataConfiguration);
   styleOuterCircles(outerCircles, dataConfiguration);
+
+  // Apply keyboard-accessibility attributes to each dot. tabindex=-1 keeps dots
+  // out of the natural Tab cycle (the dots-group surrogate is the single tab stop)
+  // while letting `useGraphDotsKeyboard` programmatically focus them via arrow keys.
+  // aria-label/aria-pressed are re-applied on every refresh so they stay in sync
+  // with current data values and selection state.
+  if (graphDots) {
+    graphDots
+      .attr("tabindex", -1)
+      .attr("role", "button")
+      .attr("aria-label", (d: CaseData) => buildDotAriaLabel(d, dataConfiguration))
+      .attr("aria-pressed", (d: CaseData) => isCircleSelected(d, dataConfiguration) ? "true" : "false");
+  }
 }
 
 /**

--- a/src/plugins/graph/utilities/graph-utils.ts
+++ b/src/plugins/graph/utilities/graph-utils.ts
@@ -361,19 +361,22 @@ function isCircleSelected(aCaseData: CaseData, dataConfiguration?: IDataConfigur
 }
 
 /**
- * Whether the dot's keyboard toggle (Enter / Space, the same action driven by
- * {@link activateDotSelection}) is currently in its "pressed" state. Narrower
- * than {@link isCircleSelected}: only the Y cell counts, since that's the
- * only thing keyboard activation toggles. Used to drive `aria-pressed`, so
- * the announced state reflects what *this button* controls, not unrelated
- * selections (attribute header, X cell, broader case selection) that the dot
- * cannot un-toggle.
+ * Whether the dot's keyboard toggle (Enter / Space) is currently in its
+ * "pressed" state. Narrower than {@link isCircleSelected}: a single keyboard
+ * activation must be able to flip this back to false, so it covers exactly
+ * the selection states the keyboard toggle clears — case, X-cell, and
+ * Y-cell. Attribute (column-header) selection is column-wide and stays out
+ * of scope; if a dot is visually selected only because its attribute is
+ * selected, the keyboard reports aria-pressed=false.
  */
-function isDotKeyActivated(caseData: CaseData, dataConfiguration?: IDataConfigurationModel) {
+export function isDotKeyActivated(caseData: CaseData, dataConfiguration?: IDataConfigurationModel) {
   const dataset = dataConfiguration?.dataset;
   if (!dataset) return false;
+  const xAttributeId = dataConfiguration?.xAttributeID;
   const yAttributeId = dataConfiguration?.yAttributeID(caseData.plotNum);
-  return dataset.isCellSelected({ attributeId: yAttributeId, caseId: caseData.caseID });
+  return dataset.isCaseSelected(caseData.caseID)
+    || (!!xAttributeId && dataset.isCellSelected({ attributeId: xAttributeId, caseId: caseData.caseID }))
+    || (!!yAttributeId && dataset.isCellSelected({ attributeId: yAttributeId, caseId: caseData.caseID }));
 }
 
 function applySelectedClassToCircles(selection: DotSelection, dataConfiguration?: IDataConfigurationModel){

--- a/src/plugins/graph/utilities/graph-utils.ts
+++ b/src/plugins/graph/utilities/graph-utils.ts
@@ -360,6 +360,22 @@ function isCircleSelected(aCaseData: CaseData, dataConfiguration?: IDataConfigur
     || dataset.isCellSelected({ attributeId: yAttributeId, caseId: aCaseData.caseID });
 }
 
+/**
+ * Whether the dot's keyboard toggle (Enter / Space, the same action driven by
+ * {@link activateDotSelection}) is currently in its "pressed" state. Narrower
+ * than {@link isCircleSelected}: only the Y cell counts, since that's the
+ * only thing keyboard activation toggles. Used to drive `aria-pressed`, so
+ * the announced state reflects what *this button* controls, not unrelated
+ * selections (attribute header, X cell, broader case selection) that the dot
+ * cannot un-toggle.
+ */
+function isDotKeyActivated(caseData: CaseData, dataConfiguration?: IDataConfigurationModel) {
+  const dataset = dataConfiguration?.dataset;
+  if (!dataset) return false;
+  const yAttributeId = dataConfiguration?.yAttributeID(caseData.plotNum);
+  return dataset.isCellSelected({ attributeId: yAttributeId, caseId: caseData.caseID });
+}
+
 function applySelectedClassToCircles(selection: DotSelection, dataConfiguration?: IDataConfigurationModel){
   selection
     .classed('selected', (aCaseData: CaseData) => isCircleSelected(aCaseData, dataConfiguration));
@@ -568,6 +584,22 @@ export interface ISetPointSelection {
   pointStrokeColor: string
 }
 
+/**
+ * Re-applies the per-dot ARIA attributes whose value depends on the current
+ * selection (aria-label's "Selected" suffix; aria-pressed). Called from both
+ * the data-driven refresh path ({@link setPointCoordinates}) and the
+ * selection-only refresh path ({@link setPointSelection}), so the announced
+ * state stays in sync with the rendered state regardless of which trigger
+ * fired the update.
+ */
+function refreshDotSelectionAria(dotsRef: IDotsRef, dataConfiguration?: IDataConfigurationModel) {
+  const graphDots = selectGraphDots(dotsRef.current);
+  if (!graphDots) return;
+  graphDots
+    .attr("aria-label", (d: CaseData) => buildDotAriaLabel(d, dataConfiguration))
+    .attr("aria-pressed", (d: CaseData) => isDotKeyActivated(d, dataConfiguration) ? "true" : "false");
+}
+
 export function setPointSelection(props: ISetPointSelection) {
   const { dotsRef, dataConfiguration } = props;
   const outerCircles = selectOuterCircles(dotsRef.current);
@@ -575,6 +607,10 @@ export function setPointSelection(props: ISetPointSelection) {
     applySelectedClassToCircles(outerCircles, dataConfiguration);
     styleOuterCircles(outerCircles, dataConfiguration);
   }
+  // Selection-only refresh: also update aria-label / aria-pressed on each dot
+  // so screen readers see the new state (setPointCoordinates won't run on a
+  // pure selection change).
+  refreshDotSelectionAria(dotsRef, dataConfiguration);
 }
 
 export interface ISetPointCoordinates {
@@ -714,18 +750,18 @@ export function setPointCoordinates(props: ISetPointCoordinates) {
   if (outerCircles) applySelectedClassToCircles(outerCircles, dataConfiguration);
   styleOuterCircles(outerCircles, dataConfiguration);
 
-  // Apply keyboard-accessibility attributes to each dot. tabindex=-1 keeps dots
-  // out of the natural Tab cycle (the dots-group surrogate is the single tab stop)
-  // while letting `useGraphDotsKeyboard` programmatically focus them via arrow keys.
-  // aria-label/aria-pressed are re-applied on every refresh so they stay in sync
-  // with current data values and selection state.
+  // Apply the static keyboard-accessibility attributes to each dot. tabindex=-1
+  // keeps dots out of the natural Tab cycle (the dots-group surrogate is the
+  // single tab stop) while letting `useGraphDotsKeyboard` programmatically focus
+  // them via arrow keys. Per-dot aria-label / aria-pressed (which depend on the
+  // current selection) are refreshed via the shared helper so the selection-only
+  // path (setPointSelection) stays in sync too.
   if (graphDots) {
     graphDots
       .attr("tabindex", -1)
-      .attr("role", "button")
-      .attr("aria-label", (d: CaseData) => buildDotAriaLabel(d, dataConfiguration))
-      .attr("aria-pressed", (d: CaseData) => isCircleSelected(d, dataConfiguration) ? "true" : "false");
+      .attr("role", "button");
   }
+  refreshDotSelectionAria(dotsRef, dataConfiguration);
 }
 
 /**

--- a/src/plugins/graph/utilities/graph-utils.ts
+++ b/src/plugins/graph/utilities/graph-utils.ts
@@ -196,7 +196,7 @@ export function buildDotAriaLabel(
   const legendAttrID = dataConfiguration.attributeID("legend");
   if (legendAttrID) {
     const legendValue = dataset?.getValue(caseID, legendAttrID);
-    if (legendValue) label += `, Color: ${legendValue}`;
+    if (legendValue != null && legendValue !== "") label += `, Color: ${legendValue}`;
   }
 
   if (isCircleSelected(caseData, dataConfiguration)) {


### PR DESCRIPTION
[CLUE-502](https://concord-consortium.atlassian.net/browse/CLUE-502)

Implements keyboard navigation and screen-reader accessibility for the XY Plot tile. The tile now participates in the shared focus-trap system used by other tiles, with `Tab` cycling through axis labels → dots-group → legend elements → toolbar → resize → title.

**XY Plot a11y** (primary deliverable)

- Axis labels are keyboard-focusable buttons. `Enter` starts inline edit; `Escape` cancels and restores focus to the trigger; in CODAP-legend mode with no attribute selected, `Enter` opens the attribute menu.
- Data points are navigable as a composite widget: the layer's `<svg>` is a single tab stop with arrow / Home / End roving over child dots via `useGraphDotsKeyboard`. `Enter`/`Space` toggles selection (`Shift` extends). Coordinates are announced through a per-tile aria-live region.
- Legend controls (unlink, dataset-name editor, color picker, attribute menu, add-series) each become individual tab stops via `tabWithinSlots: ["topbar", "content", "palette"]`.
- Read-only graphs use `type: "region"` (no trap) but keep all axis-label / dots-group focus affordances and continue to register the annotation/export API.

**Shared a11y infrastructure** (required by the [@concord-consortium/accessibility-tools](https://github.com/concord-consortium/accessibility-tools) upgrade to 0.1.0-pre.1)

- `ITileFocusableElements` gains `tabWithinSlots` and `escapeHandlers` overrides so tiles can opt slots into within-slot `Tab` routing and intercept `Escape` for inline editors.
- `focusContent` callbacks now receive a `FocusContentContext ({ entryMode })` so direction-aware tiles can target the correct end on `Shift+Tab`. Bar Graph and Drawing tiles updated accordingly.
- Dead pre-existing focus-trap plumbing in `useClueAccessibility` (`containerRef` / `strategyRef` / `onFocusTrapReady`) removed — tile-component.tsx's `FocusTrapController` owns the trap for every tile.

[CLUE-502]: https://concord-consortium.atlassian.net/browse/CLUE-502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ