### PR TITLE
CLUE-295: fix Table in Question losing its data on export

### DIFF
--- a/cypress/e2e/functional/author_tests/doc-editor_spec.js
+++ b/cypress/e2e/functional/author_tests/doc-editor_spec.js
@@ -5,6 +5,12 @@ function beforeTest() {
   cy.visit(url);
   cy.get('.editable-document-content', { timeout: 60000 });
 }
+
+// Open/Save/Export/Reset now live in the "File" menu.
+function clickFileMenuItem(label) {
+  cy.contains("button", "File").click();
+  cy.contains('[role="menuitem"]', label).click();
+}
 context('Doc Editor', () => {
   it('verify doc editor and solution button work', function () {
     beforeTest();
@@ -51,11 +57,24 @@ context('Doc Editor', () => {
       cy.stub(win, 'showSaveFilePicker').as('showSaveFilePicker')
         .returns(fakeFileHandle)
     );
-    cy.contains("button", 'save').click();
+    clickFileMenuItem('Save');
     cy.get('@showSaveFilePicker')
       .should('have.been.calledOnce')
       .invoke('restore');
     cy.get(".status").should("contain", "test.json");
+
+
+    cy.log("test export as authoring format");
+    cy.window().then((win) => {
+      fakeFile.name = "test-export.json";
+      cy.stub(win, 'showSaveFilePicker').as('showSaveFilePickerExport')
+        .returns(fakeFileHandle);
+    });
+    clickFileMenuItem('Export as Authoring Format');
+    cy.get('@showSaveFilePickerExport')
+      .should('have.been.calledOnce')
+      .invoke('restore');
+    cy.get(".status").should("contain", "exported: test-export.json");
 
 
     cy.log("test open an empty document");
@@ -64,7 +83,7 @@ context('Doc Editor', () => {
       cy.stub(win, 'showOpenFilePicker').as('showOpenFilePicker')
         .returns([fakeFileHandle]);
     });
-    cy.contains("button", 'open').click();
+    clickFileMenuItem('Open');
     cy.get('@showOpenFilePicker')
       .should('have.been.calledOnce')
       .invoke('restore');

--- a/src/components/doc-editor/doc-editor-app.tsx
+++ b/src/components/doc-editor/doc-editor-app.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useState } from "react";
 import stringify from "json-stringify-pretty-compact";
 import { applySnapshot, getSnapshot, onSnapshot } from "mobx-state-tree";
 import { observer } from "mobx-react";
+import { Menu, MenuButton, MenuDivider, MenuItem, MenuList, Portal } from "@chakra-ui/react";
 
 import { defaultDocumentModel, defaultDocumentModelParts } from "./doc-editor-app-defaults";
 import { EditableDocumentContent } from "../document/editable-document-content";
@@ -156,6 +157,24 @@ export const DocEditorApp = observer(function DocEditorApp() {
     setStatus(`file: ${_fileName}`);
   }
 
+  // Always writes the CLUE authoring/export format (each tile generates its own JSON via
+  // exportAsJson), regardless of how the document was loaded. Picks a new file each time and
+  // does not become the current Save file, so export stays independent of the working file.
+  async function handleExport() {
+    if (!document.content) {
+      console.error("Can't export without document.content");
+      return;
+    }
+    const _fileHandle = await (window as any).showSaveFilePicker();
+    if (!_fileHandle) return;
+    const file = await _fileHandle.getFile();
+    const contents = document.content.exportAsJson({ includeTileIds: true });
+    const writable = await _fileHandle.createWritable();
+    await writable.write(contents);
+    await writable.close();
+    setStatus(`exported: ${file.name}`);
+  }
+
   const [showSettings] = useCustomModal({
     title: "Settings",
     Content: SettingsDialog,
@@ -237,11 +256,20 @@ export const DocEditorApp = observer(function DocEditorApp() {
           <div className="document">
             <div className="titlebar">
               <div className="actions left">
-                <button onClick={handleOpen}>open</button>
-                <button onClick={handleSave}>save</button>
+                <Menu>
+                  <MenuButton className="file-menu-button">File ▾</MenuButton>
+                  <Portal>
+                    <MenuList>
+                      <MenuItem onClick={handleOpen}>Open</MenuItem>
+                      <MenuItem onClick={handleSave}>Save</MenuItem>
+                      <MenuItem onClick={handleExport}>Export as Authoring Format...</MenuItem>
+                      <MenuDivider/>
+                      <MenuItem onClick={handleClear}>Reset doc</MenuItem>
+                    </MenuList>
+                  </Portal>
+                </Menu>
                 <span className="status">{status}</span>
                 {showAiSummary && <button onClick={handleToggleAiSummary}>ai summary</button>}
-                <button onClick={handleClear}>reset doc</button>
                 <button onClick={handleSettings}>settings</button>
                 <DocumentAnnotationToolbar/>
               </div>

--- a/src/models/document/document-content-tests/question-tile-operations.test.ts
+++ b/src/models/document/document-content-tests/question-tile-operations.test.ts
@@ -537,4 +537,24 @@ Contents of embedded row list:
 
   });
 
+  describe("Question tile export", () => {
+    function flattenTilesOrRows(tilesOrRows: any[]): any[] {
+      return tilesOrRows.flatMap(t => Array.isArray(t) ? t : [t]);
+    }
+
+    // Tiles inside of question tiles need their ids.
+    // The document-level
+    // sharedModels need to reference the tiles by their ids. Without these ids, tiles like the table will have no data.
+    it("includes the ids of tiles nested inside a Question tile", () => {
+      const exported = JSON.parse(documentContent.exportAsJson({ includeTileIds: true }));
+
+      const exportedQuestion = flattenTilesOrRows(exported.tiles)
+        .find(t => t?.content?.type === "Question");
+      expect(exportedQuestion.id).toBe("question-1");
+
+      const nestedIds = flattenTilesOrRows(exportedQuestion.content.tiles).map(t => t.id);
+      expect(nestedIds).toEqual(expect.arrayContaining(["text-2", "table-2", "sketch-1"]));
+    });
+  });
+
 });

--- a/src/models/tiles/question/question-content.ts
+++ b/src/models/tiles/question/question-content.ts
@@ -1,6 +1,6 @@
 import { types, Instance, SnapshotIn } from "mobx-state-tree";
 import { ITileContentModel, TileContentModel } from "../tile-content";
-import { ITileExportOptions, IDefaultContentOptions } from "../tile-content-info";
+import { IDocumentExportOptions, IDefaultContentOptions } from "../tile-content-info";
 import { RowList } from "../../document/row-list";
 import { isPlaceholderContent, kPlaceholderTileType } from "../placeholder/placeholder-content";
 import { StringBuilder } from "../../../utilities/string-builder";
@@ -44,7 +44,7 @@ export const QuestionContentModel = types.compose(
     questionId: types.optional(types.string, () => generateQuestionId()),
   })
   .views(self => ({
-    exportJson(options: ITileExportOptions, tileMap: ITileMapLookup) {
+    exportJson(options: IDocumentExportOptions, tileMap: ITileMapLookup) {
       const builder = new StringBuilder();
       builder.pushLine("{");
       builder.pushLine(`"type": "${self.type}",`, 2);

--- a/src/models/tiles/tile-model.ts
+++ b/src/models/tiles/tile-model.ts
@@ -118,7 +118,12 @@ export const TileModel = types
     },
     exportJson(options?: ITileExportOptions, tileMap?: ITileMapLookup): string | undefined {
       const { includeId, excludeTitle, ...otherOptions } = options || {};
-      let contentJson = (self.content as any).exportJson?.(otherOptions, tileMap);
+      // Container tiles (e.g. Question) export their nested tiles via their content's row
+      // list. Re-propagate the id-inclusion policy as includeTileIds so those nested tiles
+      // keep their ids; otherwise document-level sharedModel/annotation references to them
+      // break when the document is reloaded.
+      const contentOptions = { ...otherOptions, includeTileIds: includeId };
+      let contentJson = (self.content as any).exportJson?.(contentOptions, tileMap);
       if (!contentJson) return;
       if (options?.rowHeight) {
         // add comma before layout/height entry


### PR DESCRIPTION
## Summary

- **Fix CLUE-295** — a Table (or any shared-model tile) dragged into a Question tile rendered as if it had no data after the document was exported and reloaded. The export dropped the ids of tiles nested inside a Question, so the document-level `sharedModels`/`annotations` references to those tiles were orphaned on reload. The `includeTileIds` policy is now re-propagated into nested tile export, so nested tiles keep their ids and their shared data set survives the round-trip.
- **Doc editor tooling** — the standalone `/editor/` now has a "File" menu (Open / Save / Reset doc) with a new **Export as Authoring Format...** item that always writes the CLUE authoring/export format regardless of how the document was loaded. This makes it easy to build a document and exercise the export round-trip that this bug lives in.

## Details

- `tile-model.ts`: container tiles (Question) export nested tiles via their content's row list; `includeId` is now passed through as `includeTileIds` so the nested row export includes ids.
- `question-content.ts`: `exportJson` typed against `IDocumentExportOptions` so the flag flows through visibly.
- `dc-question-tile-move-copy.test.ts` renamed to `question-tile-operations.test.ts` (the outer suite is already "Question tile operations") with a regression test asserting nested tile ids are present in the export.

## Test plan

- [x] `npm test -- question-tile-operations` — passes; the new test fails if the fix is reverted.
- [x] In `/editor/`: build a Table with data inside a Question, **Export as Authoring Format...**, then **Open** the exported file — the inner table keeps its data.
- [x] Cypress `doc-editor_spec` passes (File menu drives open / save / export / settings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)