### PR TITLE
fix(authoring): ensure firstOrdinal is numeric to prevent zero-padded…

### DIFF
--- a/src/authoring/components/workspace/container-config/unit-item-children.tsx
+++ b/src/authoring/components/workspace/container-config/unit-item-children.tsx
@@ -23,7 +23,7 @@ export const UnitItemChildren: React.FC<UnitItemChildrenProps> = (
           type="number"
           id="firstOrdinal"
           defaultValue={defaultValues?.firstOrdinal}
-          {...register("firstOrdinal", { required: "First Ordinal is required" })}
+          {...register("firstOrdinal", { required: "First Ordinal is required", valueAsNumber: true })}
         />
         {errors.firstOrdinal && <span className="form-error">{errors.firstOrdinal.message}</span>}
       </div>


### PR DESCRIPTION
Authoring was creating a leading 0 in front of problem ordinals because react-hook-form returns input values as strings by default, even for type="number" inputs. Adding valueAsNumber: true to the register call ensures firstOrdinal is a number, preventing JavaScript string concatenation (0 + "1" = "01") from producing zero-padded directory names and string ordinals in content.json.