### PR TITLE
feat: Coordinate Grid keyboard nav (CLUE-503)

### DIFF
--- a/cypress/e2e/functional/tile_tests/geometry_tool_keyboard_spec.js
+++ b/cypress/e2e/functional/tile_tests/geometry_tool_keyboard_spec.js
@@ -1,0 +1,332 @@
+import ClueCanvas from '../../../support/elements/common/cCanvas';
+import GeometryToolTile from '../../../support/elements/tile/GeometryToolTile';
+import TableToolTile from '../../../support/elements/tile/TableToolTile';
+
+const clueCanvas = new ClueCanvas();
+const geometryTile = new GeometryToolTile();
+const tableToolTile = new TableToolTile();
+
+context('Coordinate Grid keyboard accessibility', function () {
+  beforeEach(function () {
+    cy.visit('/?appMode=qa&fakeClass=5&fakeUser=student:5&qaGroup=5&problem=1.1&unit=qa&noStorage');
+    cy.waitForLoad();
+    clueCanvas.addTile('geometry');
+  });
+
+  function selectGeometryTile() {
+    // Click the outer `.geometry-tool-tile` wrapper to select the tile, then
+    // explicitly focus it. The click alone doesn't reliably leave focus on the
+    // outer wrapper because clicks land on the centermost descendant — which
+    // for the geometry tile is the JSXGraph SVG (tabindex=0 grabs focus on
+    // click). The subsequent Enter then needs focus on `.tool-tile` to trigger
+    // `tile-component.handleKeyDown`'s `enterTrap()` branch.
+    cy.get('.primary-workspace .canvas-area .geometry-tool-tile')
+      .click()
+      .focus();
+    cy.realPress('Enter');
+    cy.focused().should('have.class', 'editable-tile-title-text');
+  }
+
+  // The empty Coordinate Grid tile has this trap cycle:
+  //   title → SVG board (content) → toolbar (single tab stop) → resize → wrap.
+  // The SVG board is the JSXGraph root, decorated with role="group" + tabindex="0"
+  // in handleCreateBoard so the trap visits it as the sole content tab stop.
+  // The toolbar uses the standard CLUE pattern of one tab stop + internal arrow-key
+  // roving via useRovingTabindex.
+  const emptyFocusOrder = [
+    ['css',   '.geometry-content [role="group"]'],  // JSXGraph SVG root
+    ['class', 'toolbar-button'],                    // first toolbar button
+    ['class', 'tool-tile-resize-handle-wrapper'],   // resize handle
+  ];
+
+  function assertFocused([attr, value]) {
+    if (attr === 'class') cy.focused().should('have.class', value);
+    else if (attr === 'css') cy.focused().should('match', value);
+    else if (value === '') cy.focused().should('have.attr', attr);
+    else cy.focused().should('have.attr', attr, value);
+  }
+
+  it('Empty Coordinate Grid — focus trap, title editing, toolbar contracts, color palette, polygon seed', function () {
+    selectGeometryTile();
+
+    cy.log('Tab cycles forward through every focus slot, then wraps to title');
+    emptyFocusOrder.forEach(entry => {
+      cy.realPress('Tab');
+      assertFocused(entry);
+    });
+    cy.realPress('Tab');
+    cy.focused().should('have.class', 'editable-tile-title-text');
+
+    cy.log('Shift+Tab cycles in reverse, then wraps to title');
+    [...emptyFocusOrder].reverse().forEach(entry => {
+      cy.realPress(['Shift', 'Tab']);
+      assertFocused(entry);
+    });
+    cy.realPress(['Shift', 'Tab']);
+    cy.focused().should('have.class', 'editable-tile-title-text');
+
+    cy.log('Escape exits the trap to the .tool-tile container');
+    cy.realPress('Tab'); // title → SVG board
+    cy.realPress('Escape');
+    cy.focused().should('have.class', 'tool-tile');
+
+    cy.log('Enter on the focused title opens the inline editor; Escape cancels');
+    selectGeometryTile();
+    cy.realPress('Enter');
+    cy.get('.geometry-tool .editable-tile-title input').should('be.visible').type('Renamed');
+    cy.realPress('Escape');
+    cy.get('.geometry-tool .editable-tile-title input').should('not.exist');
+    cy.focused().should('have.class', 'editable-tile-title-text');
+
+    cy.log('Enter again opens the editor; typing + Enter commits the new title');
+    cy.realPress('Enter');
+    cy.get('.geometry-tool .editable-tile-title input').clear().type('My grid');
+    cy.realPress('Enter');
+    cy.get('.geometry-tool .editable-tile-title input').should('not.exist');
+    cy.get('.geometry-tool .editable-tile-title-text').should('contain.text', 'My grid');
+    cy.focused().should('have.class', 'editable-tile-title-text');
+
+    cy.log('Each toolbar button exposes a non-empty aria-label');
+    cy.get('.tile-toolbar.geometry-toolbar .toolbar-button')
+      .should('have.length.greaterThan', 0)
+      .each($el => {
+        expect($el.attr('aria-label'), 'aria-label set').to.not.be.empty;
+      });
+
+    cy.log('Mode buttons reflect on/off state via aria-pressed (Select is default)');
+    cy.get('button.toolbar-button.select')
+      .should('have.attr', 'aria-pressed', 'true');
+    cy.get('button.toolbar-button.point')
+      .should('have.attr', 'aria-pressed', 'false');
+
+    cy.log('Disabled toolbar buttons use aria-disabled (still keyboard-focusable)');
+    cy.get('button.toolbar-button.duplicate')
+      .should('have.attr', 'aria-disabled', 'true')
+      .and('not.have.attr', 'disabled');
+
+    cy.log('Mouse click on the Point button flips mode but does NOT seed (detail===1)');
+    cy.get('button.toolbar-button.point').click();
+    cy.get('button.toolbar-button.point').should('have.attr', 'aria-pressed', 'true');
+    geometryTile.getGraphPoint().should('have.length', 0);
+    clueCanvas.clickToolbarButton('geometry', 'select'); // restore Select mode
+
+    cy.log('Enter on the Color button opens the palette with role=group + aria-label; focus on a swatch');
+    cy.get('button.toolbar-button.color').focus();
+    cy.realPress('Enter');
+    cy.get('.color-palette').should('be.visible')
+      .and('have.attr', 'role', 'group')
+      .and('have.attr', 'aria-label', 'Color picker');
+    cy.focused()
+      .should('have.attr', 'role', 'button')
+      .and('have.class', 'color-swatch');
+
+    cy.log('Each swatch exposes aria-label and aria-pressed');
+    cy.get('.color-swatch[role="button"]').each($el => {
+      expect($el.attr('aria-label'), 'aria-label non-empty').to.not.be.empty;
+      expect($el.attr('aria-pressed'), 'aria-pressed set').to.match(/^(true|false)$/);
+    });
+
+    cy.log('Escape closes the palette and returns focus to the Color button');
+    cy.realPress('Escape');
+    cy.get('.color-palette').should('not.exist');
+    cy.focused().should('have.class', 'toolbar-button').and('have.class', 'color');
+
+    cy.log('Keyboard Enter on the Polygon button seeds a unit-square (4 vertices + 1 polygon)');
+    // Representative coverage of the toolbar-Enter → seed-shape pipeline.
+    // Per-shape branch coverage (point, polygon, circle, line) lives in
+    // src/components/tiles/geometry/geometry-keyboard-create.test.ts.
+    // Scope to `.show-tile` — the navigator mini-map renders a `.show-all`
+    // copy of the same content that would double every count.
+    cy.get('button.toolbar-button.polygon').focus();
+    cy.realPress('Enter');
+    cy.get('.geometry-content.show-tile polygon[data-object-id]').should('have.length', 1);
+    cy.get('.geometry-content.show-tile ellipse[data-object-id]').should('have.length', 4);
+
+    cy.log('The seeded polygon\'s rendNode carries a "Polygon ... with N vertices" aria-label');
+    cy.get('.geometry-content.show-tile polygon[data-object-id]')
+      .invoke('attr', 'aria-label')
+      .should('match', /^Polygon .*with 4 vertices/);
+
+    cy.log('Each vertex carries a "Vertex k of N of polygon ..." aria-label');
+    cy.get('.geometry-content.show-tile ellipse[data-object-id][aria-label*="Vertex"]')
+      .should('have.length.greaterThan', 0)
+      .each($el => {
+        expect($el.attr('aria-label'), 'vertex label format')
+          .to.match(/^Vertex \d+ of \d+ of polygon /);
+      });
+  });
+
+  context('Free-point selection and movement', function () {
+    beforeEach(function () {
+      // Switch to Point mode so board clicks realize free points. (Select mode
+      // treats board clicks as deselect.)
+      clueCanvas.clickToolbarButton('geometry', 'point');
+      geometryTile.clickGraphPosition(3, 4);
+      geometryTile.clickGraphPosition(5, 5);
+      geometryTile.clickGraphPosition(6, 7);
+      // Return to Select mode so the focus-trap flow isn't biased by point-mode
+      // clicks landing on the title's editable surface.
+      clueCanvas.clickToolbarButton('geometry', 'select');
+    });
+
+    it('Tab walks board → points; Enter / Shift+Enter / replace; ArrowRight nudge; announcer', function () {
+      selectGeometryTile();
+
+      cy.log('From the title, Tab walks the SVG board, then each point in DOM order');
+      cy.realPress('Tab'); // title → SVG board
+      cy.focused().should('match', '.geometry-content [role="group"]');
+      const collected = [];
+      cy.realPress('Tab');
+      cy.focused().then($el => collected.push($el.attr('data-object-id') ?? ''));
+      cy.realPress('Tab');
+      cy.focused().then($el => collected.push($el.attr('data-object-id') ?? ''));
+      cy.realPress('Tab');
+      cy.focused().then($el => collected.push($el.attr('data-object-id') ?? ''))
+        .then(() => {
+          expect(collected.filter(Boolean), 'each Tab landed on a focusable geometry object')
+            .to.have.length(3);
+        });
+
+      // After three forward Tabs, focus is on point[2]. Shift+Tab twice to reach point[0].
+      cy.realPress(['Shift', 'Tab']);
+      cy.realPress(['Shift', 'Tab']);
+
+      cy.log('Enter on focused point flips aria-pressed and triggers the aria-live announcer');
+      cy.focused().should('have.attr', 'aria-pressed', 'false');
+      cy.realPress('Enter');
+      cy.focused().should('have.attr', 'aria-pressed', 'true');
+      // The double-rAF debounce in announceGeometry posts the message after a
+      // microtask + two frames. Cypress auto-retry synchronises with it.
+      cy.get('[data-grid-announcer]').should('contain.text', 'Selected');
+
+      cy.log('Shift+Enter on a second point extends the selection (both stay selected)');
+      cy.realPress('Tab'); // → point[1]
+      cy.realPress(['Shift', 'Enter']);
+      cy.focused().should('have.attr', 'aria-pressed', 'true');
+      cy.get('.geometry-content.show-tile [data-object-id][aria-pressed="true"]').should('have.length', 2);
+
+      cy.log('Plain Enter on a third focused point replaces the existing selection');
+      cy.realPress('Tab'); // → point[2]
+      cy.realPress('Enter');
+      cy.focused().should('have.attr', 'aria-pressed', 'true');
+      cy.get('.geometry-content.show-tile [data-object-id][aria-pressed="true"]').should('have.length', 1);
+
+      cy.log('ArrowRight nudges the focused selected point (+0.1 user-units → +cx px)');
+      cy.focused().then($el => {
+        const initialCx = parseFloat($el.attr('cx') ?? '0');
+        cy.realPress('ArrowRight');
+        cy.focused().should('have.attr', 'aria-pressed', 'true');
+        cy.focused().then($el2 => {
+          const newCx = parseFloat($el2.attr('cx') ?? '0');
+          expect(newCx - initialCx, 'cx increased after ArrowRight nudge').to.be.greaterThan(0);
+        });
+      });
+    });
+  });
+
+  context('Linked Table integration', function () {
+    beforeEach(function () {
+      // The Add Data button enables itself when ANY linkable shared model
+      // (SharedDataSet) is registered in the document; an empty Table tile is
+      // sufficient. Rows are populated later, just before linking.
+      clueCanvas.addTile('table');
+    });
+
+    it('Add Data dialog opens with focus inside; linked points are tab stops; Enter selects', function () {
+      cy.log('Enter on the Add Data button opens the link-tile dialog with focus inside');
+      geometryTile.getGeometryTile().click();
+      cy.get('button.toolbar-button.add-data').focus();
+      cy.realPress('Enter');
+      cy.get('.custom-modal.link-tile').should('be.visible');
+      cy.focused().then($el => {
+        expect($el.closest('.custom-modal').length, 'focused element is inside the dialog')
+          .to.be.greaterThan(0);
+      });
+
+      cy.log('Escape closes the dialog');
+      cy.realPress('Escape');
+      cy.get('.custom-modal.link-tile').should('not.exist');
+
+      cy.log('Populate the Table with three rows and link it to the geometry tile');
+      cy.get('.primary-workspace').within(() => {
+        tableToolTile.typeInTableCell(1, '1{enter}');
+        tableToolTile.typeInTableCell(2, '2{enter}');
+        tableToolTile.typeInTableCell(5, '3{enter}');
+        tableToolTile.typeInTableCell(6, '4{enter}');
+        tableToolTile.typeInTableCell(9, '5{enter}');
+        tableToolTile.typeInTableCell(10, '6{enter}');
+      });
+      cy.linkTableToTile('Table Data 1', 'Coordinate Grid 1');
+
+      cy.log('Each linked point carries "Linked point" aria-label, role=button, and is a Tab stop');
+      cy.get('.geometry-content [data-object-id]')
+        .filter('[aria-label^="Linked point"]')
+        .should('have.length.at.least', 3)
+        .each($el => {
+          expect($el.attr('tabindex'), 'tabindex on linked rendNode').to.equal('0');
+          expect($el.attr('role'), 'role=button on linked rendNode').to.equal('button');
+        });
+
+      cy.log('From the title, Tab walks SVG board → first linked point with proper aria');
+      selectGeometryTile();
+      cy.realPress('Tab'); // title → SVG board
+      cy.focused().should('match', '.geometry-content [role="group"]');
+      cy.realPress('Tab'); // → first linked point
+      cy.focused().should('have.attr', 'data-object-id').and('not.be.empty');
+      cy.focused()
+        .invoke('attr', 'aria-label')
+        .should('match', /^Linked point at /);
+
+      cy.log('Enter on a focused linked point flips its aria-pressed to "true"');
+      cy.focused().should('have.attr', 'aria-pressed', 'false');
+      cy.realPress('Enter');
+      cy.focused().should('have.attr', 'aria-pressed', 'true');
+    });
+  });
+
+  context('Read-only mode', function () {
+    // The `/editor/` route renders three workspaces side-by-side: the editable
+    // primary, plus `.read-only-local-workspace` and `.read-only-remote-workspace`.
+    // We exercise the `type: "region"` path via `.read-only-local-workspace`.
+    beforeEach(function () {
+      cy.visit('/editor/?appMode=qa&unit=./demo/units/qa/content.json');
+      cy.get('.editable-document-content', { timeout: 60000 });
+      clueCanvas.addTile('geometry');
+      // Switch to Point mode so board clicks realize free points (Select treats
+      // clicks as deselect rather than create).
+      clueCanvas.clickToolbarButton('geometry', 'point');
+      geometryTile.clickGraphPosition(3, 4);
+      geometryTile.clickGraphPosition(6, 7);
+    });
+
+    function readOnlyTile() {
+      return cy.get('.read-only-local-workspace .geometry-tool-tile');
+    }
+
+    it('Read-only Coordinate Grid exposes accessible scaffold without editing affordances', function () {
+      cy.log('Board objects render but are NOT keyboard tab stops in read-only mode');
+      readOnlyTile().find('.geometry-content svg ellipse').should('have.length.greaterThan', 0);
+      readOnlyTile().find('.geometry-content [role="button"]').should('not.exist');
+      readOnlyTile().find('.geometry-content [data-object-id]').should('not.exist');
+
+      cy.log('SVG board container exposes role=group + tabindex (single content entry)');
+      readOnlyTile()
+        .find('.geometry-content [role="group"]')
+        .should('exist')
+        .and('have.attr', 'tabindex', '0');
+
+      cy.log('Aria-live announcer is still rendered');
+      readOnlyTile()
+        .find('[data-grid-announcer]')
+        .should('exist')
+        .and('have.attr', 'aria-live', 'polite');
+
+      cy.log('Read-only title is focusable but has no "editable title" aria suffix');
+      readOnlyTile()
+        .find('.editable-tile-title-text')
+        .should('have.attr', 'tabindex', '0')
+        .invoke('attr', 'aria-label')
+        .should('not.match', /editable title/);
+    });
+  });
+});

--- a/cypress/e2e/functional/tile_tests/xy_plot_tool_keyboard_spec.js
+++ b/cypress/e2e/functional/tile_tests/xy_plot_tool_keyboard_spec.js
@@ -6,7 +6,7 @@ const clueCanvas = new ClueCanvas;
 const xyTile = new XYPlotToolTile;
 const tableToolTile = new TableToolTile;
 
-context('XY Plot keyboard accessibility (CLUE-502)', function () {
+context('XY Plot keyboard accessibility', function () {
   beforeEach(function () {
     // Use the local qa unit's content.json rather than the bare `unit=qa`
     // shorthand. The shorthand resolves to a remote qa unit in CODAP-legend

--- a/cypress/support/elements/tile/GeometryToolTile.js
+++ b/cypress/support/elements/tile/GeometryToolTile.js
@@ -177,7 +177,7 @@ class GeometryToolTile {
         cy.get('.single-workspace.primary-workspace .geometry-toolbar .button.comment.enabled').click();
     }
     selectColor(color){
-      return cy.get(`[data-test=canvas] .tile-toolbar .toolbar-button.color .palette-buttons .color-swatch.${color}`).click();
+      return cy.get(`[data-test=canvas] .tile-toolbar .color-palette .palette-buttons .color-swatch.${color}`).click();
     }
 }
 export default GeometryToolTile;

--- a/src/components/tiles/editable-tile-title.tsx
+++ b/src/components/tiles/editable-tile-title.tsx
@@ -40,14 +40,18 @@ export const EditableTileTitle: React.FC<IProps> = observer(({
   const editingTitleRef = useRef(editingTitle);
   editingTitleRef.current = editingTitle;
 
-  // On edit-mode exit (commit / cancel / blur) return focus to the title text
-  // so the trap has a stable anchor for the next Tab — otherwise focus is left
-  // on the now-unmounted <input> (typically falls back to body).
+  // When edit mode exits via keyboard (Enter / Escape), focus falls back to
+  // body because the input unmounts; restore focus to the title text so the
+  // trap has a stable anchor for the next Tab. When edit mode exits because
+  // the user clicked elsewhere, leave focus on whatever they clicked.
   const titleTextRef = useRef<HTMLDivElement>(null);
   const prevIsEditingRef = useRef(false);
   useEffect(() => {
     if (prevIsEditingRef.current && !isEditing) {
-      titleTextRef.current?.focus();
+      const active = document.activeElement;
+      if (!active || active === document.body) {
+        titleTextRef.current?.focus();
+      }
     }
     prevIsEditingRef.current = isEditing;
   }, [isEditing]);

--- a/src/components/tiles/editable-tile-title.tsx
+++ b/src/components/tiles/editable-tile-title.tsx
@@ -1,6 +1,6 @@
 import classNames from "classnames";
 import { observer } from "mobx-react";
-import React, { useContext, useRef, useState } from "react";
+import React, { useContext, useEffect, useRef, useState } from "react";
 import { useReadOnlyContext } from "../document/read-only-context";
 import { TileModelContext } from "../tiles/tile-api";
 import { TileLabelInput } from "./tile-label-input";
@@ -39,6 +39,18 @@ export const EditableTileTitle: React.FC<IProps> = observer(({
   // after voice typing commits interim text (React 17 batches state updates).
   const editingTitleRef = useRef(editingTitle);
   editingTitleRef.current = editingTitle;
+
+  // On edit-mode exit (commit / cancel / blur) return focus to the title text
+  // so the trap has a stable anchor for the next Tab — otherwise focus is left
+  // on the now-unmounted <input> (typically falls back to body).
+  const titleTextRef = useRef<HTMLDivElement>(null);
+  const prevIsEditingRef = useRef(false);
+  useEffect(() => {
+    if (prevIsEditingRef.current && !isEditing) {
+      titleTextRef.current?.focus();
+    }
+    prevIsEditingRef.current = isEditing;
+  }, [isEditing]);
 
   const handleClick = () => {
     if (!readOnly && !isEditing) {
@@ -93,6 +105,7 @@ export const EditableTileTitle: React.FC<IProps> = observer(({
         ? <TileLabelInput value={editingTitle} style={inputStyle}
             onKeyDown={handleKeyDown} onChange={setEditingTitle} onBlur={() => handleClose(true)} />
         : <div className="editable-tile-title-text" tabIndex={0}
+            ref={titleTextRef}
             role={readOnly ? undefined : "button"}
             aria-label={readOnly ? title : `${title}, editable title`}
             onKeyDown={readOnly ? undefined : (e) => {

--- a/src/components/tiles/geometry/color-palette.scss
+++ b/src/components/tiles/geometry/color-palette.scss
@@ -9,6 +9,7 @@
   background-color: $workspace-teal-light-9;
   border-radius: 5px;
   padding: 5px;
+  position: absolute;
   margin: 0 auto;
 
   .palette-buttons {

--- a/src/components/tiles/geometry/color-palette.test.tsx
+++ b/src/components/tiles/geometry/color-palette.test.tsx
@@ -1,0 +1,109 @@
+import React from "react";
+import { render, fireEvent, act } from "@testing-library/react";
+import { ColorPalette } from "./color-palette";
+
+describe("ColorPalette — keyboard accessibility", () => {
+  it("renders as a labelled group of color swatches", () => {
+    const { container } = render(
+      <ColorPalette selectedColor={0} onSelectColor={jest.fn()} onClose={jest.fn()} />
+    );
+    const group = container.querySelector(".color-palette");
+    expect(group?.getAttribute("role")).toBe("group");
+    expect(group?.getAttribute("aria-label")).toBe("Color picker");
+    expect(container.querySelectorAll(".color-swatch[role='button']").length).toBeGreaterThan(0);
+  });
+
+  it("auto-focuses the currently-selected swatch when opened", () => {
+    const { container } = render(
+      <ColorPalette selectedColor={2} onSelectColor={jest.fn()} onClose={jest.fn()} />
+    );
+    const swatches = container.querySelectorAll<HTMLElement>(".color-swatch[role='button']");
+    expect(document.activeElement).toBe(swatches[2]);
+  });
+
+  it("focuses the first swatch when no swatch is selected", () => {
+    const { container } = render(
+      <ColorPalette onSelectColor={jest.fn()} onClose={jest.fn()} />
+    );
+    const swatches = container.querySelectorAll<HTMLElement>(".color-swatch[role='button']");
+    expect(document.activeElement).toBe(swatches[0]);
+  });
+
+  it("calls onClose when Escape is pressed inside the palette", () => {
+    const onClose = jest.fn();
+    const { container } = render(
+      <ColorPalette selectedColor={0} onSelectColor={jest.fn()} onClose={onClose} />
+    );
+    const group = container.querySelector(".color-palette") as HTMLElement;
+    act(() => {
+      fireEvent.keyDown(group, { key: "Escape" });
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call onClose for non-Escape keys", () => {
+    const onClose = jest.fn();
+    const { container } = render(
+      <ColorPalette selectedColor={0} onSelectColor={jest.fn()} onClose={onClose} />
+    );
+    const group = container.querySelector(".color-palette") as HTMLElement;
+    fireEvent.keyDown(group, { key: "ArrowRight" });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  describe("arrow-key navigation between swatches", () => {
+    function renderPalette(selectedColor = 0) {
+      const { container } = render(
+        <ColorPalette selectedColor={selectedColor} onSelectColor={jest.fn()} onClose={jest.fn()} />
+      );
+      const group = container.querySelector(".color-palette") as HTMLElement;
+      const swatches = Array.from(
+        container.querySelectorAll<HTMLElement>(".color-swatch[role='button']")
+      );
+      return { group, swatches };
+    }
+
+    it("ArrowRight moves focus to the next swatch", () => {
+      const { group, swatches } = renderPalette(0);
+      expect(document.activeElement).toBe(swatches[0]);
+      act(() => { fireEvent.keyDown(group, { key: "ArrowRight" }); });
+      expect(document.activeElement).toBe(swatches[1]);
+    });
+
+    it("ArrowDown also moves to the next swatch", () => {
+      const { group, swatches } = renderPalette(0);
+      act(() => { fireEvent.keyDown(group, { key: "ArrowDown" }); });
+      expect(document.activeElement).toBe(swatches[1]);
+    });
+
+    it("ArrowLeft moves focus to the previous swatch", () => {
+      const { group, swatches } = renderPalette(2);
+      expect(document.activeElement).toBe(swatches[2]);
+      act(() => { fireEvent.keyDown(group, { key: "ArrowLeft" }); });
+      expect(document.activeElement).toBe(swatches[1]);
+    });
+
+    it("ArrowRight wraps from the last swatch to the first", () => {
+      const { group, swatches } = renderPalette(0);
+      const last = swatches.length - 1;
+      act(() => { swatches[last].focus(); });
+      act(() => { fireEvent.keyDown(group, { key: "ArrowRight" }); });
+      expect(document.activeElement).toBe(swatches[0]);
+    });
+
+    it("ArrowLeft wraps from the first swatch to the last", () => {
+      const { group, swatches } = renderPalette(0);
+      expect(document.activeElement).toBe(swatches[0]);
+      act(() => { fireEvent.keyDown(group, { key: "ArrowLeft" }); });
+      expect(document.activeElement).toBe(swatches[swatches.length - 1]);
+    });
+
+    it("Home focuses the first swatch, End focuses the last", () => {
+      const { group, swatches } = renderPalette(3);
+      act(() => { fireEvent.keyDown(group, { key: "Home" }); });
+      expect(document.activeElement).toBe(swatches[0]);
+      act(() => { fireEvent.keyDown(group, { key: "End" }); });
+      expect(document.activeElement).toBe(swatches[swatches.length - 1]);
+    });
+  });
+});

--- a/src/components/tiles/geometry/color-palette.tsx
+++ b/src/components/tiles/geometry/color-palette.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import { ColorSwatch } from "./color-swatch";
 import { ClueColor, clueBasicDataColorInfo } from "../../../utilities/color-utils";
 
@@ -7,11 +7,70 @@ import "./color-palette.scss";
 interface IProps {
   selectedColor?: number;
   onSelectColor: (color: number) => void;
+  onClose: () => void;
 }
 
-export const ColorPalette: React.FC<IProps> = ({ selectedColor, onSelectColor }) => {
+export const ColorPalette: React.FC<IProps> = ({ selectedColor, onSelectColor, onClose }) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const getSwatches = () =>
+    Array.from(containerRef.current?.querySelectorAll<HTMLElement>(".color-swatch[role='button']") ?? []);
+
+  useEffect(() => {
+    const swatches = getSwatches();
+    if (swatches.length === 0) return;
+    const target = (selectedColor != null && swatches[selectedColor]) || swatches[0];
+    target.focus();
+    // Mount-only: re-running on prop changes would steal focus mid-pick.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Escape") {
+      e.stopPropagation();
+      e.preventDefault();
+      onClose();
+      return;
+    }
+
+    const navKeys = ["ArrowRight", "ArrowDown", "ArrowLeft", "ArrowUp", "Home", "End"];
+    if (!navKeys.includes(e.key)) return;
+    const swatches = getSwatches();
+    if (swatches.length === 0) return;
+    const current = swatches.indexOf(document.activeElement as HTMLElement);
+    const last = swatches.length - 1;
+    let next: number;
+    switch (e.key) {
+      case "ArrowRight":
+      case "ArrowDown":
+        next = current < 0 ? 0 : (current + 1) % swatches.length;
+        break;
+      case "ArrowLeft":
+      case "ArrowUp":
+        next = current < 0 ? last : (current - 1 + swatches.length) % swatches.length;
+        break;
+      case "Home":
+        next = 0;
+        break;
+      case "End":
+        next = last;
+        break;
+      default:
+        return;
+    }
+    e.preventDefault();
+    e.stopPropagation();
+    swatches[next].focus();
+  }
+
   return (
-    <div className="toolbar-palette color-palette">
+    <div
+      ref={containerRef}
+      className="toolbar-palette color-palette"
+      role="group"
+      aria-label="Color picker"
+      onKeyDown={handleKeyDown}
+    >
       <div className="palette-buttons">
         {clueBasicDataColorInfo.map((colorInfo: ClueColor, index) =>
           <ColorSwatch

--- a/src/components/tiles/geometry/color-swatch.test.tsx
+++ b/src/components/tiles/geometry/color-swatch.test.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import { render, fireEvent } from "@testing-library/react";
+import { ColorSwatch } from "./color-swatch";
+
+describe("ColorSwatch — keyboard accessibility", () => {
+  function getSwatch(container: HTMLElement) {
+    return container.querySelector<HTMLElement>(".color-swatch[role='button']");
+  }
+
+  it("renders as a focusable role='button' with the color name as aria-label", () => {
+    const { container } = render(
+      <ColorSwatch name="blue" color="#3366ff" index={0} isSelected={false} onSelectColor={jest.fn()} />
+    );
+    const swatch = getSwatch(container);
+    expect(swatch).not.toBeNull();
+    expect(swatch?.getAttribute("tabindex")).toBe("0");
+    expect(swatch?.getAttribute("aria-label")).toBe("blue");
+    expect(swatch?.getAttribute("aria-pressed")).toBe("false");
+  });
+
+  it("uses aria-pressed='true' when the swatch is the currently selected color", () => {
+    const { container } = render(
+      <ColorSwatch name="orange" color="#ff9933" index={1} isSelected={true} onSelectColor={jest.fn()} />
+    );
+    expect(getSwatch(container)?.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("calls onSelectColor with the swatch index on click", () => {
+    const onSelect = jest.fn();
+    const { container } = render(
+      <ColorSwatch name="green" color="#33cc66" index={2} isSelected={false} onSelectColor={onSelect} />
+    );
+    fireEvent.click(getSwatch(container)!);
+    expect(onSelect).toHaveBeenCalledWith(2);
+  });
+
+  it("calls onSelectColor when Enter is pressed (role=button needs manual keyboard handling)", () => {
+    const onSelect = jest.fn();
+    const { container } = render(
+      <ColorSwatch name="red" color="#cc3333" index={3} isSelected={false} onSelectColor={onSelect} />
+    );
+    fireEvent.keyDown(getSwatch(container)!, { key: "Enter" });
+    expect(onSelect).toHaveBeenCalledWith(3);
+  });
+
+  it("calls onSelectColor when Space is pressed", () => {
+    const onSelect = jest.fn();
+    const { container } = render(
+      <ColorSwatch name="purple" color="#9933cc" index={4} isSelected={false} onSelectColor={onSelect} />
+    );
+    fireEvent.keyDown(getSwatch(container)!, { key: " " });
+    expect(onSelect).toHaveBeenCalledWith(4);
+  });
+
+  it("ignores other keys", () => {
+    const onSelect = jest.fn();
+    const { container } = render(
+      <ColorSwatch name="indigo" color="#333399" index={5} isSelected={false} onSelectColor={onSelect} />
+    );
+    fireEvent.keyDown(getSwatch(container)!, { key: "ArrowRight" });
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/tiles/geometry/color-swatch.tsx
+++ b/src/components/tiles/geometry/color-swatch.tsx
@@ -10,14 +10,30 @@ interface IProps {
   onSelectColor: (index: number) => void;
 }
 
+/**
+ * A single color choice in the geometry tile's color palette. Rendered as
+ * `<div role="button">` because the palette is a child of the Color toolbar
+ * <button> and nesting buttons is invalid HTML; aria-label/aria-pressed +
+ * the Enter/Space handler replicate the semantics a real button would have.
+ */
 export const ColorSwatch: React.FC<IProps> = ({ color, isSelected, onSelectColor, index, name }) => {
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      e.stopPropagation();
+      onSelectColor(index);
+    }
+  }
 
   return (
     <div
-      className={classNames("color-swatch", name,
-      { selected: isSelected })}
-      onClick={() =>
-      onSelectColor(index)}
+      role="button"
+      tabIndex={0}
+      className={classNames("color-swatch", name, { selected: isSelected })}
+      aria-label={name}
+      aria-pressed={isSelected}
+      onClick={() => onSelectColor(index)}
+      onKeyDown={handleKeyDown}
     >
       <div className={classNames("color-icon", name)} />
       <SwatchCheckIcon/>

--- a/src/components/tiles/geometry/geometry-apply-a11y.test.ts
+++ b/src/components/tiles/geometry/geometry-apply-a11y.test.ts
@@ -1,0 +1,322 @@
+import { destroy } from "mobx-state-tree";
+import { defaultGeometryContent, GeometryContentModelType, GeometryMetadataModel }
+  from "../../../models/tiles/geometry/geometry-content";
+import { applyA11yAttributes, getOrderedGeometryFocusables, refreshA11yAttributes }
+  from "./geometry-aria-utils";
+import { createLinkedPoint } from "../../../models/tiles/geometry/jxg-table-link";
+import { isComment } from "../../../models/tiles/geometry/jxg-types";
+
+// Mirror geometry-content.test.ts — the logger reaches into a Documents store
+// we don't set up here, so stub it out to keep tests focused on a11y attrs.
+jest.mock("../../../models/tiles/log/log-tile-change-event", () => ({
+  logTileChangeEvent: () => undefined,
+}));
+
+// Mock to silence JSXGraph's "IntersectionObserver not available" console.log,
+// mirroring src/models/tiles/geometry/geometry-content.test.ts.
+// eslint-disable-next-line no-console
+const origConsoleLog = console.log;
+let consoleSpy: jest.SpyInstance;
+beforeAll(() => {
+  consoleSpy = jest.spyOn(console, "log").mockImplementation((...args: any[]) => {
+    if (!args.some(arg => typeof arg === "string" && arg.includes("IntersectionObserver not available"))) {
+      origConsoleLog(...args);
+    }
+  });
+});
+afterAll(() => {
+  consoleSpy.mockRestore();
+});
+
+const divId = "applyA11yBoard";
+document.body.innerHTML = `<div id="${divId}" style="width:200px;height:200px"></div>`;
+
+function createContentAndBoard(): { content: GeometryContentModelType, board: JXG.Board } {
+  const content = defaultGeometryContent();
+  const metadata = GeometryMetadataModel.create({ id: "geometry-1" });
+  content.doPostCreate!(metadata);
+  const board = content.initializeBoard(divId, false, () => {/* noop */}, () => {/* noop */}) as JXG.Board;
+  content.resizeBoard(board, 200, 200);
+  return { content, board };
+}
+
+function cleanup(content: GeometryContentModelType, board: JXG.Board) {
+  content.destroyBoard(board);
+  destroy(content);
+}
+
+describe("applyA11yAttributes — free point", () => {
+  it("sets tabindex, role=button, aria-pressed=false, data-object-id, and aria-label on the rendNode", () => {
+    const { content, board } = createContentAndBoard();
+    const point = content.addPoint(board, [3, 4])! as JXG.Point;
+    applyA11yAttributes(point, content);
+    expect(point.rendNode.getAttribute("tabindex")).toBe("0");
+    expect(point.rendNode.getAttribute("role")).toBe("button");
+    expect(point.rendNode.getAttribute("aria-pressed")).toBe("false");
+    expect(point.rendNode.getAttribute("data-object-id")).toBe(point.id);
+    expect(point.rendNode.getAttribute("aria-label")).toContain("Point");
+    expect(point.rendNode.getAttribute("aria-label")).toContain("(3, 4)");
+    cleanup(content, board);
+  });
+
+  it("sets aria-pressed=true and ', Selected' suffix when the point is selected", () => {
+    const { content, board } = createContentAndBoard();
+    const point = content.addPoint(board, [3, 4])! as JXG.Point;
+    content.selectElement(board, point.id);
+    applyA11yAttributes(point, content);
+    expect(point.rendNode.getAttribute("aria-pressed")).toBe("true");
+    expect(point.rendNode.getAttribute("aria-label")).toContain(", Selected");
+    cleanup(content, board);
+  });
+
+  it("removes tabindex and aria-label on a phantom point so it is not focusable", () => {
+    const { content, board } = createContentAndBoard();
+    const phantomPoint = content.addPhantomPoint(board, [0, 0])! as JXG.Point;
+    applyA11yAttributes(phantomPoint, content);
+    expect(phantomPoint.rendNode.getAttribute("tabindex")).toBeNull();
+    expect(phantomPoint.rendNode.getAttribute("aria-label")).toBeNull();
+    expect(phantomPoint.rendNode.getAttribute("role")).toBeNull();
+    cleanup(content, board);
+  });
+
+  it("does not make objects focusable in read-only mode", () => {
+    const { content, board } = createContentAndBoard();
+    const point = content.addPoint(board, [3, 4])! as JXG.Point;
+    applyA11yAttributes(point, content, { readOnly: true });
+    expect(point.rendNode.getAttribute("tabindex")).toBeNull();
+    expect(point.rendNode.getAttribute("role")).toBeNull();
+    expect(point.rendNode.getAttribute("aria-label")).toBeNull();
+    cleanup(content, board);
+  });
+});
+
+describe("applyA11yAttributes — polygon", () => {
+  it("sets attrs on the polygon's own rendNode with the polygon aria-label", () => {
+    const { content, board } = createContentAndBoard();
+    content.addPhantomPoint(board, [0, 0]);
+    const { point: p1 } = content.realizePhantomPoint(board, [1, 1], "polygon");
+    content.realizePhantomPoint(board, [2, 1], "polygon");
+    content.realizePhantomPoint(board, [2, 2], "polygon");
+    const polygon = content.closeActivePolygon(board, p1!) as JXG.Polygon;
+    expect(polygon).toBeDefined();
+
+    applyA11yAttributes(polygon, content);
+
+    expect(polygon.rendNode.getAttribute("tabindex")).toBe("0");
+    expect(polygon.rendNode.getAttribute("role")).toBe("button");
+    expect(polygon.rendNode.getAttribute("data-object-id")).toBe(polygon.id);
+    const label = polygon.rendNode.getAttribute("aria-label") ?? "";
+    expect(label).toMatch(/^Polygon .* with 3 vertices$/);
+    cleanup(content, board);
+  });
+
+  it("decorates each polygon vertex with its 'Vertex k of N of polygon X' label", () => {
+    const { content, board } = createContentAndBoard();
+    content.addPhantomPoint(board, [0, 0]);
+    const { point: p1 } = content.realizePhantomPoint(board, [1, 1], "polygon");
+    const { point: p2 } = content.realizePhantomPoint(board, [2, 1], "polygon");
+    const { point: p3 } = content.realizePhantomPoint(board, [2, 2], "polygon");
+    const polygon = content.closeActivePolygon(board, p1!) as JXG.Polygon;
+
+    applyA11yAttributes(polygon, content);
+
+    const labels = [p1!, p2!, p3!].map(pt => pt.rendNode.getAttribute("aria-label") ?? "");
+    expect(labels[0]).toMatch(/^Vertex 1 of 3 of polygon /);
+    expect(labels[1]).toMatch(/^Vertex 2 of 3 of polygon /);
+    expect(labels[2]).toMatch(/^Vertex 3 of 3 of polygon /);
+    cleanup(content, board);
+  });
+
+  it("keeps the vertex label after a standalone pass over the same point (order-independent)", () => {
+    // A full-board refresh visits every object, including each polygon vertex
+    // directly (with no vertexInfo). The polygon's recursive pass (not the
+    // standalone point pass) must own the vertex label, regardless of which
+    // pass runs last. Here we apply the standalone pass *after* the polygon's
+    // pass to prove the bare "Point" label never clobbers "Vertex k of N".
+    const { content, board } = createContentAndBoard();
+    content.addPhantomPoint(board, [0, 0]);
+    const { point: p1 } = content.realizePhantomPoint(board, [1, 1], "polygon");
+    const { point: p2 } = content.realizePhantomPoint(board, [2, 1], "polygon");
+    const { point: p3 } = content.realizePhantomPoint(board, [2, 2], "polygon");
+    const polygon = content.closeActivePolygon(board, p1!) as JXG.Polygon;
+
+    applyA11yAttributes(polygon, content);
+    // Re-run the standalone point pass on each vertex, simulating a later
+    // iteration of forEachBoardObject reaching the vertex with no vertexInfo.
+    [p1!, p2!, p3!].forEach(pt => applyA11yAttributes(pt, content));
+
+    const labels = [p1!, p2!, p3!].map(pt => pt.rendNode.getAttribute("aria-label") ?? "");
+    expect(labels[0]).toMatch(/^Vertex 1 of 3 of polygon /);
+    expect(labels[1]).toMatch(/^Vertex 2 of 3 of polygon /);
+    expect(labels[2]).toMatch(/^Vertex 3 of 3 of polygon /);
+    cleanup(content, board);
+  });
+});
+
+describe("applyA11yAttributes — linked Table point", () => {
+  it("labels a point created via createLinkedPoint with the 'Linked point' phrasing", () => {
+    const { content, board } = createContentAndBoard();
+    // Mirror the production wiring at geometry-content.tsx:967 — createLinkedPoint
+    // produces a JXG.Point with clientType="linkedPoint"; handleCreatePoint then
+    // calls applyA11yAttributes which uses the isLinked branch of the label
+    // builder. We exercise the same boundary directly here.
+    const point = createLinkedPoint(board, [3, 4], { id: "linked-test", name: "T1" });
+    expect(point).toBeDefined();
+
+    applyA11yAttributes(point as JXG.Point, content);
+
+    expect((point as JXG.Point).rendNode.getAttribute("aria-label"))
+      .toBe("Linked point at (3, 4)");
+    expect((point as JXG.Point).rendNode.getAttribute("data-object-id"))
+      .toBe((point as JXG.Point).id);
+    expect((point as JXG.Point).rendNode.getAttribute("tabindex")).toBe("0");
+    cleanup(content, board);
+  });
+});
+
+describe("applyA11yAttributes — comment", () => {
+  it("names the anchored object in the comment's aria-label", () => {
+    const { content, board } = createContentAndBoard();
+    const point = content.addPoint(board, [3, 4])! as JXG.Point;
+    const elems = content.addComment(board, point.id, "needs work");
+    const comment = elems?.find(isComment) as JXG.Text;
+    expect(comment).toBeDefined();
+
+    applyA11yAttributes(comment, content);
+
+    const label = comment.rendNode.getAttribute("aria-label") ?? "";
+    expect(label).toMatch(/^Comment on Point/);
+    expect(label).toContain("needs work");
+    cleanup(content, board);
+  });
+});
+
+describe("getOrderedGeometryFocusables — semantic Tab order", () => {
+  it("groups each polygon's defining vertices immediately after the polygon", () => {
+    const { content, board } = createContentAndBoard();
+
+    // First polygon: 3 vertices, drawn before the orphan points / second polygon.
+    content.addPhantomPoint(board, [0, 0]);
+    const r1a = content.realizePhantomPoint(board, [1, 1], "polygon");
+    const r1b = content.realizePhantomPoint(board, [2, 1], "polygon");
+    const r1c = content.realizePhantomPoint(board, [2, 2], "polygon");
+    const polygon1 = content.closeActivePolygon(board, r1a.point!) as JXG.Polygon;
+    // Apply attrs so isFocusable checks (tabindex=0) succeed.
+    applyA11yAttributes(polygon1, content);
+
+    // Orphan free points.
+    const orphan1 = content.addPoint(board, [10, 10])! as JXG.Point;
+    const orphan2 = content.addPoint(board, [20, 20])! as JXG.Point;
+    applyA11yAttributes(orphan1, content);
+    applyA11yAttributes(orphan2, content);
+
+    // Second polygon: 3 different vertices, drawn after the orphans.
+    content.addPhantomPoint(board, [0, 0]);
+    const r2a = content.realizePhantomPoint(board, [5, 5], "polygon");
+    const r2b = content.realizePhantomPoint(board, [6, 5], "polygon");
+    const r2c = content.realizePhantomPoint(board, [6, 6], "polygon");
+    const polygon2 = content.closeActivePolygon(board, r2a.point!) as JXG.Polygon;
+    applyA11yAttributes(polygon2, content);
+
+    const ordered = getOrderedGeometryFocusables(board);
+    const ids = ordered.map(el => el.getAttribute("data-object-id"));
+
+    // Expected: polygon1, p1.v1, p1.v2, p1.v3, polygon2, p2.v1, p2.v2, p2.v3, orphan1, orphan2.
+    expect(ids).toEqual([
+      polygon1.id, r1a.point!.id, r1b.point!.id, r1c.point!.id,
+      polygon2.id, r2a.point!.id, r2b.point!.id, r2c.point!.id,
+      orphan1.id, orphan2.id,
+    ]);
+    cleanup(content, board);
+  });
+
+  it("excludes phantom and invisible elements", () => {
+    const { content, board } = createContentAndBoard();
+    const point = content.addPoint(board, [1, 1])! as JXG.Point;
+    const phantom = content.addPhantomPoint(board, [3, 3])! as JXG.Point;
+    applyA11yAttributes(point, content);
+    applyA11yAttributes(phantom, content);
+
+    const ordered = getOrderedGeometryFocusables(board);
+    const ids = ordered.map(el => el.getAttribute("data-object-id"));
+
+    expect(ids).toContain(point.id);
+    expect(ids).not.toContain(phantom.id);
+    cleanup(content, board);
+  });
+
+  it("returns an empty list for an empty board", () => {
+    const { content, board } = createContentAndBoard();
+    expect(getOrderedGeometryFocusables(board)).toEqual([]);
+    cleanup(content, board);
+  });
+
+  it("visits each point at most once when it belongs to multiple compound shapes", () => {
+    const { content, board } = createContentAndBoard();
+    // Build a polygon, then a circle that reuses the polygon's first vertex.
+    content.addPhantomPoint(board, [0, 0]);
+    const rp1 = content.realizePhantomPoint(board, [1, 1], "polygon");
+    content.realizePhantomPoint(board, [3, 1], "polygon");
+    content.realizePhantomPoint(board, [2, 3], "polygon");
+    const polygon = content.closeActivePolygon(board, rp1.point!) as JXG.Polygon;
+    applyA11yAttributes(polygon, content);
+
+    // Now make a circle that shares the polygon's first vertex as its center.
+    // (createCircleIncludingPoint reuses an existing point as the circle's center.)
+    content.addPhantomPoint(board, [4, 4]);
+    const circle = content.createCircleIncludingPoint(board, rp1.point!.id) as JXG.Circle;
+    applyA11yAttributes(circle, content);
+
+    const ordered = getOrderedGeometryFocusables(board);
+    const sharedPointAppearances = ordered.filter(
+      el => el.getAttribute("data-object-id") === rp1.point!.id,
+    ).length;
+    expect(sharedPointAppearances).toBe(1);
+    cleanup(content, board);
+  });
+});
+
+describe("refreshA11yAttributes", () => {
+  it("re-applies attrs to every visible object on the board in one pass", () => {
+    const { content, board } = createContentAndBoard();
+    const pointA = content.addPoint(board, [1, 1])! as JXG.Point;
+    const pointB = content.addPoint(board, [2, 2])! as JXG.Point;
+    // Strip the attrs so we can prove the refresh re-applies them (otherwise
+    // applyA11yAttributes called via createContentAndBoard could already have
+    // set them).
+    pointA.rendNode.removeAttribute("tabindex");
+    pointB.rendNode.removeAttribute("tabindex");
+
+    refreshA11yAttributes(board, content);
+
+    expect(pointA.rendNode.getAttribute("tabindex")).toBe("0");
+    expect(pointB.rendNode.getAttribute("tabindex")).toBe("0");
+    cleanup(content, board);
+  });
+
+  it("updates aria-pressed when a point is selected after the first decoration", () => {
+    const { content, board } = createContentAndBoard();
+    const point = content.addPoint(board, [3, 4])! as JXG.Point;
+    applyA11yAttributes(point, content);
+    expect(point.rendNode.getAttribute("aria-pressed")).toBe("false");
+
+    content.selectElement(board, point.id);
+    refreshA11yAttributes(board, content);
+
+    expect(point.rendNode.getAttribute("aria-pressed")).toBe("true");
+    expect(point.rendNode.getAttribute("aria-label")).toContain(", Selected");
+    cleanup(content, board);
+  });
+
+  it("clears object tab stops when refreshing a read-only board", () => {
+    const { content, board } = createContentAndBoard();
+    const point = content.addPoint(board, [1, 1])! as JXG.Point;
+    applyA11yAttributes(point, content);
+    expect(point.rendNode.getAttribute("tabindex")).toBe("0");
+
+    refreshA11yAttributes(board, content, true);
+
+    expect(point.rendNode.getAttribute("tabindex")).toBeNull();
+    cleanup(content, board);
+  });
+});

--- a/src/components/tiles/geometry/geometry-aria-utils.test.ts
+++ b/src/components/tiles/geometry/geometry-aria-utils.test.ts
@@ -1,0 +1,347 @@
+import {
+  announceGeometry,
+  applyBoardA11yAttributes,
+  buildBoardSummaryAriaLabel,
+  buildPointAriaLabel,
+  buildPolygonAriaLabel,
+  buildCircleAriaLabel,
+  buildInfiniteLineAriaLabel,
+  buildMovableLineAriaLabel,
+  buildVertexAngleAriaLabel,
+  buildCommentAriaLabel,
+  buildImageAriaLabel,
+  findGeometryAnnouncer,
+  focusGeometryContentEntry,
+} from "./geometry-aria-utils";
+
+describe("applyBoardA11yAttributes", () => {
+  it("makes the SVG element a focusable group with an initial aria-label", () => {
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    applyBoardA11yAttributes(svg);
+    expect(svg.getAttribute("tabindex")).toBe("0");
+    expect(svg.getAttribute("role")).toBe("group");
+    expect(svg.getAttribute("aria-label")).toBe("Coordinate grid board: empty");
+  });
+
+  it("is a no-op when called with undefined (defensive)", () => {
+    expect(() => applyBoardA11yAttributes(undefined)).not.toThrow();
+  });
+});
+
+describe("buildPointAriaLabel", () => {
+  it("labels a named free point with its coordinates", () => {
+    expect(buildPointAriaLabel({ name: "P1", x: 3, y: 4, isSelected: false }))
+      .toBe("Point P1 at (3, 4)");
+  });
+
+  it("omits the name segment when the point has no name", () => {
+    expect(buildPointAriaLabel({ x: 3, y: 4, isSelected: false }))
+      .toBe("Point at (3, 4)");
+  });
+
+  it("appends ', Selected' when selected", () => {
+    expect(buildPointAriaLabel({ name: "P1", x: 3, y: 4, isSelected: true }))
+      .toBe("Point P1 at (3, 4), Selected");
+  });
+
+  it("rounds fractional coordinates to one decimal", () => {
+    expect(buildPointAriaLabel({ x: 3.456, y: -1.234, isSelected: false }))
+      .toBe("Point at (3.5, -1.2)");
+  });
+
+  it("uses 'Linked point' phrasing when the point is linked from a Table", () => {
+    expect(buildPointAriaLabel({ x: 3, y: 4, isSelected: false, isLinked: true }))
+      .toBe("Linked point at (3, 4)");
+  });
+
+  it("labels a polygon vertex with its index, total, and polygon name", () => {
+    expect(buildPointAriaLabel({
+      name: "B", x: 3, y: 4, isSelected: false,
+      vertex: { polygonName: "ABCD", index: 2, total: 4 },
+    })).toBe("Vertex 2 of 4 of polygon ABCD: Point B at (3, 4)");
+  });
+
+  it("labels an unnamed polygon vertex without the per-point name segment", () => {
+    expect(buildPointAriaLabel({
+      x: 3, y: 4, isSelected: false,
+      vertex: { polygonName: "ABCD", index: 2, total: 4 },
+    })).toBe("Vertex 2 of 4 of polygon ABCD: Point at (3, 4)");
+  });
+
+  it("preserves the ', Selected' suffix on a vertex label", () => {
+    expect(buildPointAriaLabel({
+      name: "B", x: 3, y: 4, isSelected: true,
+      vertex: { polygonName: "ABCD", index: 2, total: 4 },
+    })).toBe("Vertex 2 of 4 of polygon ABCD: Point B at (3, 4), Selected");
+  });
+});
+
+describe("buildPolygonAriaLabel", () => {
+  it("includes the polygon name and vertex count", () => {
+    expect(buildPolygonAriaLabel({ name: "ABCD", vertexCount: 4, isSelected: false }))
+      .toBe("Polygon ABCD with 4 vertices");
+  });
+
+  it("omits the name segment when the polygon has no name", () => {
+    expect(buildPolygonAriaLabel({ vertexCount: 5, isSelected: false }))
+      .toBe("Polygon with 5 vertices");
+  });
+
+  it("uses singular 'vertex' when there is exactly one vertex", () => {
+    // A degenerate polygon, but the language should still read naturally.
+    expect(buildPolygonAriaLabel({ vertexCount: 1, isSelected: false }))
+      .toBe("Polygon with 1 vertex");
+  });
+
+  it("appends ', Selected' when selected", () => {
+    expect(buildPolygonAriaLabel({ name: "ABCD", vertexCount: 4, isSelected: true }))
+      .toBe("Polygon ABCD with 4 vertices, Selected");
+  });
+});
+
+describe("buildCircleAriaLabel", () => {
+  it("describes a circle with its center and radius", () => {
+    expect(buildCircleAriaLabel({ centerX: 0, centerY: 0, radius: 3, isSelected: false }))
+      .toBe("Circle centered at (0, 0) with radius 3");
+  });
+
+  it("rounds fractional center and radius to one decimal", () => {
+    expect(buildCircleAriaLabel({ centerX: 1.55, centerY: -2.49, radius: 2.7321, isSelected: false }))
+      .toBe("Circle centered at (1.6, -2.5) with radius 2.7");
+  });
+
+  it("appends ', Selected' when selected", () => {
+    expect(buildCircleAriaLabel({ centerX: 0, centerY: 0, radius: 3, isSelected: true }))
+      .toBe("Circle centered at (0, 0) with radius 3, Selected");
+  });
+});
+
+describe("buildInfiniteLineAriaLabel", () => {
+  it("describes an infinite line by its two defining points", () => {
+    expect(buildInfiniteLineAriaLabel({
+      p1: { x: 0, y: 0 }, p2: { x: 1, y: 1 }, isSelected: false,
+    })).toBe("Line through (0, 0) and (1, 1)");
+  });
+
+  it("appends ', Selected' when selected", () => {
+    expect(buildInfiniteLineAriaLabel({
+      p1: { x: 0, y: 0 }, p2: { x: 1, y: 1 }, isSelected: true,
+    })).toBe("Line through (0, 0) and (1, 1), Selected");
+  });
+});
+
+describe("buildMovableLineAriaLabel", () => {
+  it("describes a movable line as 'from … to …' (segment-like, not infinite)", () => {
+    expect(buildMovableLineAriaLabel({
+      p1: { x: 0, y: 0 }, p2: { x: 5, y: 5 }, isSelected: false,
+    })).toBe("Movable line from (0, 0) to (5, 5)");
+  });
+
+  it("appends ', Selected' when selected", () => {
+    expect(buildMovableLineAriaLabel({
+      p1: { x: 0, y: 0 }, p2: { x: 5, y: 5 }, isSelected: true,
+    })).toBe("Movable line from (0, 0) to (5, 5), Selected");
+  });
+});
+
+describe("buildVertexAngleAriaLabel", () => {
+  it("describes a vertex angle as 'NN degrees at (x, y)' with the vertex location", () => {
+    expect(buildVertexAngleAriaLabel({ degrees: 90, vertexX: 1, vertexY: 1, isSelected: false }))
+      .toBe("Vertex angle of 90 degrees at (1, 1)");
+  });
+
+  it("rounds the degree value to one decimal", () => {
+    expect(buildVertexAngleAriaLabel({ degrees: 42.678, vertexX: 0, vertexY: 0, isSelected: false }))
+      .toBe("Vertex angle of 42.7 degrees at (0, 0)");
+  });
+
+  it("appends ', Selected' when selected", () => {
+    expect(buildVertexAngleAriaLabel({ degrees: 90, vertexX: 1, vertexY: 1, isSelected: true }))
+      .toBe("Vertex angle of 90 degrees at (1, 1), Selected");
+  });
+});
+
+describe("buildCommentAriaLabel", () => {
+  it("formats a comment with its anchor label and full text when short", () => {
+    expect(buildCommentAriaLabel({ text: "Looks good", anchorLabel: "Point P1" }))
+      .toBe("Comment on Point P1: Looks good");
+  });
+
+  it("truncates comment text longer than ~50 characters with an ellipsis", () => {
+    const longText = "This is a very long comment that exceeds the announcement budget for screen readers";
+    expect(buildCommentAriaLabel({ text: longText, anchorLabel: "Point P1" }))
+      .toBe(`Comment on Point P1: ${longText.slice(0, 50)}…`);
+  });
+
+  it("omits the anchor segment when none is supplied", () => {
+    expect(buildCommentAriaLabel({ text: "Hi" }))
+      .toBe("Comment: Hi");
+  });
+});
+
+describe("buildImageAriaLabel", () => {
+  it("formats a background image with its pixel dimensions", () => {
+    expect(buildImageAriaLabel({ width: 480, height: 320 }))
+      .toBe("Background image, 480 × 320 pixels");
+  });
+});
+
+describe("findGeometryAnnouncer", () => {
+  it("returns the direct-child announcer of the nearest .geometry-tool ancestor", () => {
+    document.body.innerHTML = `
+      <div class="geometry-tool">
+        <div data-grid-announcer="" aria-live="polite"></div>
+        <div class="geometry-content"><svg><g></g></svg></div>
+      </div>`;
+    const start = document.querySelector(".geometry-content g") as Element;
+    const announcer = findGeometryAnnouncer(start);
+    expect(announcer).not.toBeNull();
+    expect(announcer?.hasAttribute("data-grid-announcer")).toBe(true);
+  });
+
+  it("returns the correct announcer when geometry tiles are nested (uses :scope)", () => {
+    document.body.innerHTML = `
+      <div class="geometry-tool" data-id="outer">
+        <div data-grid-announcer="" data-id="outer-announcer"></div>
+        <div class="geometry-tool" data-id="inner">
+          <div data-grid-announcer="" data-id="inner-announcer"></div>
+          <div class="geometry-content"><svg><g></g></svg></div>
+        </div>
+      </div>`;
+    const start = document.querySelector('[data-id="inner"] .geometry-content g') as Element;
+    const announcer = findGeometryAnnouncer(start);
+    expect(announcer?.getAttribute("data-id")).toBe("inner-announcer");
+  });
+
+  it("returns null when there is no .geometry-tool ancestor", () => {
+    document.body.innerHTML = `<div class="not-geometry"><span></span></div>`;
+    const start = document.querySelector("span") as Element;
+    expect(findGeometryAnnouncer(start)).toBeNull();
+  });
+});
+
+describe("announceGeometry", () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div class="geometry-tool">
+        <div data-grid-announcer="" aria-live="polite"></div>
+      </div>`;
+  });
+
+  function nextDoubleRaf(): Promise<void> {
+    return new Promise(resolve => {
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+    });
+  }
+
+  it("writes the message to the [data-grid-announcer] element after a double rAF", async () => {
+    const start = document.querySelector(".geometry-tool") as HTMLElement;
+    announceGeometry(start, "Point P1 at (3, 4), Selected");
+    await nextDoubleRaf();
+    expect(document.querySelector("[data-grid-announcer]")?.textContent)
+      .toBe("Point P1 at (3, 4), Selected");
+  });
+
+  it("re-announces the same message by clearing textContent first", async () => {
+    const start = document.querySelector(".geometry-tool") as HTMLElement;
+    const announcer = document.querySelector("[data-grid-announcer]") as HTMLElement;
+    announceGeometry(start, "Same message");
+    await nextDoubleRaf();
+    expect(announcer.textContent).toBe("Same message");
+
+    // Pre-set to the same string to verify the clear+re-set behaviour.
+    announcer.textContent = "Same message";
+    announceGeometry(start, "Same message");
+    // Mid-rAF the announcer is cleared so the screen reader notices the change.
+    await new Promise<void>(r => requestAnimationFrame(() => r()));
+    expect(announcer.textContent).toBe("");
+    await new Promise<void>(r => requestAnimationFrame(() => r()));
+    expect(announcer.textContent).toBe("Same message");
+  });
+
+  it("is a no-op when called from outside a .geometry-tool subtree", async () => {
+    document.body.innerHTML = `<div class="some-other-tile"><span></span></div>`;
+    const stray = document.querySelector("span") as HTMLElement;
+    expect(() => announceGeometry(stray, "should not throw")).not.toThrow();
+  });
+});
+
+describe("focusGeometryContentEntry", () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div class="geometry-content">
+        <svg tabindex="0" role="group">
+          <ellipse tabindex="0" data-object-id="p1" id="p1"></ellipse>
+          <ellipse tabindex="0" data-object-id="p2" id="p2"></ellipse>
+        </svg>
+      </div>`;
+  });
+
+  function content() {
+    return document.querySelector(".geometry-content") as HTMLElement;
+  }
+
+  it("focuses the SVG board on forward entry (Tab from title)", () => {
+    const ok = focusGeometryContentEntry(content(), /* reverse */ false);
+    expect(ok).toBe(true);
+    expect(document.activeElement?.tagName).toBe("svg");
+  });
+
+  it("focuses the last focusable rendNode on reverse entry (Shift+Tab from toolbar)", () => {
+    const ok = focusGeometryContentEntry(content(), /* reverse */ true);
+    expect(ok).toBe(true);
+    expect((document.activeElement as Element).getAttribute("data-object-id")).toBe("p2");
+  });
+
+  it("falls back to the SVG board on reverse entry when there are no focusable objects", () => {
+    document.body.innerHTML = `
+      <div class="geometry-content">
+        <svg tabindex="0" role="group"></svg>
+      </div>`;
+    const ok = focusGeometryContentEntry(content(), /* reverse */ true);
+    expect(ok).toBe(true);
+    expect(document.activeElement?.tagName).toBe("svg");
+  });
+
+  it("returns false when the content element is undefined", () => {
+    expect(focusGeometryContentEntry(undefined, false)).toBe(false);
+    expect(focusGeometryContentEntry(undefined, true)).toBe(false);
+  });
+});
+
+describe("buildBoardSummaryAriaLabel", () => {
+  it("returns 'empty' when there are no objects", () => {
+    expect(buildBoardSummaryAriaLabel({
+      byType: { points: 0, polygons: 0, circles: 0, lines: 0 },
+      selectedCount: 0,
+    })).toBe("Coordinate grid board: empty");
+  });
+
+  it("summarises a mixed board with type counts and selection count", () => {
+    expect(buildBoardSummaryAriaLabel({
+      byType: { points: 3, polygons: 1, circles: 0, lines: 0 },
+      selectedCount: 1,
+    })).toBe("Coordinate grid board: 3 points, 1 polygon, 1 selected");
+  });
+
+  it("uses singular type names when the count is 1", () => {
+    expect(buildBoardSummaryAriaLabel({
+      byType: { points: 1, polygons: 0, circles: 0, lines: 0 },
+      selectedCount: 0,
+    })).toBe("Coordinate grid board: 1 point");
+  });
+
+  it("omits zero-count types from the summary", () => {
+    expect(buildBoardSummaryAriaLabel({
+      byType: { points: 2, polygons: 0, circles: 1, lines: 0 },
+      selectedCount: 0,
+    })).toBe("Coordinate grid board: 2 points, 1 circle");
+  });
+
+  it("omits the selection segment when nothing is selected", () => {
+    expect(buildBoardSummaryAriaLabel({
+      byType: { points: 2, polygons: 0, circles: 0, lines: 0 },
+      selectedCount: 0,
+    })).toBe("Coordinate grid board: 2 points");
+  });
+});

--- a/src/components/tiles/geometry/geometry-aria-utils.ts
+++ b/src/components/tiles/geometry/geometry-aria-utils.ts
@@ -1,0 +1,516 @@
+// Accessibility helpers for the Coordinate Grid (geometry) tile: decorating
+// the JSXGraph SVG root, building per-object aria-labels, and refreshing
+// focusable objects after board mutations.
+
+import type { GeometryContentModelType } from "../../../models/tiles/geometry/geometry-content";
+import { forEachBoardObject } from "../../../models/tiles/geometry/geometry-utils";
+import {
+  isCircle, isComment, isImage, isInfiniteLine, isLinkedPoint, isMovableLine,
+  isMovableLineLabel, isPoint, isPolygon, isVertexAngle,
+} from "../../../models/tiles/geometry/jxg-types";
+
+/** Decorates the JSXGraph SVG root so it participates in the tile's focus trap. */
+export function applyBoardA11yAttributes(svg: SVGElement | undefined): void {
+  if (!svg) return;
+  svg.setAttribute("tabindex", "0");
+  svg.setAttribute("role", "group");
+  svg.setAttribute("aria-label", "Coordinate grid board: empty");
+}
+
+/**
+ * Returns the aria-live announcer for the geometry tile containing `start`.
+ * Uses `:scope >` so nested geometry tiles (e.g. inside a question tile) don't
+ * match the wrong announcer.
+ */
+export function findGeometryAnnouncer(start: Element | null): HTMLElement | null {
+  if (!start) return null;
+  const wrapper = start.closest(".geometry-tool");
+  return wrapper?.querySelector<HTMLElement>(":scope > [data-grid-announcer]") ?? null;
+}
+
+/**
+ * Announces `message` through the geometry tile's aria-live region. Clears
+ * textContent first inside a double-rAF so screen readers re-announce
+ * identical consecutive messages (which they otherwise suppress).
+ */
+export function announceGeometry(start: Element | null, message: string): void {
+  const announcer = findGeometryAnnouncer(start);
+  if (!announcer) return;
+  requestAnimationFrame(() => {
+    announcer.textContent = "";
+    requestAnimationFrame(() => {
+      announcer.textContent = message;
+    });
+  });
+}
+
+/**
+ * Direction-aware focus entry for the geometry content slot: forward focuses
+ * the SVG board (first stop, carries the summary aria-label); reverse focuses
+ * the last element in the semantic Tab order via getOrderedGeometryFocusables.
+ * Falls back to DOM-order `tabindex="0"` when board/content aren't supplied.
+ */
+export function focusGeometryContentEntry(
+  content: HTMLElement | undefined,
+  reverse: boolean,
+  board?: JXG.Board,
+  contentModel?: GeometryContentModelType,
+): boolean {
+  if (!content) return false;
+  if (reverse) {
+    if (board && contentModel) {
+      const ordered = getOrderedGeometryFocusables(board);
+      if (ordered.length > 0) {
+        const target = ordered[ordered.length - 1];
+        target.focus();
+        return document.activeElement === target;
+      }
+    }
+    const stops = content.querySelectorAll<HTMLElement | SVGElement>('[tabindex="0"]');
+    if (stops.length > 0) {
+      const target = stops[stops.length - 1] as HTMLElement;
+      target.focus();
+      return document.activeElement === target;
+    }
+  }
+  const svg = content.querySelector<SVGElement>("svg");
+  if (!svg) return false;
+  (svg as unknown as HTMLElement).focus();
+  return document.activeElement === svg;
+}
+
+// Aria-label builders for visible geometry objects. Each takes a plain-data
+// context object (not a JSXGraph object) so it's unit-testable without a
+// real board; applyA11yAttributes extracts each element's data into one.
+
+function formatCoord(n: number): string {
+  if (Number.isInteger(n)) return String(n);
+  return (Math.round(n * 10) / 10).toString();
+}
+
+function formatCoordsPair(x: number, y: number): string {
+  return `(${formatCoord(x)}, ${formatCoord(y)})`;
+}
+
+function selectedSuffix(isSelected: boolean): string {
+  return isSelected ? ", Selected" : "";
+}
+
+export interface PointAriaContext {
+  /** The point's user-facing label (e.g. "P1", "A"). Omitted if empty. */
+  name?: string;
+  x: number;
+  y: number;
+  isSelected: boolean;
+  /** True for points sourced from a linked Table tile (clientType=linkedPoint). */
+  isLinked?: boolean;
+  /**
+   * When present, the point is a vertex of a polygon — the label leads with
+   * "Vertex {index} of {total} of polygon {polygonName}:".
+   */
+  vertex?: { polygonName: string; index: number; total: number };
+}
+
+/** "Point P1 at (3, 4), Selected" — with "Linked point" or "Vertex k of N of polygon X" prefix when applicable. */
+export function buildPointAriaLabel(ctx: PointAriaContext): string {
+  const coords = formatCoordsPair(ctx.x, ctx.y);
+  const namePart = ctx.name ? ` ${ctx.name}` : "";
+  if (ctx.vertex) {
+    const { polygonName, index, total } = ctx.vertex;
+    const suffix = selectedSuffix(ctx.isSelected);
+    return `Vertex ${index} of ${total} of polygon ${polygonName}: Point${namePart} at ${coords}${suffix}`;
+  }
+  if (ctx.isLinked) {
+    return `Linked point at ${coords}${selectedSuffix(ctx.isSelected)}`;
+  }
+  return `Point${namePart} at ${coords}${selectedSuffix(ctx.isSelected)}`;
+}
+
+export interface PolygonAriaContext {
+  /** The polygon's user-facing label (e.g. "ABCD"). Omitted if empty. */
+  name?: string;
+  vertexCount: number;
+  isSelected: boolean;
+}
+
+export function buildPolygonAriaLabel(ctx: PolygonAriaContext): string {
+  const namePart = ctx.name ? ` ${ctx.name}` : "";
+  const vertexNoun = ctx.vertexCount === 1 ? "vertex" : "vertices";
+  return `Polygon${namePart} with ${ctx.vertexCount} ${vertexNoun}${selectedSuffix(ctx.isSelected)}`;
+}
+
+export interface CircleAriaContext {
+  centerX: number;
+  centerY: number;
+  radius: number;
+  isSelected: boolean;
+}
+
+export function buildCircleAriaLabel(ctx: CircleAriaContext): string {
+  const center = formatCoordsPair(ctx.centerX, ctx.centerY);
+  return `Circle centered at ${center} with radius ${formatCoord(ctx.radius)}${selectedSuffix(ctx.isSelected)}`;
+}
+
+export interface LineAriaContext {
+  p1: { x: number; y: number };
+  p2: { x: number; y: number };
+  isSelected: boolean;
+}
+
+/** "Line through (x1, y1) and (x2, y2)" — "through" signals infinite extent. */
+export function buildInfiniteLineAriaLabel(ctx: LineAriaContext): string {
+  const a = formatCoordsPair(ctx.p1.x, ctx.p1.y);
+  const b = formatCoordsPair(ctx.p2.x, ctx.p2.y);
+  return `Line through ${a} and ${b}${selectedSuffix(ctx.isSelected)}`;
+}
+
+/** "Movable line from (x1, y1) to (x2, y2)" — "from…to" signals bounded segment. */
+export function buildMovableLineAriaLabel(ctx: LineAriaContext): string {
+  const a = formatCoordsPair(ctx.p1.x, ctx.p1.y);
+  const b = formatCoordsPair(ctx.p2.x, ctx.p2.y);
+  return `Movable line from ${a} to ${b}${selectedSuffix(ctx.isSelected)}`;
+}
+
+export interface VertexAngleAriaContext {
+  degrees: number;
+  vertexX: number;
+  vertexY: number;
+  isSelected: boolean;
+}
+
+export function buildVertexAngleAriaLabel(ctx: VertexAngleAriaContext): string {
+  const vertex = formatCoordsPair(ctx.vertexX, ctx.vertexY);
+  return `Vertex angle of ${formatCoord(ctx.degrees)} degrees at ${vertex}${selectedSuffix(ctx.isSelected)}`;
+}
+
+const kCommentMaxChars = 50;
+
+export interface CommentAriaContext {
+  text: string;
+  /** Label of the anchored object, e.g. "Point P1". */
+  anchorLabel?: string;
+}
+
+export function buildCommentAriaLabel(ctx: CommentAriaContext): string {
+  const text = ctx.text.length > kCommentMaxChars
+    ? `${ctx.text.slice(0, kCommentMaxChars)}…`
+    : ctx.text;
+  const prefix = ctx.anchorLabel ? `Comment on ${ctx.anchorLabel}` : "Comment";
+  return `${prefix}: ${text}`;
+}
+
+export interface ImageAriaContext {
+  width: number;
+  height: number;
+}
+
+/** "Background image, W × H pixels" — true U+00D7 so the screen reader says "by". */
+export function buildImageAriaLabel(ctx: ImageAriaContext): string {
+  return `Background image, ${ctx.width} × ${ctx.height} pixels`;
+}
+
+export interface BoardSummaryAriaContext {
+  byType: {
+    points: number;
+    polygons: number;
+    circles: number;
+    lines: number;
+  };
+  selectedCount: number;
+}
+
+const kBoardSummaryTypeLabels = {
+  points:   { singular: "point",   plural: "points"   },
+  polygons: { singular: "polygon", plural: "polygons" },
+  circles:  { singular: "circle",  plural: "circles"  },
+  lines:    { singular: "line",    plural: "lines"    },
+} as const;
+
+/** "Coordinate grid board: N points, M selected" — what a screen reader hears on board entry. */
+export function buildBoardSummaryAriaLabel(ctx: BoardSummaryAriaContext): string {
+  const segments: string[] = [];
+  for (const key of ["points", "polygons", "circles", "lines"] as const) {
+    const count = ctx.byType[key];
+    if (count > 0) {
+      const noun = count === 1
+        ? kBoardSummaryTypeLabels[key].singular
+        : kBoardSummaryTypeLabels[key].plural;
+      segments.push(`${count} ${noun}`);
+    }
+  }
+  if (segments.length === 0) return "Coordinate grid board: empty";
+  if (ctx.selectedCount > 0) {
+    segments.push(`${ctx.selectedCount} selected`);
+  }
+  return `Coordinate grid board: ${segments.join(", ")}`;
+}
+
+export function updateBoardAriaLabel(board: JXG.Board, content: GeometryContentModelType): void {
+  const svg = board.containerObj?.querySelector("svg") as SVGElement | null;
+  if (!svg) return;
+  const byType = { points: 0, polygons: 0, circles: 0, lines: 0 };
+  let selectedCount = 0;
+  forEachBoardObject(board, elt => {
+    const isPhantom = !!elt.getAttribute("isPhantom");
+    const isInvisible = elt.visProp && !elt.visProp.visible;
+    if (isPhantom || isInvisible) return;
+    if (isPoint(elt)) byType.points += 1;
+    else if (isPolygon(elt)) byType.polygons += 1;
+    else if (isCircle(elt)) byType.circles += 1;
+    else if (isInfiniteLine(elt) || isMovableLine(elt)) byType.lines += 1;
+    else return;
+    if (content.isSelected(elt.id)) selectedCount += 1;
+  });
+  svg.setAttribute("aria-label", buildBoardSummaryAriaLabel({ byType, selectedCount }));
+}
+
+// ---------------------------------------------------------------------------
+// Per-element attribute application
+// ---------------------------------------------------------------------------
+
+function pointXY(point: JXG.Point): [number, number] {
+  const [, x, y] = point.coords.usrCoords;
+  return [x, y];
+}
+
+interface VertexInfo {
+  polygonName: string;
+  /** 1-based; excludes the closing-vertex duplicate. */
+  index: number;
+  total: number;
+}
+
+interface ApplyA11yOptions {
+  /** Set by the polygon recursion so each vertex gets a "Vertex k of N…" label. */
+  vertexInfo?: VertexInfo;
+  /** Read-only boards (navigator mini-map, read-only docs) clear attrs so objects skip the Tab cycle. */
+  readOnly?: boolean;
+}
+
+function clearA11yAttributes(rendNode: HTMLElement | undefined): void {
+  if (!rendNode) return;
+  rendNode.removeAttribute("tabindex");
+  rendNode.removeAttribute("role");
+  rendNode.removeAttribute("aria-pressed");
+  rendNode.removeAttribute("aria-label");
+  rendNode.removeAttribute("data-object-id");
+}
+
+function writeButtonA11yAttributes(
+  rendNode: HTMLElement, id: string, label: string, isSelected: boolean,
+): void {
+  rendNode.setAttribute("tabindex", "0");
+  rendNode.setAttribute("role", "button");
+  rendNode.setAttribute("aria-pressed", isSelected ? "true" : "false");
+  rendNode.setAttribute("aria-label", label);
+  rendNode.setAttribute("data-object-id", id);
+}
+
+/**
+ * Decorates a JSXGraph element's rendNode for screen readers and the focus
+ * trap. Phantom / invisible / read-only elements get their attributes cleared
+ * so they drop out of the Tab cycle. Polygons recurse over their vertices
+ * with vertex-aware labels.
+ */
+export function applyA11yAttributes(
+  elt: JXG.GeometryElement,
+  content: GeometryContentModelType,
+  options: ApplyA11yOptions = {},
+): void {
+  const { vertexInfo, readOnly } = options;
+  const rendNode = elt.rendNode;
+  if (!rendNode) return;
+
+  const isPhantom = !!elt.getAttribute("isPhantom");
+  const isInvisible = elt.visProp && !elt.visProp.visible;
+  if (readOnly || isPhantom || isInvisible) {
+    clearA11yAttributes(rendNode);
+    return;
+  }
+
+  const isSelected = content.isSelected(elt.id);
+
+  if (isPolygon(elt)) {
+    const vertices = polygonVertices(elt);
+    const label = buildPolygonAriaLabel({
+      name: elt.name || undefined, vertexCount: vertices.length, isSelected,
+    });
+    writeButtonA11yAttributes(rendNode, elt.id, label, isSelected);
+    vertices.forEach((vertex, i) => {
+      applyA11yAttributes(vertex, content, {
+        vertexInfo: {
+          polygonName: elt.name || "unnamed",
+          index: i + 1,
+          total: vertices.length,
+        },
+      });
+    });
+    return;
+  }
+
+  if (isPoint(elt)) {
+    // A full-board refresh also reaches each polygon vertex standalone (with
+    // no vertexInfo); skip so the polygon's recursive pass owns the label —
+    // otherwise iteration order would determine whether the vertex gets the
+    // "Vertex k of N of polygon X" label or a bare "Point" label.
+    if (!vertexInfo && isPolygonVertex(elt)) return;
+    const [x, y] = pointXY(elt);
+    const label = buildPointAriaLabel({
+      name: elt.name || undefined,
+      x, y,
+      isSelected,
+      isLinked: isLinkedPoint(elt),
+      vertex: vertexInfo,
+    });
+    writeButtonA11yAttributes(rendNode, elt.id, label, isSelected);
+    return;
+  }
+
+  if (isCircle(elt)) {
+    const [cx, cy] = pointXY(elt.center as JXG.Point);
+    const label = buildCircleAriaLabel({
+      centerX: cx, centerY: cy, radius: elt.Radius(), isSelected,
+    });
+    writeButtonA11yAttributes(rendNode, elt.id, label, isSelected);
+    return;
+  }
+
+  if (isInfiniteLine(elt) || isMovableLine(elt)) {
+    const [x1, y1] = pointXY(elt.point1 as JXG.Point);
+    const [x2, y2] = pointXY(elt.point2 as JXG.Point);
+    const builder = isInfiniteLine(elt) ? buildInfiniteLineAriaLabel : buildMovableLineAriaLabel;
+    const label = builder({
+      p1: { x: x1, y: y1 }, p2: { x: x2, y: y2 }, isSelected,
+    });
+    writeButtonA11yAttributes(rendNode, elt.id, label, isSelected);
+    return;
+  }
+
+  if (isVertexAngle(elt)) {
+    // JXG.Angle: `point` is the vertex; `Value()` returns radians.
+    const angle = elt as unknown as { point: JXG.Point; Value: () => number };
+    const [vx, vy] = pointXY(angle.point);
+    const label = buildVertexAngleAriaLabel({
+      degrees: angle.Value() * 180 / Math.PI,
+      vertexX: vx, vertexY: vy, isSelected,
+    });
+    writeButtonA11yAttributes(rendNode, elt.id, label, isSelected);
+    return;
+  }
+
+  if (isComment(elt)) {
+    const text = (elt as JXG.Text).plaintext ?? "";
+    const label = buildCommentAriaLabel({ text, anchorLabel: resolveAnchorLabel(elt) });
+    writeButtonA11yAttributes(rendNode, elt.id, label, isSelected);
+    return;
+  }
+
+  if (isMovableLineLabel(elt)) {
+    // Reachable via the parent line — not its own tab stop.
+    clearA11yAttributes(rendNode);
+    return;
+  }
+
+  if (isImage(elt)) {
+    // `.size` is present at runtime but missing from the .d.ts.
+    const image = elt as unknown as { size: [number, number] };
+    const [width, height] = image.size ?? [0, 0];
+    const label = buildImageAriaLabel({ width, height });
+    writeButtonA11yAttributes(rendNode, elt.id, label, isSelected);
+  }
+}
+
+/** JSXGraph closes polygons by repeating vs[0] as the last vertex; drop that duplicate. */
+function polygonVertices(polygon: JXG.Polygon): JXG.Point[] {
+  const vs = polygon.vertices as JXG.Point[];
+  if (vs.length >= 2 && vs[vs.length - 1] === vs[0]) {
+    return vs.slice(0, -1);
+  }
+  return vs;
+}
+
+function isPolygonVertex(point: JXG.Point): boolean {
+  const descendants = point.descendants ?? {};
+  return Object.values(descendants).some(isPolygon);
+}
+
+function describeAnchorElement(anchor: JXG.GeometryElement): string | undefined {
+  const name = anchor.name || undefined;
+  if (isPoint(anchor)) return name ? `Point ${name}` : "Point";
+  if (isPolygon(anchor)) return name ? `Polygon ${name}` : "Polygon";
+  if (isCircle(anchor)) return "Circle";
+  if (isInfiniteLine(anchor) || isMovableLine(anchor)) return "Line";
+  return undefined;
+}
+
+function resolveAnchorLabel(comment: JXG.GeometryElement): string | undefined {
+  const anchorId = comment.getAttribute("anchor");
+  if (!anchorId) return undefined;
+  const anchor = comment.board?.objects?.[anchorId] as JXG.GeometryElement | undefined;
+  return anchor ? describeAnchorElement(anchor) : undefined;
+}
+
+/**
+ * Re-applies a11y attributes to every board object and refreshes the summary
+ * label in one pass. Caller skips during active drag.
+ */
+export function refreshA11yAttributes(
+  board: JXG.Board, content: GeometryContentModelType, readOnly = false,
+): void {
+  forEachBoardObject(board, elt => applyA11yAttributes(elt, content, { readOnly }));
+  updateBoardAriaLabel(board, content);
+}
+
+function isFocusableForTabOrder(elt: JXG.GeometryElement): boolean {
+  if (!elt.rendNode) return false;
+  if (elt.getAttribute("isPhantom")) return false;
+  if (elt.visProp && !elt.visProp.visible) return false;
+  return elt.rendNode.getAttribute("tabindex") === "0";
+}
+
+/**
+ * Visible focusable rendNodes in a screen-reader-friendly Tab order: each
+ * compound shape (polygon / circle / infinite / movable line) followed by its
+ * defining points, then orphan points, then standalone elements (vertex
+ * angles, comments, images). Points shared across shapes appear once, under
+ * the first shape that claims them.
+ *
+ * Why a custom order: JSXGraph paints shape outlines before points, so plain
+ * DOM-order Tab would walk every shape first then every point — including
+ * points the user just heard described as belonging to a shape.
+ */
+export function getOrderedGeometryFocusables(board: JXG.Board): HTMLElement[] {
+  const ordered: HTMLElement[] = [];
+  const seenPointIds = new Set<string>();
+
+  // Compound shapes + their defining points (in creation order).
+  forEachBoardObject(board, elt => {
+    if (!isFocusableForTabOrder(elt)) return;
+    if (isPolygon(elt) || isCircle(elt) || isInfiniteLine(elt) || isMovableLine(elt)) {
+      ordered.push(elt.rendNode);
+      const definingPoints = Object.values(elt.ancestors).filter(isPoint);
+      for (const pt of definingPoints) {
+        if (!isFocusableForTabOrder(pt)) continue;
+        if (seenPointIds.has(pt.id)) continue;
+        seenPointIds.add(pt.id);
+        ordered.push(pt.rendNode);
+      }
+    }
+  });
+
+  // Orphan points + standalone elements.
+  forEachBoardObject(board, elt => {
+    if (!isFocusableForTabOrder(elt)) return;
+    if (isPoint(elt)) {
+      if (seenPointIds.has(elt.id)) return;
+      seenPointIds.add(elt.id);
+      ordered.push(elt.rendNode);
+      return;
+    }
+    if (isVertexAngle(elt) || isComment(elt) || isImage(elt)) {
+      ordered.push(elt.rendNode);
+    }
+  });
+
+  return ordered;
+}

--- a/src/components/tiles/geometry/geometry-content.tsx
+++ b/src/components/tiles/geometry/geometry-content.tsx
@@ -50,6 +50,12 @@ import { createLinkedPoint, getAllLinkedPoints } from "../../../models/tiles/geo
 import { extractDragTileType, kDragTileContent, kDragTileId, dragTileSrcDocId } from "../tile-component";
 import { gImageMap, ImageMapEntry } from "../../../models/image-map";
 import { ITileExportOptions } from "../../../models/tiles/tile-content-info";
+import { ITileApi } from "../tile-api";
+import {
+  applyBoardA11yAttributes, applyA11yAttributes, refreshA11yAttributes, updateBoardAriaLabel,
+} from "./geometry-aria-utils";
+import { seedShapeForMode } from "./geometry-keyboard-create";
+import { GeometryTileMode } from "./geometry-types";
 import { getParentWithTypeName } from "../../../utilities/mst-utils";
 import { notEmpty, safeJsonParse, uniqueId } from "../../../utilities/js-utils";
 import { hasSelectionModifier } from "../../../utilities/event-utils";
@@ -72,6 +78,15 @@ export interface IGeometryContentProps extends IGeometryProps {
   onSetBoard?: (board: JXG.Board) => void;
   onSetActionHandlers?: (handlers: IActionHandlers) => void;
   onContentChange?: () => void;
+  /**
+   * Called from componentDidMount / componentWillUnmount with the geometry-specific
+   * annotation/export API (or an empty object on unmount). The parent
+   * `GeometryToolComponent` captures these implementations into a ref so that
+   * `useClueAccessibility` can register a single tile API per mount — the hook's
+   * `additionalApi` proxy delegates to the latest captured implementations at
+   * call time. See [src/hooks/use-clue-accessibility.ts](../../../hooks/use-clue-accessibility.ts).
+   */
+  onSetAdditionalApi?: (api: Partial<ITileApi>) => void;
 }
 export interface IProps extends IGeometryContentProps, SizeMeProps {
   measureText: (text: string) => number;
@@ -217,11 +232,24 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
         handleZoomOut: this.handleZoomOut,
         handleFitAll: this.handleScaleToFit,
         handleSetShowColorPalette: this.handleSetShowColorPalette,
-        handleColorChange: this.handleColorChange
+        handleColorChange: this.handleColorChange,
+        handleSeedShape: this.handleSeedShape,
       };
       onSetActionHandlers(handlers);
     }
   }
+
+  private handleSeedShape = (mode: GeometryTileMode) => {
+    const { board } = this.state;
+    if (!board || this.props.readOnly) return;
+    this.applyChange(() => {
+      const created = seedShapeForMode(board, this.getContent(), mode);
+      created.forEach(elt => this.handleCreateElements(elt));
+      // closeActivePolygon can replace the polygon's rendNode, leaving the
+      // attrs we just set on a stale node. Re-decorate every live node.
+      refreshA11yAttributes(board, this.getContent(), this.props.readOnly);
+    });
+  };
 
   private getPointScreenCoords(pointId: string) {
     if (!this.state.board) return;
@@ -278,7 +306,7 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
     this.initializeContent();
 
     if (!this.props.showAllContent) {
-      this.props.onRegisterTileApi({
+      this.props.onSetAdditionalApi?.({
 
         isLinked: () => {
           return this.getContent().isLinked;
@@ -486,6 +514,11 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
           const selected = this.getContent().isSelected(edge.point1.id) && this.getContent().isSelected(edge.point2.id);
           updateVisualProps(_board, edge.id, selected);
         });
+        // Refresh aria-pressed + ", Selected" suffix. Skipped mid-drag
+        // (endDragSelectedPoints does the catch-up).
+        if (!this.isVertexDrag) {
+          this.scheduleA11yRefresh();
+        }
       }
     }));
 
@@ -556,13 +589,21 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
 
   public componentWillUnmount() {
     this.disposers.forEach(disposer => disposer());
+    if (this.a11yRefreshHandle !== null) {
+      cancelAnimationFrame(this.a11yRefreshHandle);
+      this.a11yRefreshHandle = null;
+    }
+    if (this.boardSummaryHandle !== null) {
+      cancelAnimationFrame(this.boardSummaryHandle);
+      this.boardSummaryHandle = null;
+    }
 
     if (this.state.board) {
       // delay so any asynchronous JSXGraph actions have time to complete
       setTimeout(() => this.destroyBoard());
     }
 
-    this.props.onUnregisterTileApi();
+    this.props.onSetAdditionalApi?.({});
 
     this._isMounted = false;
   }
@@ -1501,6 +1542,29 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
     });
   };
 
+  // rAF-coalesced refreshes — without these, the per-id selection observer
+  // and per-create handlers would sweep the board N times for one user action.
+  private a11yRefreshHandle: number | null = null;
+  private boardSummaryHandle: number | null = null;
+
+  private scheduleA11yRefresh = () => {
+    if (this.a11yRefreshHandle !== null) return;
+    this.a11yRefreshHandle = requestAnimationFrame(() => {
+      this.a11yRefreshHandle = null;
+      const board = this.state.board;
+      if (board) refreshA11yAttributes(board, this.getContent(), this.props.readOnly);
+    });
+  };
+
+  private refreshBoardSummary = () => {
+    if (this.boardSummaryHandle !== null) return;
+    this.boardSummaryHandle = requestAnimationFrame(() => {
+      this.boardSummaryHandle = null;
+      const board = this.state.board;
+      if (board) updateBoardAriaLabel(board, this.getContent());
+    });
+  };
+
   private applyChange(change: () => void) {
     try {
       ++this.suspendSnapshotResponse;
@@ -1632,6 +1696,10 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
     }
     this.dragPts = {};
 
+    // One-shot catch-up: the selection-change observer skips refreshes while
+    // isVertexDrag is true.
+    refreshA11yAttributes(board, content, this.props.readOnly);
+
     return didDragPoints;
   }
 
@@ -1759,6 +1827,8 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
       this.props.onSetBoard(board);
     }
 
+    applyBoardA11yAttributes(this.domElement?.querySelector("svg") ?? undefined);
+
     board.on("down", handlePointerDown);
     board.on("up", handlePointerUp);
   };
@@ -1835,6 +1905,8 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
   }
 
   private handleCreatePoint = (point: JXG.Point) => {
+    applyA11yAttributes(point, this.getContent(), { readOnly: this.props.readOnly });
+    this.refreshBoardSummary();
 
     const handlePointerDown = (evt: Event) => {
       const { board, mode } = this.context;
@@ -1934,6 +2006,8 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
   };
 
   private handleCreateLine = (line: JXG.Line) => {
+    applyA11yAttributes(line, this.getContent(), { readOnly: this.props.readOnly });
+    this.refreshBoardSummary();
 
     function getVertices() {
       return [line.point1, line.point2];
@@ -2011,6 +2085,8 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
   };
 
   private handleCreateCircle = (circle: JXG.Circle) => {
+    applyA11yAttributes(circle, this.getContent(), { readOnly: this.props.readOnly });
+    this.refreshBoardSummary();
 
     const isInVertex = (evt: any) => {
       const { scale } = this.props;
@@ -2097,6 +2173,8 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
   };
 
   private handleCreateInfiniteLine = (line: JXG.Line) => {
+    applyA11yAttributes(line, this.getContent(), { readOnly: this.props.readOnly });
+    this.refreshBoardSummary();
 
     const isInVertex = (evt: any) => {
       const { scale } = this.props;
@@ -2181,6 +2259,8 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
   };
 
   private handleCreatePolygon = (polygon: JXG.Polygon) => {
+    applyA11yAttributes(polygon, this.getContent(), { readOnly: this.props.readOnly });
+    this.refreshBoardSummary();
 
     const isInVertex = (evt: any) => {
       const { scale } = this.props;
@@ -2271,9 +2351,11 @@ export class GeometryContentComponent extends BaseComponent<IProps, IState> {
 
   private handleCreateVertexAngle = (angle: JXG.Angle) => {
     updateVertexAngle(angle);
+    applyA11yAttributes(angle, this.getContent(), { readOnly: this.props.readOnly });
   };
 
   private handleCreateText = (text: JXG.Text) => {
+    applyA11yAttributes(text, this.getContent(), { readOnly: this.props.readOnly });
     const handlePointerDown = (evt: any) => {
       const content = this.getContent();
       const { readOnly } = this.props;

--- a/src/components/tiles/geometry/geometry-keyboard-create.test.ts
+++ b/src/components/tiles/geometry/geometry-keyboard-create.test.ts
@@ -44,12 +44,10 @@ function pointCoords(p: JXG.Point): [number, number] {
 }
 
 describe("seedShapeForMode — points / select", () => {
-  it("seeds a single free point at user-coords (1, 1) for 'select' mode", () => {
+  it("is a no-op for 'select' mode (navigation only — no point created)", () => {
     const { content, board } = createContentAndBoard();
     const created = seedShapeForMode(board, content, "select");
-    const points = created.filter(isPoint);
-    expect(points).toHaveLength(1);
-    expect(pointCoords(points[0])).toEqual([1, 1]);
+    expect(created).toEqual([]);
     cleanup(content, board);
   });
 

--- a/src/components/tiles/geometry/geometry-keyboard-create.test.ts
+++ b/src/components/tiles/geometry/geometry-keyboard-create.test.ts
@@ -1,0 +1,120 @@
+import { destroy } from "mobx-state-tree";
+import {
+  defaultGeometryContent, GeometryContentModelType, GeometryMetadataModel,
+} from "../../../models/tiles/geometry/geometry-content";
+import { isCircle, isInfiniteLine, isPoint, isPolygon } from "../../../models/tiles/geometry/jxg-types";
+import { seedShapeForMode } from "./geometry-keyboard-create";
+
+jest.mock("../../../models/tiles/log/log-tile-change-event", () => ({
+  logTileChangeEvent: () => undefined,
+}));
+
+// eslint-disable-next-line no-console
+const origConsoleLog = console.log;
+let consoleSpy: jest.SpyInstance;
+beforeAll(() => {
+  consoleSpy = jest.spyOn(console, "log").mockImplementation((...args: any[]) => {
+    if (!args.some(arg => typeof arg === "string" && arg.includes("IntersectionObserver not available"))) {
+      origConsoleLog(...args);
+    }
+  });
+});
+afterAll(() => consoleSpy.mockRestore());
+
+const divId = "keyboardCreateBoard";
+document.body.innerHTML = `<div id="${divId}" style="width:200px;height:200px"></div>`;
+
+function createContentAndBoard(): { content: GeometryContentModelType, board: JXG.Board } {
+  const content = defaultGeometryContent();
+  const metadata = GeometryMetadataModel.create({ id: "geometry-1" });
+  content.doPostCreate!(metadata);
+  const board = content.initializeBoard(divId, false, () => {/* noop */}, () => {/* noop */}) as JXG.Board;
+  content.resizeBoard(board, 200, 200);
+  return { content, board };
+}
+
+function cleanup(content: GeometryContentModelType, board: JXG.Board) {
+  content.destroyBoard(board);
+  destroy(content);
+}
+
+function pointCoords(p: JXG.Point): [number, number] {
+  const [, x, y] = p.coords.usrCoords;
+  return [x, y];
+}
+
+describe("seedShapeForMode — points / select", () => {
+  it("seeds a single free point at user-coords (1, 1) for 'select' mode", () => {
+    const { content, board } = createContentAndBoard();
+    const created = seedShapeForMode(board, content, "select");
+    const points = created.filter(isPoint);
+    expect(points).toHaveLength(1);
+    expect(pointCoords(points[0])).toEqual([1, 1]);
+    cleanup(content, board);
+  });
+
+  it("seeds a single free point at (1, 1) for 'points' mode", () => {
+    const { content, board } = createContentAndBoard();
+    const created = seedShapeForMode(board, content, "points");
+    const points = created.filter(isPoint);
+    expect(points).toHaveLength(1);
+    expect(pointCoords(points[0])).toEqual([1, 1]);
+    cleanup(content, board);
+  });
+});
+
+describe("seedShapeForMode — polygon", () => {
+  it("seeds a unit-square polygon with 4 vertices at (1,1) (2,1) (2,2) (1,2)", () => {
+    const { content, board } = createContentAndBoard();
+    const created = seedShapeForMode(board, content, "polygon");
+    const points = created.filter(isPoint);
+    const polygons = created.filter(isPolygon);
+
+    expect(points).toHaveLength(4);
+    expect(polygons).toHaveLength(1);
+    const coords = points.map(pointCoords).sort();
+    expect(coords).toEqual([[1, 1], [1, 2], [2, 1], [2, 2]]);
+    cleanup(content, board);
+  });
+});
+
+describe("seedShapeForMode — circle", () => {
+  it("seeds a unit circle centered at (1, 1) with tangent point at (2, 1)", () => {
+    const { content, board } = createContentAndBoard();
+    const created = seedShapeForMode(board, content, "circle");
+    const points = created.filter(isPoint);
+    const circles = created.filter(isCircle);
+
+    expect(points).toHaveLength(2);
+    expect(circles).toHaveLength(1);
+    const coords = points.map(pointCoords).sort();
+    expect(coords).toEqual([[1, 1], [2, 1]]);
+    cleanup(content, board);
+  });
+});
+
+describe("seedShapeForMode — line (infinite)", () => {
+  it("seeds an infinite line through (1, 1) and (2, 1)", () => {
+    const { content, board } = createContentAndBoard();
+    const created = seedShapeForMode(board, content, "line");
+    const points = created.filter(isPoint);
+    const lines = created.filter(isInfiniteLine);
+
+    expect(points).toHaveLength(2);
+    expect(lines).toHaveLength(1);
+    const coords = points.map(pointCoords).sort();
+    expect(coords).toEqual([[1, 1], [2, 1]]);
+    cleanup(content, board);
+  });
+});
+
+describe("seedShapeForMode — unknown / unhandled modes", () => {
+  it("returns an empty list and creates no objects for an unhandled mode", () => {
+    const { content, board } = createContentAndBoard();
+    const initialSize = content.objects.size;
+    const created = seedShapeForMode(board, content, "unhandledmode" as any);
+    expect(created).toEqual([]);
+    expect(content.objects.size).toBe(initialSize);
+    cleanup(content, board);
+  });
+});

--- a/src/components/tiles/geometry/geometry-keyboard-create.ts
+++ b/src/components/tiles/geometry/geometry-keyboard-create.ts
@@ -1,0 +1,61 @@
+import { GeometryContentModelType } from "../../../models/tiles/geometry/geometry-content";
+import { GeometryTileMode } from "./geometry-types";
+
+/**
+ * Seeds a unit-sized shape at user-coords (1, 1) for keyboard activation of a
+ * toolbar mode button — replays the same `addPhantomPoint` + `realizePhantomPoint`
+ * sequence the click handler uses. Returns the JXG elements created so the caller
+ * can pass them to handleCreateElements for aria decoration.
+ */
+export function seedShapeForMode(
+  board: JXG.Board,
+  content: GeometryContentModelType,
+  mode: GeometryTileMode,
+): JXG.GeometryElement[] {
+  const created: JXG.GeometryElement[] = [];
+
+  if (mode === "select" || mode === "points") {
+    content.addPhantomPoint(board, [1, 1]);
+    const { point } = content.realizePhantomPoint(board, [1, 1], "select");
+    if (point) created.push(point);
+    content.clearPhantomPoint(board);
+    return created;
+  }
+
+  if (mode === "polygon") {
+    content.addPhantomPoint(board, [1, 1]);
+    const r1 = content.realizePhantomPoint(board, [1, 1], "polygon");
+    const r2 = content.realizePhantomPoint(board, [2, 1], "polygon");
+    const r3 = content.realizePhantomPoint(board, [2, 2], "polygon");
+    const r4 = content.realizePhantomPoint(board, [1, 2], "polygon");
+    if (r1.polygon) created.push(r1.polygon);
+    [r1.point, r2.point, r3.point, r4.point].forEach(p => { if (p) created.push(p); });
+    if (r1.point) content.closeActivePolygon(board, r1.point);
+    content.clearPhantomPoint(board);
+    content.clearActivePolygon(board);
+    return created;
+  }
+
+  if (mode === "circle") {
+    content.addPhantomPoint(board, [1, 1]);
+    const r1 = content.realizePhantomPoint(board, [1, 1], "circle");
+    const r2 = content.realizePhantomPoint(board, [2, 1], "circle");
+    if (r1.circle) created.push(r1.circle);
+    [r1.point, r2.point].forEach(p => { if (p) created.push(p); });
+    content.clearPhantomPoint(board);
+    return created;
+  }
+
+  if (mode === "line") {
+    content.addPhantomPoint(board, [1, 1]);
+    const r1 = content.realizePhantomPoint(board, [1, 1], "line");
+    const r2 = content.realizePhantomPoint(board, [2, 1], "line");
+    if (r1.line) created.push(r1.line);
+    [r1.point, r2.point].forEach(p => { if (p) created.push(p); });
+    content.clearPhantomPoint(board);
+    content.clearActiveLine(board);
+    return created;
+  }
+
+  return created;
+}

--- a/src/components/tiles/geometry/geometry-keyboard-create.ts
+++ b/src/components/tiles/geometry/geometry-keyboard-create.ts
@@ -14,7 +14,9 @@ export function seedShapeForMode(
 ): JXG.GeometryElement[] {
   const created: JXG.GeometryElement[] = [];
 
-  if (mode === "select" || mode === "points") {
+  if (mode === "select") return created;
+
+  if (mode === "points") {
     content.addPhantomPoint(board, [1, 1]);
     const { point } = content.realizePhantomPoint(board, [1, 1], "select");
     if (point) created.push(point);

--- a/src/components/tiles/geometry/geometry-keyboard-selection.test.ts
+++ b/src/components/tiles/geometry/geometry-keyboard-selection.test.ts
@@ -1,0 +1,179 @@
+import { destroy } from "mobx-state-tree";
+import {
+  defaultGeometryContent, GeometryContentModelType, GeometryMetadataModel,
+} from "../../../models/tiles/geometry/geometry-content";
+import { applyA11yAttributes } from "./geometry-aria-utils";
+import { selectFocusedGeometryObject } from "./geometry-keyboard-selection";
+
+// Logger / DOM scaffold mirroring geometry-apply-a11y.test.ts.
+jest.mock("../../../models/tiles/log/log-tile-change-event", () => ({
+  logTileChangeEvent: () => undefined,
+}));
+
+// eslint-disable-next-line no-console
+const origConsoleLog = console.log;
+let consoleSpy: jest.SpyInstance;
+beforeAll(() => {
+  consoleSpy = jest.spyOn(console, "log").mockImplementation((...args: any[]) => {
+    if (!args.some(arg => typeof arg === "string" && arg.includes("IntersectionObserver not available"))) {
+      origConsoleLog(...args);
+    }
+  });
+});
+afterAll(() => consoleSpy.mockRestore());
+
+const divId = "keyboardSelectionBoard";
+document.body.innerHTML = `<div id="${divId}" style="width:200px;height:200px"></div>`;
+
+function createContentAndBoard(): { content: GeometryContentModelType, board: JXG.Board } {
+  const content = defaultGeometryContent();
+  const metadata = GeometryMetadataModel.create({ id: "geometry-1" });
+  content.doPostCreate!(metadata);
+  const board = content.initializeBoard(divId, false, () => {/* noop */}, () => {/* noop */}) as JXG.Board;
+  content.resizeBoard(board, 200, 200);
+  return { content, board };
+}
+
+function cleanup(content: GeometryContentModelType, board: JXG.Board) {
+  content.destroyBoard(board);
+  destroy(content);
+}
+
+function focus(elt: HTMLElement | SVGElement) {
+  // jsdom honors .focus() on elements with tabindex; applyA11yAttributes sets tabindex=0.
+  (elt as HTMLElement).focus();
+}
+
+describe("selectFocusedGeometryObject — bails", () => {
+  it("returns false when nothing in the document is focused", () => {
+    const { content, board } = createContentAndBoard();
+    (document.activeElement as HTMLElement | null)?.blur();
+    expect(selectFocusedGeometryObject(board, content, { extend: false })).toBe(false);
+    cleanup(content, board);
+  });
+
+  it("returns false when the focused element has no data-object-id", () => {
+    const { content, board } = createContentAndBoard();
+    const stray = document.createElement("button");
+    stray.tabIndex = 0;
+    document.body.appendChild(stray);
+    focus(stray);
+    expect(selectFocusedGeometryObject(board, content, { extend: false })).toBe(false);
+    stray.remove();
+    cleanup(content, board);
+  });
+});
+
+describe("selectFocusedGeometryObject — free point", () => {
+  it("selects the focused point and returns true on first activation", () => {
+    const { content, board } = createContentAndBoard();
+    const point = content.addPoint(board, [3, 4])! as JXG.Point;
+    applyA11yAttributes(point, content);
+    focus(point.rendNode);
+
+    const consumed = selectFocusedGeometryObject(board, content, { extend: false });
+
+    expect(consumed).toBe(true);
+    expect(content.isSelected(point.id)).toBe(true);
+    cleanup(content, board);
+  });
+
+  it("deselects the focused point on second activation (toggle off)", () => {
+    const { content, board } = createContentAndBoard();
+    const point = content.addPoint(board, [3, 4])! as JXG.Point;
+    applyA11yAttributes(point, content);
+    content.selectElement(board, point.id);
+    focus(point.rendNode);
+
+    selectFocusedGeometryObject(board, content, { extend: false });
+
+    expect(content.isSelected(point.id)).toBe(false);
+    cleanup(content, board);
+  });
+
+  it("replaces the existing selection when activating a different point (extend=false)", () => {
+    const { content, board } = createContentAndBoard();
+    const pointA = content.addPoint(board, [1, 1])! as JXG.Point;
+    const pointB = content.addPoint(board, [2, 2])! as JXG.Point;
+    applyA11yAttributes(pointA, content);
+    applyA11yAttributes(pointB, content);
+    content.selectElement(board, pointA.id);
+    focus(pointB.rendNode);
+
+    selectFocusedGeometryObject(board, content, { extend: false });
+
+    expect(content.isSelected(pointA.id)).toBe(false);
+    expect(content.isSelected(pointB.id)).toBe(true);
+    cleanup(content, board);
+  });
+
+  it("extends the selection (Shift) without deselecting the existing point", () => {
+    const { content, board } = createContentAndBoard();
+    const pointA = content.addPoint(board, [1, 1])! as JXG.Point;
+    const pointB = content.addPoint(board, [2, 2])! as JXG.Point;
+    applyA11yAttributes(pointA, content);
+    applyA11yAttributes(pointB, content);
+    content.selectElement(board, pointA.id);
+    focus(pointB.rendNode);
+
+    selectFocusedGeometryObject(board, content, { extend: true });
+
+    expect(content.isSelected(pointA.id)).toBe(true);
+    expect(content.isSelected(pointB.id)).toBe(true);
+    cleanup(content, board);
+  });
+
+  it("no-ops when readOnly is true", () => {
+    const { content, board } = createContentAndBoard();
+    const point = content.addPoint(board, [3, 4])! as JXG.Point;
+    applyA11yAttributes(point, content);
+    focus(point.rendNode);
+
+    const consumed = selectFocusedGeometryObject(board, content, { extend: false, readOnly: true });
+
+    expect(consumed).toBe(false);
+    expect(content.isSelected(point.id)).toBe(false);
+    cleanup(content, board);
+  });
+});
+
+describe("selectFocusedGeometryObject — polygon (compound shape)", () => {
+  it("selects the polygon AND all its defining points so arrow-nudge moves the whole shape", () => {
+    const { content, board } = createContentAndBoard();
+    content.addPhantomPoint(board, [0, 0]);
+    const { point: p1 } = content.realizePhantomPoint(board, [1, 1], "polygon");
+    const { point: p2 } = content.realizePhantomPoint(board, [2, 1], "polygon");
+    const { point: p3 } = content.realizePhantomPoint(board, [2, 2], "polygon");
+    const polygon = content.closeActivePolygon(board, p1!) as JXG.Polygon;
+    applyA11yAttributes(polygon, content);
+    focus(polygon.rendNode);
+
+    selectFocusedGeometryObject(board, content, { extend: false });
+
+    expect(content.isSelected(polygon.id)).toBe(true);
+    expect(content.isSelected(p1!.id)).toBe(true);
+    expect(content.isSelected(p2!.id)).toBe(true);
+    expect(content.isSelected(p3!.id)).toBe(true);
+    cleanup(content, board);
+  });
+
+  it("deselects polygon + all its points when toggled off", () => {
+    const { content, board } = createContentAndBoard();
+    content.addPhantomPoint(board, [0, 0]);
+    const { point: p1 } = content.realizePhantomPoint(board, [1, 1], "polygon");
+    const { point: p2 } = content.realizePhantomPoint(board, [2, 1], "polygon");
+    const { point: p3 } = content.realizePhantomPoint(board, [2, 2], "polygon");
+    const polygon = content.closeActivePolygon(board, p1!) as JXG.Polygon;
+    applyA11yAttributes(polygon, content);
+    content.selectObjects(board, [polygon.id, p1!.id, p2!.id, p3!.id]);
+    focus(polygon.rendNode);
+
+    selectFocusedGeometryObject(board, content, { extend: false });
+
+    expect(content.isSelected(polygon.id)).toBe(false);
+    expect(content.isSelected(p1!.id)).toBe(false);
+    expect(content.isSelected(p2!.id)).toBe(false);
+    expect(content.isSelected(p3!.id)).toBe(false);
+    cleanup(content, board);
+  });
+});

--- a/src/components/tiles/geometry/geometry-keyboard-selection.ts
+++ b/src/components/tiles/geometry/geometry-keyboard-selection.ts
@@ -1,0 +1,57 @@
+import { GeometryContentModelType } from "../../../models/tiles/geometry/geometry-content";
+import {
+  isCircle, isInfiniteLine, isMovableLine, isPoint, isPolygon,
+} from "../../../models/tiles/geometry/jxg-types";
+
+export interface SelectFocusedOptions {
+  /** Shift+Return / Shift+Space — union the new selection onto the current one. */
+  extend: boolean;
+  /** Read-only tiles never mutate selection. */
+  readOnly?: boolean;
+}
+
+/**
+ * Toggles selection of the focused board object (identified by its
+ * data-object-id attribute). Compound shapes select alongside their defining
+ * points so arrow-key nudge (which acts on selected points) moves the shape.
+ * Returns false when there's no focused geometry object to act on.
+ */
+export function selectFocusedGeometryObject(
+  board: JXG.Board,
+  content: GeometryContentModelType,
+  options: SelectFocusedOptions,
+): boolean {
+  if (options.readOnly) return false;
+  const focused = document.activeElement as Element | null;
+  if (!focused) return false;
+  const objectId = focused.getAttribute("data-object-id");
+  if (!objectId) return false;
+  const elt = board.objects[objectId] as JXG.GeometryElement | undefined;
+  if (!elt) return false;
+
+  const ids = selectionIdsFor(elt);
+  if (options.extend) {
+    content.selectObjects(board, ids);
+  } else {
+    // Toggle: if any id is already selected, deselect the whole set; else replace.
+    const anyAlreadySelected = ids.some(id => content.isSelected(id));
+    if (anyAlreadySelected) {
+      content.deselectObjects(board, ids);
+    } else {
+      content.deselectAll(board);
+      content.selectObjects(board, ids);
+    }
+  }
+  return true;
+}
+
+/** Mirrors mouse handlers' ancestors-based selection so keyboard and mouse share semantics. */
+function selectionIdsFor(elt: JXG.GeometryElement): string[] {
+  if (isPolygon(elt) || isCircle(elt) || isInfiniteLine(elt) || isMovableLine(elt)) {
+    const ancestorPointIds = Object.values(elt.ancestors)
+      .filter(isPoint)
+      .map(obj => obj.id);
+    return [...ancestorPointIds, elt.id];
+  }
+  return [elt.id];
+}

--- a/src/components/tiles/geometry/geometry-shared.tsx
+++ b/src/components/tiles/geometry/geometry-shared.tsx
@@ -1,5 +1,6 @@
 import { ITileProps } from "../tile-component";
 import { HotKeyHandler } from "../../../utilities/hot-keys";
+import { GeometryTileMode } from "./geometry-types";
 
 export interface IToolbarActionHandlers {
   handleDuplicate: () => void;
@@ -14,6 +15,8 @@ export interface IToolbarActionHandlers {
   handleFitAll: () => void;
   handleSetShowColorPalette: (showColorPalette: boolean) => void;
   handleColorChange: (color: number) => void;
+  /** Keyboard/SR activation of a mode button seeds a unit-sized shape at (1, 1). */
+  handleSeedShape: (mode: GeometryTileMode) => void;
 }
 export interface IActionHandlers extends IToolbarActionHandlers {
   handleArrows: HotKeyHandler;

--- a/src/components/tiles/geometry/geometry-tile-accessibility.test.tsx
+++ b/src/components/tiles/geometry/geometry-tile-accessibility.test.tsx
@@ -1,0 +1,123 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { Provider } from "mobx-react";
+import { ModalProvider } from "react-modal-hook";
+
+import GeometryToolComponent from "./geometry-tile";
+import { ITileApi, TileModelContext } from "../tile-api";
+import { TileModel } from "../../../models/tiles/tile-model";
+import { specStores } from "../../../models/stores/spec-stores";
+import { defaultGeometryContent } from "../../../models/tiles/geometry/geometry-content";
+
+import "../../../models/tiles/geometry/geometry-registration";
+
+// GeometryContentWrapper renders the real JSXGraph board on mount and pulls in
+// many heavy dependencies we don't need to exercise here. Stub it so the
+// accessibility-focused tests stay fast and deterministic.
+jest.mock("./geometry-content-wrapper", () => ({
+  GeometryContentWrapper: () => <div data-testid="geometry-content-stub" />,
+}));
+
+// TileToolbar registers floating portals we don't need for these tests; stub it.
+jest.mock("../../toolbar/tile-toolbar", () => ({
+  TileToolbar: () => <div data-testid="tile-toolbar-stub" />,
+}));
+
+// TileNavigator pulls in the bar-graph/graph navigator chain; not needed here.
+jest.mock("../tile-navigator", () => ({
+  TileNavigator: () => null,
+}));
+
+function renderGeometryTile(overrides: Partial<React.ComponentProps<typeof GeometryToolComponent>> = {}) {
+  const stores = specStores();
+  const content = defaultGeometryContent();
+  const model = TileModel.create({ content });
+  const onRegisterTileApi = jest.fn();
+  const onUnregisterTileApi = jest.fn();
+
+  const defaultProps = {
+    model,
+    tileElt: null,
+    context: "",
+    docId: "",
+    documentContent: null as any as HTMLElement,
+    isUserResizable: true,
+    navigatorAllowed: false,
+    readOnly: false,
+    onResizeRow: jest.fn(),
+    onSetCanAcceptDrop: jest.fn(),
+    onRequestRowHeight: jest.fn(),
+    onRegisterTileApi,
+    onUnregisterTileApi,
+  };
+
+  const utils = render(
+    <ModalProvider>
+      <Provider stores={stores}>
+        <TileModelContext.Provider value={model}>
+          <GeometryToolComponent {...defaultProps} {...overrides} />
+        </TileModelContext.Provider>
+      </Provider>
+    </ModalProvider>
+  );
+
+  return { ...utils, onRegisterTileApi, onUnregisterTileApi, model };
+}
+
+describe("GeometryToolComponent — accessibility scaffolding", () => {
+  it("renders an aria-live announcer with data-grid-announcer as a child of the .geometry-tool wrapper", () => {
+    const { container } = renderGeometryTile();
+    const wrapper = container.querySelector(".geometry-tool");
+    expect(wrapper).not.toBeNull();
+    const announcer = wrapper?.querySelector(":scope > [data-grid-announcer]");
+    expect(announcer).not.toBeNull();
+    expect(announcer?.getAttribute("aria-live")).toBe("polite");
+    expect(announcer?.classList.contains("visually-hidden")).toBe(true);
+  });
+
+  it("registers a tile API with getFocusableElements (focus-trap wired)", () => {
+    const { onRegisterTileApi } = renderGeometryTile();
+    expect(onRegisterTileApi).toHaveBeenCalled();
+    const registeredApi: ITileApi = onRegisterTileApi.mock.calls[0][0];
+    expect(registeredApi.getFocusableElements).toBeDefined();
+  });
+
+  it("getFocusableElements exposes title and content slot getters", () => {
+    const { onRegisterTileApi } = renderGeometryTile();
+    const registeredApi: ITileApi = onRegisterTileApi.mock.calls[0][0];
+    const elements = registeredApi.getFocusableElements?.();
+    expect(elements).toHaveProperty("titleElement");
+    expect(elements).toHaveProperty("contentElement");
+  });
+
+  it("registered tile API includes the annotation / export proxy methods", () => {
+    // Even though GeometryContentWrapper is mocked (so no real implementations
+    // are wired into the ref), the proxy still has to expose the key set —
+    // that's the contract the hook captures at mount.
+    const { onRegisterTileApi } = renderGeometryTile();
+    const registeredApi: ITileApi = onRegisterTileApi.mock.calls[0][0];
+    expect(registeredApi.exportContentAsTileJson).toBeInstanceOf(Function);
+    expect(registeredApi.getObjectBoundingBox).toBeInstanceOf(Function);
+    expect(registeredApi.getObjectButtonSVG).toBeInstanceOf(Function);
+    expect(registeredApi.isLinked).toBeInstanceOf(Function);
+    expect(registeredApi.getLinkedTiles).toBeInstanceOf(Function);
+  });
+
+  it("does not register a focus trap in read-only mode (no getFocusableElements)", () => {
+    const { onRegisterTileApi } = renderGeometryTile({ readOnly: true });
+    expect(onRegisterTileApi).toHaveBeenCalled();
+    const registeredApi: ITileApi = onRegisterTileApi.mock.calls[0][0];
+    expect(registeredApi.getFocusableElements).toBeUndefined();
+    // Annotation/export API still present so sparrows and export keep working.
+    expect(registeredApi.exportContentAsTileJson).toBeInstanceOf(Function);
+    expect(registeredApi.getObjectBoundingBox).toBeInstanceOf(Function);
+  });
+
+  it("still renders the aria-live announcer in read-only mode (screen-reader focus narration)", () => {
+    const { container } = renderGeometryTile({ readOnly: true });
+    const wrapper = container.querySelector(".geometry-tool");
+    const announcer = wrapper?.querySelector(":scope > [data-grid-announcer]");
+    expect(announcer).not.toBeNull();
+    expect(announcer?.getAttribute("aria-live")).toBe("polite");
+  });
+});

--- a/src/components/tiles/geometry/geometry-tile.scss
+++ b/src/components/tiles/geometry/geometry-tile.scss
@@ -1,4 +1,5 @@
 @import "../../vars";
+@import "../../mixins";
 
 $toolbar-width: 44px;
 
@@ -38,6 +39,19 @@ $toolbar-width: 44px;
           &.selected {
             background-color: red;
           }
+        }
+
+        // Use `:focus` rather than `:focus-visible` — the latter doesn't match
+        // reliably on programmatically-focused SVG elements in Safari/WebKit.
+        // JSXGraph never focuses SVG nodes on click, so `:focus` is effectively
+        // a keyboard-focus ring here.
+        svg[role="group"]:focus {
+          outline: 2px solid $focus-ring-color;
+          outline-offset: -2px;
+        }
+        svg [tabindex="0"]:focus {
+          outline: 2px solid $focus-ring-color;
+          outline-offset: 2px;
         }
 
         svg {

--- a/src/components/tiles/geometry/geometry-tile.tsx
+++ b/src/components/tiles/geometry/geometry-tile.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import classNames from "classnames";
 import { observer } from "mobx-react";
 import { isEqual } from "lodash";
@@ -10,6 +10,7 @@ import { useTileSelectionPointerEvents } from "./use-tile-selection-pointer-even
 import { useUIStore } from "../../../hooks/use-stores";
 import { useCurrent } from "../../../hooks/use-current";
 import { useForceUpdate } from "../hooks/use-force-update";
+import { useClueAccessibility } from "../../../hooks/use-clue-accessibility";
 import { HotKeys } from "../../../utilities/hot-keys";
 import { TileToolbar } from "../../toolbar/tile-toolbar";
 import { IGeometryTileContext, GeometryTileContext } from "./geometry-tile-context";
@@ -19,13 +20,71 @@ import { TileNavigatorContext } from "../hooks/use-tile-navigator-context";
 import { TileNavigator } from "../tile-navigator";
 import { userSelectTile } from "../../../models/stores/ui";
 import { useContainerContext } from "../../document/container-context";
+import { getEditableTitleElement } from "../../../utilities/dom-utils";
+import { ITileApi } from "../tile-api";
+import { selectFocusedGeometryObject } from "./geometry-keyboard-selection";
+import {
+  announceGeometry, applyA11yAttributes, focusGeometryContentEntry, getOrderedGeometryFocusables,
+} from "./geometry-aria-utils";
 
 import "./geometry-toolbar-registration";
 
 import "./geometry-tile.scss";
 
+/**
+ * Tab handler for the content slot that walks the semantic order from
+ * getOrderedGeometryFocusables instead of DOM order (which JSXGraph paints as
+ * "every shape, then every point"). Returns "exit" at the slot boundaries.
+ */
+function handleContentTab(
+  e: KeyboardEvent,
+  reverse: boolean,
+  tileElt: HTMLElement | null | undefined,
+  board: JXG.Board | undefined,
+): "handled" | "exit" {
+  if (!board || !tileElt) return "exit";
+  const active = document.activeElement;
+  if (!active) return "exit";
+
+  const svg = tileElt.querySelector<SVGElement>(".geometry-content svg");
+  const ordered = getOrderedGeometryFocusables(board);
+
+  if (svg && active === svg) {
+    if (reverse) return "exit";
+    if (ordered.length === 0) return "exit";
+    e.preventDefault();
+    ordered[0].focus();
+    return "handled";
+  }
+
+  const idx = ordered.indexOf(active as HTMLElement);
+  if (idx < 0) return "exit";
+
+  if (reverse) {
+    if (idx === 0) {
+      // Step back to the SVG board (carries the dynamic summary aria-label).
+      if (svg) {
+        e.preventDefault();
+        (svg as unknown as HTMLElement).focus();
+        return "handled";
+      }
+      return "exit";
+    }
+    e.preventDefault();
+    ordered[idx - 1].focus();
+    return "handled";
+  }
+
+  if (idx === ordered.length - 1) return "exit";
+  e.preventDefault();
+  ordered[idx + 1].focus();
+  return "handled";
+}
+
 const GeometryToolComponent: React.FC<IGeometryProps> = observer(function _GeometryToolComponent(props) {
-  const { model, readOnly, navigatorAllowed = true, hovered, ...others } = props;
+  const {
+    model, readOnly, navigatorAllowed = true, hovered, onRegisterTileApi, onUnregisterTileApi, ...others
+  } = props;
   const { tileElt } = others;
   const modelRef = useCurrent(model);
   const containerContext = useContainerContext();
@@ -39,6 +98,97 @@ const GeometryToolComponent: React.FC<IGeometryProps> = observer(function _Geome
   const [mode, setMode] = useState<GeometryTileMode>("select");
   const hotKeys = useRef(new HotKeys());
   const forceUpdate = useForceUpdate();
+
+  // HotKeys handlers are registered once at mount, before `board` state is set;
+  // read the latest via this ref at dispatch time.
+  const boardRef = useRef<JXG.Board>();
+  boardRef.current = board;
+
+  // tileAdditionalApi below must be a stable reference per mount — a fresh
+  // object each render would re-register the tile API and clobber the focus
+  // trap. The proxy delegates here so the impl can update without re-registering.
+  const apiImplRef = useRef<Partial<ITileApi>>({});
+  const handleSetAdditionalApi = useCallback((api: Partial<ITileApi>) => {
+    apiImplRef.current = api;
+  }, []);
+
+  const tileAdditionalApi = useMemo<Partial<ITileApi>>(() => ({
+    isLinked: () => apiImplRef.current.isLinked?.() ?? false,
+    getLinkedTiles: () => apiImplRef.current.getLinkedTiles?.(),
+    exportContentAsTileJson: (opts) => apiImplRef.current.exportContentAsTileJson?.(opts) ?? "",
+    getObjectBoundingBox: (id, type) => apiImplRef.current.getObjectBoundingBox?.(id, type),
+    getObjectButtonSVG: (args) => apiImplRef.current.getObjectButtonSVG?.(args),
+  }), []);
+
+  useClueAccessibility(readOnly ? { type: "region" } : {
+    type: "tile",
+    focusTrap: {
+      tileType: "geometry",
+      onRegisterTileApi,
+      onUnregisterTileApi,
+      getTitleElement: () => getEditableTitleElement(tileElt ?? undefined),
+      getContentElement: () => tileElt?.querySelector<HTMLElement>(".geometry-content") ?? undefined,
+      focusContent: ({ entryMode }) => focusGeometryContentEntry(
+        tileElt?.querySelector<HTMLElement>(".geometry-content") ?? undefined,
+        entryMode === "reverse",
+        boardRef.current,
+        content,
+      ),
+      additionalApi: tileAdditionalApi,
+      escapeHandlers: {
+        // Intercept Escape while the Color palette is open so it closes the
+        // palette and refocuses the Color button instead of exiting the trap.
+        // stopPropagation here kills both the toolbar's capture listener and
+        // the palette's React bubble listener — so we close + refocus inline.
+        toolbar: (e) => {
+          if (!content.showColorPalette) return "exit";
+          e.stopPropagation();
+          e.preventDefault();
+          const active = document.activeElement;
+          const button =
+            (active?.closest?.("button.toolbar-button.color") as HTMLButtonElement | null) ?? null;
+          content.setShowColorPalette(false);
+          button?.focus();
+          return "handled";
+        },
+        // While the title input is focused, let EditableTileTitle's bubble-phase
+        // onKeyDown cancel the edit instead of exiting the whole tile's trap.
+        title: () => {
+          const active = document.activeElement;
+          if (active?.tagName === "INPUT" && active.closest(".editable-tile-title")) {
+            return "handled";
+          }
+          return "exit";
+        },
+      },
+      tabHandlers: {
+        content: (e, reverse) => handleContentTab(e, reverse, tileElt, boardRef.current),
+      },
+    },
+  });
+
+  // Read-only path: register the annotation/export API directly — the
+  // type:"region" branch above doesn't touch the tile API.
+  useEffect(() => {
+    if (readOnly) {
+      onRegisterTileApi?.(tileAdditionalApi);
+      return () => onUnregisterTileApi?.();
+    }
+  }, [readOnly, tileAdditionalApi, onRegisterTileApi, onUnregisterTileApi]);
+
+  // HotKeys (Arrow nudge / Delete / Cut / Copy / Paste) attach at tileElt
+  // because the focus-trap wrapper isn't a tab stop. Gate on selection.
+  useEffect(() => {
+    if (!tileElt || readOnly) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (!ui.isSelectedTile(modelRef.current)) return;
+      // HotKeys.dispatch is typed for React.KeyboardEvent but only reads
+      // modifier flags / keyCode / preventDefault — all present on native.
+      hotKeys.current.dispatch(e as unknown as React.KeyboardEvent);
+    };
+    tileElt.addEventListener("keydown", handleKeyDown);
+    return () => tileElt.removeEventListener("keydown", handleKeyDown);
+  }, [tileElt, readOnly, ui, modelRef]);
 
   const [mainTileBoundingBox, setMainTileBoundingBox] = useState<BoundingBox|undefined>(undefined);
 
@@ -68,6 +218,25 @@ const GeometryToolComponent: React.FC<IGeometryProps> = observer(function _Geome
   };
 
   const handleSetHandlers = (handlers: IActionHandlers) => {
+    const handleSelectFocused = (extend: boolean) => () => {
+      const currentBoard = boardRef.current;
+      if (!currentBoard) return false;
+      const handled = selectFocusedGeometryObject(currentBoard, content, { extend, readOnly });
+      if (handled) {
+        const focused = document.activeElement as HTMLElement | null;
+        const focusedId = focused?.getAttribute("data-object-id");
+        const elt = focusedId ? currentBoard.objects[focusedId] : undefined;
+        if (focused && elt) {
+          // Sync-refresh aria on the focused element so the announce below
+          // reads fresh values; the board-wide refresh is rAF-coalesced.
+          applyA11yAttributes(elt as JXG.GeometryElement, content, { readOnly });
+          const isSelected = focused.getAttribute("aria-pressed") === "true";
+          const label = focused.getAttribute("aria-label") ?? "";
+          announceGeometry(focused, isSelected ? label : `${label}, Deselected`);
+        }
+      }
+      return handled;
+    };
     hotKeys.current.register({
       "left": handlers.handleArrows,
       "up": handlers.handleArrows,
@@ -78,6 +247,10 @@ const GeometryToolComponent: React.FC<IGeometryProps> = observer(function _Geome
       "cmd-c": handlers.handleCopy,
       "cmd-x": handlers.handleCut,
       "cmd-v": handlers.handlePaste,
+      "return": handleSelectFocused(false),
+      "shift-return": handleSelectFocused(true),
+      "space": handleSelectFocused(false),
+      "shift-space": handleSelectFocused(true),
     });
     setActionHandlers(handlers);
   };
@@ -113,14 +286,23 @@ const GeometryToolComponent: React.FC<IGeometryProps> = observer(function _Geome
       <div
         className={classes}
         data-testid="geometry-tool"
-        ref={domElement} tabIndex={0}
+        ref={domElement}
         onPointerDownCapture={handlePointerDown}
         onPointerUpCapture={handlePointerUp}
         onMouseDownCapture={handlePointerDown}
-        onMouseUpCapture={handlePointerUp}
-        onKeyDown={e => hotKeys.current.dispatch(e)} >
+        onMouseUpCapture={handlePointerUp} >
+        {/* Aria-live region for selection announcements; reached via
+            closest('.geometry-tool') > [data-grid-announcer]. */}
+        <div
+          aria-live="polite"
+          aria-atomic="true"
+          className="visually-hidden"
+          data-grid-announcer=""
+        />
         <TileNavigatorContext.Provider value={{ reportVisibleBoundingBox: updateMainTileBoundingBox }}>
           <GeometryContentWrapper model={model} readOnly={readOnly} showAllContent={false} {...others}
+            onRegisterTileApi={onRegisterTileApi} onUnregisterTileApi={onUnregisterTileApi}
+            onSetAdditionalApi={handleSetAdditionalApi}
             onSetBoard={setBoard} onSetActionHandlers={handleSetHandlers}
             onContentChange={forceUpdate} />
         </TileNavigatorContext.Provider>

--- a/src/components/tiles/geometry/geometry-tile.tsx
+++ b/src/components/tiles/geometry/geometry-tile.tsx
@@ -145,8 +145,8 @@ const GeometryToolComponent: React.FC<IGeometryProps> = observer(function _Geome
           e.stopPropagation();
           e.preventDefault();
           const active = document.activeElement;
-          const button =
-            (active?.closest?.("button.toolbar-button.color") as HTMLButtonElement | null) ?? null;
+          const button = active?.closest?.(".geometry-toolbar")
+            ?.querySelector<HTMLButtonElement>("button.toolbar-button.color");
           content.setShowColorPalette(false);
           button?.focus();
           return "handled";

--- a/src/components/tiles/geometry/geometry-toolbar-registration.tsx
+++ b/src/components/tiles/geometry/geometry-toolbar-registration.tsx
@@ -40,9 +40,9 @@ function getColorClass (content: GeometryContentModelType | undefined) {
 function ModeButton({name, title, targetMode, Icon, colorClass}:
   { name: string, title: string, targetMode: GeometryTileMode,
     Icon: FunctionComponent<SVGProps<SVGSVGElement>>, colorClass?: string }) {
-  const { board, content, mode, setMode } = useGeometryTileContext();
+  const { board, content, handlers, mode, setMode } = useGeometryTileContext();
 
-  function onClick() {
+  function onClick(e: React.MouseEvent) {
     if (mode !== targetMode) {
       setMode(targetMode);
       if (board) {
@@ -50,6 +50,11 @@ function ModeButton({name, title, targetMode, Icon, colorClass}:
         content?.clearActivePolygon(board);
         content?.clearActiveLine(board);
       }
+    }
+    // detail===0 marks keyboard / SR activation (no pointer count). Mouse
+    // clicks (detail>=1) only flip mode; board clicks then place points.
+    if (e.detail === 0) {
+      handlers?.handleSeedShape(targetMode);
     }
   }
 
@@ -86,6 +91,13 @@ const ColorChangeButton = observer(function ColorChangeButton({name}: IToolbarBu
   const { content, handlers } = useGeometryTileContext();
   const colorClass = getColorClass(content);
 
+  // Escape inside the palette → close + refocus this trigger button.
+  const handleClose = () => {
+    const active = document.activeElement;
+    const button = active?.closest?.<HTMLButtonElement>("button.toolbar-button.color");
+    handlers?.handleSetShowColorPalette(false);
+    button?.focus();
+  };
 
   const handleClick = () => {
     handlers?.handleSetShowColorPalette(!content?.showColorPalette);
@@ -104,6 +116,7 @@ const ColorChangeButton = observer(function ColorChangeButton({name}: IToolbarBu
          <ColorPalette
           selectedColor={content?.selectedColor}
           onSelectColor={(color) => handlers?.handleColorChange(color)}
+          onClose={handleClose}
          />
         </div>
       }

--- a/src/components/tiles/geometry/geometry-toolbar-registration.tsx
+++ b/src/components/tiles/geometry/geometry-toolbar-registration.tsx
@@ -94,7 +94,8 @@ const ColorChangeButton = observer(function ColorChangeButton({name}: IToolbarBu
   // Escape inside the palette → close + refocus this trigger button.
   const handleClose = () => {
     const active = document.activeElement;
-    const button = active?.closest?.<HTMLButtonElement>("button.toolbar-button.color");
+    const button = active?.closest?.(".geometry-toolbar")
+      ?.querySelector<HTMLButtonElement>("button.toolbar-button.color");
     handlers?.handleSetShowColorPalette(false);
     button?.focus();
   };
@@ -103,23 +104,23 @@ const ColorChangeButton = observer(function ColorChangeButton({name}: IToolbarBu
     handlers?.handleSetShowColorPalette(!content?.showColorPalette);
   };
 
+  const palette = content?.showColorPalette
+    ? <ColorPalette
+        selectedColor={content?.selectedColor}
+        onSelectColor={(color) => handlers?.handleColorChange(color)}
+        onClose={handleClose}
+      />
+    : undefined;
+
   return (
     <TileToolbarButton
       name={name}
       title="Color"
       onClick={handleClick}
       colorClass={colorClass}
+      extraContent={palette}
     >
       <ShapesColorIcon/>
-      {content?.showColorPalette &&
-        <div>
-         <ColorPalette
-          selectedColor={content?.selectedColor}
-          onSelectColor={(color) => handlers?.handleColorChange(color)}
-          onClose={handleClose}
-         />
-        </div>
-      }
     </TileToolbarButton>
   );
 });

--- a/src/components/tiles/geometry/geometry-toolbar-registration.tsx
+++ b/src/components/tiles/geometry/geometry-toolbar-registration.tsx
@@ -104,10 +104,15 @@ const ColorChangeButton = observer(function ColorChangeButton({name}: IToolbarBu
     handlers?.handleSetShowColorPalette(!content?.showColorPalette);
   };
 
+  const handleSelectColor = (color: number) => {
+    handlers?.handleColorChange(color);
+    handlers?.handleSetShowColorPalette(false);
+  };
+
   const palette = content?.showColorPalette
     ? <ColorPalette
         selectedColor={content?.selectedColor}
-        onSelectColor={(color) => handlers?.handleColorChange(color)}
+        onSelectColor={handleSelectColor}
         onClose={handleClose}
       />
     : undefined;

--- a/src/components/tiles/tile-api.tsx
+++ b/src/components/tiles/tile-api.tsx
@@ -1,7 +1,8 @@
 import { createContext, ReactElement } from "react";
 import { action, makeObservable, observable } from "mobx";
 import { Optional } from "utility-types";
-import type { EscapeHandlerResult, FocusContentContext } from "@concord-consortium/accessibility-tools/hooks";
+import type { EscapeHandlerResult, FocusContentContext, TabHandlerResult }
+  from "@concord-consortium/accessibility-tools/hooks";
 import { IOffsetModel, ObjectBoundingBox } from "../../models/annotations/clue-object";
 import { ITileExportOptions } from "../../models/tiles/tile-content-info";
 import { ITileModel } from "../../models/tiles/tile-model";
@@ -33,17 +34,18 @@ export interface ITileFocusableElements {
   // as its own slot in the trap cycle, between content and the standard floating
   // toolbar, so its internal roving-tabindex is a single tab stop with arrow nav.
   paletteElement?: HTMLElement;
-  // Optional per-tile override for which slots have Tab routed within them.
-  // The outer FocusTrapController (in tile-component.tsx) reads this back from
-  // the tile's registered API and applies it to its own strategy, so the inner
-  // tile can opt slots into within-slot Tab routing (e.g. XY Plot opts palette in
-  // because its CLUE legend has many heterogeneous controls).
+  // Per-tile override for which slots route Tab within them. The outer
+  // FocusTrapController reads this and applies it to its strategy (e.g. XY
+  // Plot opts palette in because its legend has heterogeneous controls).
   tabWithinSlots?: string[];
-  // Optional per-slot Escape interceptors. Return "handled" to suppress the
-  // trap's default exit (e.g. when an inline editor is open and Escape should
-  // cancel the edit rather than exit the trap). Return "exit" or omit to let
-  // the trap exit normally.
+  // Per-slot Escape interceptors. Return "handled" to suppress the trap's
+  // exit (e.g. let an inline editor cancel instead). "exit" / omit → exit.
   escapeHandlers?: Record<string, (e: KeyboardEvent) => EscapeHandlerResult>;
+  // Per-slot Tab interceptors. Return "handled" if the handler moved focus
+  // (caller's responsibility to preventDefault); "exit" advances the slot.
+  // Any slot listed here owns its own tabindex — the trap won't touch its
+  // descendants' tabindex on mount.
+  tabHandlers?: Record<string, (e: KeyboardEvent, reverse: boolean) => TabHandlerResult>;
 }
 
 export interface ITileApi {

--- a/src/components/tiles/tile-component.tsx
+++ b/src/components/tiles/tile-component.tsx
@@ -11,7 +11,10 @@ import { ITileModel } from "../../models/tiles/tile-model";
 import { isQuestionModel } from "../../models/tiles/question/question-content";
 import { BaseComponent } from "../base";
 import PlaceholderTileComponent from "./placeholder/placeholder-tile";
-import { useKeyboardResize, FocusTrapController } from "@concord-consortium/accessibility-tools/hooks";
+import {
+  useKeyboardResize, FocusTrapController,
+  type EscapeHandlerResult, type TabHandlerResult,
+} from "@concord-consortium/accessibility-tools/hooks";
 import { kDefaultTileHeight } from "../constants";
 import {
   ITileApi, TileResizeEntry, TileApiInterfaceContext, TileModelContext, RegisterToolbarContext
@@ -522,7 +525,29 @@ class InternalTileComponent extends BaseComponent<IProps, IState> {
   // Builds a FocusTrapStrategy from the current tile's elements.
   private buildFocusTrapStrategy() {
     const { model } = this.props;
-    const tabWithinSlots = this.getFocusTrapElements().tabWithinSlots;
+    const trapElements = this.getFocusTrapElements();
+    const tabWithinSlots = trapElements.tabWithinSlots;
+    // Forward only the slot-handler keys the inner tile actually claims —
+    // any present tabHandlers entry tells the trap "this slot manages its own
+    // tabindex", which would silently break default within-slot Tab navigation
+    // for slots the tile didn't opt in to. Handlers resolve dynamically so the
+    // inner tile can update its map between strategy builds.
+    const escapeHandlers: Record<string, (e: KeyboardEvent) => EscapeHandlerResult> = {};
+    const tabHandlers: Record<string, (e: KeyboardEvent, reverse: boolean) => TabHandlerResult> = {};
+    const innerEscape = trapElements.escapeHandlers;
+    if (innerEscape) {
+      for (const slot of Object.keys(innerEscape)) {
+        escapeHandlers[slot] = (e) =>
+          this.getFocusTrapElements().escapeHandlers?.[slot]?.(e) ?? "exit";
+      }
+    }
+    const innerTab = trapElements.tabHandlers;
+    if (innerTab) {
+      for (const slot of Object.keys(innerTab)) {
+        tabHandlers[slot] = (e, reverse) =>
+          this.getFocusTrapElements().tabHandlers?.[slot]?.(e, reverse) ?? "exit";
+      }
+    }
     const strategy = createClueTileStrategy({
       onRegisterTileApi: () => {}, // Not used here — individual tiles handle registration
       onUnregisterTileApi: () => {},
@@ -536,11 +561,8 @@ class InternalTileComponent extends BaseComponent<IProps, IState> {
       focusContent: (context) => this.getFocusTrapElements().focusContent?.(context) ?? false,
       onTabWhenInactive: (e, reverse) => this.navigateToSiblingTile(e, reverse),
       tabWithinSlots,
-      // Dynamic forward: the inner tile may register/unregister content-slot
-      // Escape interceptors between strategy builds, so resolve at call time.
-      escapeHandlers: {
-        content: (e) => this.getFocusTrapElements().escapeHandlers?.content?.(e) ?? "exit",
-      },
+      escapeHandlers: Object.keys(escapeHandlers).length ? escapeHandlers : undefined,
+      tabHandlers: Object.keys(tabHandlers).length ? tabHandlers : undefined,
     });
     // Deselect the tile when the controller exits (Escape, setEnabled(false))
     strategy.onExit = () => {
@@ -596,6 +618,7 @@ class InternalTileComponent extends BaseComponent<IProps, IState> {
       paletteElement: focusable?.paletteElement || null,
       tabWithinSlots: focusable?.tabWithinSlots,
       escapeHandlers: focusable?.escapeHandlers,
+      tabHandlers: focusable?.tabHandlers,
       resizeHandle: this.resizeElement,
     };
   }

--- a/src/hooks/create-clue-tile-strategy.ts
+++ b/src/hooks/create-clue-tile-strategy.ts
@@ -1,5 +1,6 @@
 import { FocusTrapStrategy } from "@concord-consortium/accessibility-tools/hooks";
 import { getAriaLabels } from "./use-aria-labels";
+import { getTileContentInfo } from "../models/tiles/tile-content-info";
 import type { ClueFocusTrapConfig } from "./use-clue-accessibility";
 
 /**
@@ -24,6 +25,9 @@ export function createClueTileStrategy(config: ClueFocusTrapConfig): FocusTrapSt
     ?? (() => config.resizeRef?.current ?? undefined);
 
   const ariaLabels = getAriaLabels();
+  // Prefer the user-facing displayName ("Coordinate Grid" for `geometry`); the
+  // fallback covers unit tests that pass synthetic tile-type strings.
+  const announceName = getTileContentInfo(config.tileType)?.displayName ?? config.tileType;
 
   return {
     getElements: () => ({
@@ -35,25 +39,23 @@ export function createClueTileStrategy(config: ClueFocusTrapConfig): FocusTrapSt
       resize: getResize(),
     }),
     focusContent: config.focusContent,
-    // topbar sits between title and content — for tiles that have a secondary
-    // controls strip above the editor (e.g. dataflow). palette sits between
-    // content and toolbar so an inline secondary toolbar is a single tab stop
-    // with internal arrow nav. findNextSlot skips slots whose elements are
-    // undefined, so tiles that don't provide topbar/palette are unaffected.
+    // topbar: optional controls strip above the editor (e.g. dataflow).
+    // palette: inline secondary toolbar — single tab stop with arrow roving.
+    // Slots with undefined elements are skipped, so tiles without
+    // topbar/palette are unaffected.
     cycleOrder: ["title", "topbar", "content", "palette", "toolbar", "resize"],
-    // Default `tabWithinSlots`: topbar + content. Tiles that want Tab to walk
-    // through each focusable inside their palette (e.g. the XY Plot's legend,
-    // with many native controls) can opt palette in via the config. Tiles that
-    // treat palette as a single tab stop with arrow-roving inside (e.g.
-    // dataflow's Add-block panel) leave it out — the default keeps that working.
+    // Default within-slot Tab routing covers topbar + content. Tiles can opt
+    // palette in via config when its controls are heterogeneous (XY Plot's
+    // legend), or leave it out for arrow-roved palettes (dataflow's Add-block).
     tabWithinSlots: config.tabWithinSlots ?? ["topbar", "content"],
-    announceEnter: ariaLabels.announce.editingTile(config.tileType),
-    announceExit: ariaLabels.announce.exitedTile(config.tileType),
+    announceEnter: ariaLabels.announce.editingTile(announceName),
+    announceExit: ariaLabels.announce.exitedTile(announceName),
     getExternalElements: () => {
       const toolbar = getToolbar();
       return toolbar ? [toolbar] : [];
     },
     onTabWhenInactive: config.onTabWhenInactive,
     escapeHandlers: config.escapeHandlers,
+    tabHandlers: config.tabHandlers,
   };
 }

--- a/src/hooks/use-clue-accessibility.test.tsx
+++ b/src/hooks/use-clue-accessibility.test.tsx
@@ -3,11 +3,23 @@ import React from "react";
 import { ITileApi } from "../components/tiles/tile-api";
 import { ClueTileAccessibilityBridge, useClueAccessibility } from "./use-clue-accessibility";
 import { createClueTileStrategy } from "./create-clue-tile-strategy";
+import { registerTileContentInfo } from "../models/tiles/tile-content-info";
+import { TileContentModel } from "../models/tiles/tile-content";
 
 // Mock useAccessibility to avoid pulling in the full package in unit tests
 jest.mock("@concord-consortium/accessibility-tools/hooks", () => ({
   useAccessibility: () => ({ navigation: null, resizable: null, debug: null }),
 }));
+
+// Register a fake tile type with a displayName so we can verify the strategy
+// resolves the announcement text to a user-facing label rather than the raw
+// internal tile-type id.
+registerTileContentInfo({
+  type: "fake-test-tile-with-display-name",
+  displayName: "Fake Display Name",
+  modelClass: TileContentModel,
+  defaultContent: () => TileContentModel.create({ type: "fake-test-tile-with-display-name" }),
+});
 
 describe("createClueTileStrategy", () => {
   it("uses getter functions when provided", () => {
@@ -62,15 +74,30 @@ describe("createClueTileStrategy", () => {
       ["title", "topbar", "content", "palette", "toolbar", "resize"]);
   });
 
-  it("sets announcement text from tile type", () => {
+  it("falls back to the tile type id in announcements when no displayName is registered", () => {
     const strategy = createClueTileStrategy({
       onRegisterTileApi: jest.fn(),
       onUnregisterTileApi: jest.fn(),
-      tileType: "bar-graph",
+      tileType: "unregistered-fake-tile-type",
     });
 
-    expect(strategy.announceEnter).toContain("bar-graph");
-    expect(strategy.announceExit).toContain("bar-graph");
+    expect(strategy.announceEnter).toBe(
+      "Editing unregistered-fake-tile-type tile. Press Escape to exit.");
+    expect(strategy.announceExit).toBe(
+      "Exited unregistered-fake-tile-type tile. Use arrow keys to navigate.");
+  });
+
+  it("uses the tile registry displayName in announcements when available", () => {
+    const strategy = createClueTileStrategy({
+      onRegisterTileApi: jest.fn(),
+      onUnregisterTileApi: jest.fn(),
+      tileType: "fake-test-tile-with-display-name",
+    });
+
+    expect(strategy.announceEnter).toBe(
+      "Editing Fake Display Name tile. Press Escape to exit.");
+    expect(strategy.announceExit).toBe(
+      "Exited Fake Display Name tile. Use arrow keys to navigate.");
   });
 
   it("passes through focusContent", () => {

--- a/src/hooks/use-clue-accessibility.ts
+++ b/src/hooks/use-clue-accessibility.ts
@@ -6,6 +6,7 @@ import {
   FocusContentContext,
   NavigationConfig,
   ResizableConfig,
+  TabHandlerResult,
   useAccessibility,
 } from "@concord-consortium/accessibility-tools/hooks";
 import { ITileApi } from "../components/tiles/tile-api";
@@ -59,20 +60,25 @@ export interface ClueFocusTrapConfig {
   onTabWhenInactive?: (e: KeyboardEvent, reverse: boolean) => boolean;
 
   /**
-   * Optional override for which slot names should have Tab routed within the
-   * slot (vs treating the whole slot as a single Tab stop). The default in
-   * `createClueTileStrategy` is `["topbar", "content"]`. Tiles whose palette
-   * contains heterogeneous native focusables (e.g. XY Plot's legend) can opt
-   * the palette in with `["topbar", "content", "palette"]`.
+   * Override for which slots route Tab within them vs treating the whole slot
+   * as one stop. Default: `["topbar", "content"]`. Tiles with heterogeneous
+   * palette focusables (XY Plot's legend) opt the palette in.
    */
   tabWithinSlots?: string[];
 
   /**
-   * Optional per-slot Escape interceptors. Return "handled" to suppress the
-   * trap's default exit (the React keydown handler downstream gets to see the
-   * event during bubble); return "exit" to let the trap exit normally.
+   * Per-slot Escape interceptors. "handled" suppresses the trap's exit (so a
+   * React keydown can still see the event on bubble); "exit" exits normally.
    */
   escapeHandlers?: Record<string, (e: KeyboardEvent) => EscapeHandlerResult>;
+
+  /**
+   * Per-slot Tab interceptors. "handled" — the handler moved focus and called
+   * preventDefault. "exit" — let the trap advance. Any listed slot is treated
+   * as managing its own tabindex (the trap's mount-time
+   * setChildrenNonTabbable skips its descendants).
+   */
+  tabHandlers?: Record<string, (e: KeyboardEvent, reverse: boolean) => TabHandlerResult>;
 }
 
 interface ClueTileOptions {
@@ -151,6 +157,7 @@ export function useClueAccessibility(options: ClueAccessibilityOptions): Accessi
         paletteElement: elements.palette,
         tabWithinSlots: strategy.tabWithinSlots,
         escapeHandlers: strategy.escapeHandlers,
+        tabHandlers: strategy.tabHandlers,
       };
     };
 

--- a/src/plugins/graph/components/__tests__/attribute-label.test.tsx
+++ b/src/plugins/graph/components/__tests__/attribute-label.test.tsx
@@ -127,7 +127,7 @@ function renderAttributeLabel(opts: IRenderOptions = {}) {
   );
 }
 
-describe("AttributeLabel — keyboard behaviour (CLUE-502 Phase 2)", () => {
+describe("AttributeLabel — keyboard behaviour", () => {
   it("is rendered as a button with aria-label and tabIndex=0", () => {
     renderAttributeLabel({ xAttributeLabel: "Height" });
     const trigger = screen.getByRole("button", { name: /X-axis label: Height/ });

--- a/src/plugins/graph/components/__tests__/graph-toolbar.test.tsx
+++ b/src/plugins/graph/components/__tests__/graph-toolbar.test.tsx
@@ -58,7 +58,7 @@ const expectedLabels: Array<[string, string]> = [
   ["delete",             "Delete"],
 ];
 
-describe("Graph toolbar buttons — aria-label audit (CLUE-502 Phase 5)", () => {
+describe("Graph toolbar buttons — aria-label audit", () => {
   it.each(expectedLabels)("'%s' button exposes aria-label '%s'", (name, expected) => {
     renderToolbarButton(name);
     const button = screen.getByRole("button", { name: expected });
@@ -83,7 +83,7 @@ describe("Graph toolbar buttons — aria-label audit (CLUE-502 Phase 5)", () => 
 
 // --- aria-pressed on toggle-state buttons ---------------------------------------
 
-describe("Graph toolbar — aria-pressed on toggle buttons (CLUE-502 Phase 5)", () => {
+describe("Graph toolbar — aria-pressed on toggle buttons", () => {
   it("toggle-lock starts aria-pressed='false' and flips to 'true' after activation", () => {
     renderToolbarButton("toggle-lock");
     const button = document.querySelector("button.toolbar-button.toggle-lock") as HTMLButtonElement;
@@ -110,7 +110,7 @@ describe("Graph toolbar — aria-pressed on toggle buttons (CLUE-502 Phase 5)", 
 
 // --- aria-disabled (not HTML disabled) per memory rule --------------------------
 
-describe("Graph toolbar — disabled state uses aria-disabled (CLUE-502 Phase 5)", () => {
+describe("Graph toolbar — disabled state uses aria-disabled", () => {
   // The delete button is disabled when nothing is selected. A fresh graph
   // model has no selection, so it's a convenient default-disabled case.
   it("delete button uses aria-disabled='true' and remains focusable (no HTML disabled)", () => {

--- a/src/plugins/graph/components/__tests__/graph-wrapper-component.test.tsx
+++ b/src/plugins/graph/components/__tests__/graph-wrapper-component.test.tsx
@@ -51,7 +51,7 @@ function renderWrapper(overrides: Partial<React.ComponentProps<typeof GraphWrapp
   return { ...utils, onRegisterTileApi, onUnregisterTileApi, model };
 }
 
-describe("GraphWrapperComponent — focus trap wiring (CLUE-502 Phase 1)", () => {
+describe("GraphWrapperComponent — focus trap wiring", () => {
   it("registers a tile API with getFocusableElements", () => {
     const { onRegisterTileApi } = renderWrapper();
     expect(onRegisterTileApi).toHaveBeenCalled();

--- a/src/plugins/graph/components/__tests__/read-only-graph.test.tsx
+++ b/src/plugins/graph/components/__tests__/read-only-graph.test.tsx
@@ -51,7 +51,7 @@ function renderReadOnlyWrapper(overrides: Partial<React.ComponentProps<typeof Gr
   return { ...utils, onRegisterTileApi, onUnregisterTileApi, model };
 }
 
-describe("Read-only XY Plot — Phase 6 wiring (CLUE-502)", () => {
+describe("Read-only XY Plot — focus trap wiring", () => {
   it("does not register a focus trap when readOnly is true", () => {
     const { onRegisterTileApi } = renderReadOnlyWrapper();
     expect(onRegisterTileApi).toHaveBeenCalled();

--- a/src/plugins/graph/components/graph-wrapper-component.tsx
+++ b/src/plugins/graph/components/graph-wrapper-component.tsx
@@ -293,12 +293,10 @@ export const GraphWrapperComponent: React.FC<ITileProps> = observer(function(pro
     }
   }, [readOnly, tileAdditionalApi, onRegisterTileApi, onUnregisterTileApi]);
 
-  // Capture Delete / Backspace on the .tool-tile container. Previously the wrapper
-  // div had `tabIndex={0}` + inline `onKeyDown` to receive these keys, but the focus
-  // trap requires the wrapper not to be its own tab stop. The .tool-tile element is
-  // the focus-trap root, so attaching the listener there gives us the same coverage
-  // without adding a stray tab stop. Gated on selected + editable, mirroring the
-  // original behavior.
+  // Capture Delete / Backspace on the .tool-tile container. The focus trap
+  // requires the wrapper div not to be its own tab stop, so we attach the
+  // listener to the .tool-tile element (the focus-trap root) and gate it on
+  // selected + editable.
   useEffect(() => {
     if (!tileElt || readOnly) return;
     const handleKeyDown = (e: KeyboardEvent) => {

--- a/src/plugins/graph/components/legend/__tests__/legend-accessibility.test.tsx
+++ b/src/plugins/graph/components/legend/__tests__/legend-accessibility.test.tsx
@@ -11,7 +11,7 @@ import { ReadOnlyContext } from "../../../../../components/document/read-only-co
 
 // --- AddSeriesButton ------------------------------------------------------------
 
-describe("AddSeriesButton — aria contract (CLUE-502 Phase 4)", () => {
+describe("AddSeriesButton — aria contract", () => {
   function renderAddSeries(hasUnplottedAttribute: boolean) {
     const dataConfig = {
       dataset: hasUnplottedAttribute
@@ -52,7 +52,7 @@ describe("AddSeriesButton — aria contract (CLUE-502 Phase 4)", () => {
 
 // --- SimpleAttributeLabel (uses AxisOrLegendAttributeMenu target=null) ----------
 
-describe("SimpleAttributeLabel — legend-case aria-label (CLUE-502 Phase 4)", () => {
+describe("SimpleAttributeLabel — legend-case aria-label", () => {
   function renderSimpleAttributeLabel(attrName = "Height", readOnly = false) {
     const dataConfig = {
       dataset: {
@@ -112,7 +112,7 @@ describe("SimpleAttributeLabel — legend-case aria-label (CLUE-502 Phase 4)", (
 
 // --- LegendDropdown (color picker) ----------------------------------------------
 
-describe("LegendDropdown — aria contract (CLUE-502 Phase 4)", () => {
+describe("LegendDropdown — aria contract", () => {
   it("MenuButton exposes the buttonAriaLabel as its accessible name", () => {
     render(
       <ReadOnlyContext.Provider value={false}>

--- a/src/plugins/graph/hooks/__tests__/use-graph-dots-keyboard.test.tsx
+++ b/src/plugins/graph/hooks/__tests__/use-graph-dots-keyboard.test.tsx
@@ -56,7 +56,7 @@ describe("buildDotAriaLabel", () => {
     expect(buildDotAriaLabel(caseData, undefined)).toBe("Point");
   });
 
-  it("appends Color when a legend attribute is mapped (CLUE-502 Phase 7)", () => {
+  it("appends Color when a legend attribute is mapped", () => {
     // Mimic a CODAP-legend graph where the legend attribute provides category
     // colors. The legend attribute's value for this case is "dog".
     const cfg = makeDataConfig({


### PR DESCRIPTION
[CLUE-503](https://concord-consortium.atlassian.net/browse/CLUE-503)

Implements keyboard navigation and screen-reader accessibility for the Coordinate Grid (geometry) tile. The tile now participates in the shared focus-trap system, with `Tab` cycling through SVG board → board objects → toolbar → resize → title.

**Coordinate Grid a11y** (primary deliverable)

- The JSXGraph SVG board is decorated with `role="group"` + `tabindex="0"` and becomes the entry point into the content slot. Its aria-label dynamically reports the board summary, e.g. "Coordinate grid board: 3 points, 1 selected".
- `Tab` walks objects in a semantic order: each compound shape (polygon / circle / line) immediately followed by its defining points, then orphan free points, then standalone elements (vertex angles, comments, images). The custom routing is required because JSXGraph paints shape outlines before their points — plain DOM-order `Tab` would visit every shape then every point.
- Each focusable object exposes a per-type aria-label: "Point P1 at (3, 4), Selected", "Polygon ABCD with 4 vertices", "Circle centered at (0, 0) with radius 5", etc. Polygon vertices carry a "Vertex k of N of polygon X" prefix.
- `Enter` / `Space` toggles selection on the focused object (`Shift+Enter` extends). Compound shapes select alongside their defining points so arrow-key nudge moves the whole shape. A per-tile aria-live region announces selection changes.
- Toolbar mode buttons (Point / Polygon / Circle / Line) seed a unit-sized shape at user-coords (1, 1) when activated via keyboard / SR (`event.detail === 0`). Mouse clicks (`detail >= 1`) only flip mode — board clicks place the points as before.
- The Color palette is keyboard-accessible: `Enter` on the Color button opens it with focus on the selected swatch; arrow keys and Home/End rove between swatches; `Escape` closes the palette and refocuses the Color button.
- Linked Table points are first-class tab stops with "Linked point at (x, y)" labels and keyboard-toggleable selection.
- Read-only boards (navigator mini-map, read-only documents) keep the SVG board focusable as a single group, but individual board objects clear their tabindex so they don't pollute the page's Tab order.

**Shared a11y infrastructure**

- New `tabHandlers` slot on `ITileFocusableElements` / `ClueFocusTrapConfig` / `FocusTrapStrategy`. A handler returns `"handled"` when it moved focus (caller does `preventDefault`) or `"exit"` to let the trap advance to the next slot. Any slot listed here is treated as managing its own tabindex.
- `tile-component.tsx`'s strategy builder now forwards only the slot-handler keys the inner tile actually claims (Escape + Tab), with dynamic re-resolution per call so popovers can install / uninstall their own interceptors between strategy builds.
- `editable-tile-title.tsx` returns focus to the title-text element on edit exit (commit / cancel / blur) so the tile's focus trap has a stable anchor for the next `Tab` — affects every tile with an editable title.
- `createClueTileStrategy` announces the tile's user-facing `displayName` ("Coordinate Grid") instead of the raw type id ("geometry").

[CLUE-503]: https://concord-consortium.atlassian.net/browse/CLUE-503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ