### PR TITLE
fix: XY Plot keyboard nav (CLUE-502)

### DIFF
--- a/cypress/e2e/functional/tile_tests/xy_plot_tool_keyboard_spec.js
+++ b/cypress/e2e/functional/tile_tests/xy_plot_tool_keyboard_spec.js
@@ -328,20 +328,33 @@ context('XY Plot keyboard accessibility', function () {
       tableToolTile.getTableTile().should('be.visible');
     });
 
-    it('Link-tile dialog opens with focus inside and closes on Escape', function () {
+    it('Link-tile dialog: select focused on open, Enter on Cancel does not submit, Escape closes', function () {
       // qa unit's tools array is ['link-tile-multiple', 'fit-all', 'toggle-lock'],
       // so the first toolbar button is link-tile-multiple. Both link-tile and
       // link-tile-multiple call into useProviderTileLinking → showLinkTileDialog
       // and open the same dialog.
-      cy.log('Enter on the link-tile button opens the dialog and moves focus inside');
+      cy.log('Opening with Enter on the link button moves focus straight to the source select');
       xyTile.getTile().click();
       cy.get('button.toolbar-button.link-tile-multiple').focus();
       cy.realPress('Enter');
       xyTile.getCustomModal().should('be.visible');
-      cy.focused().then($el => {
-        expect($el.closest('.custom-modal').length,
-          'focused element is inside the dialog').to.be.greaterThan(0);
-      });
+      cy.focused().should('have.attr', 'data-test', 'link-tile-select');
+
+      cy.log('Choosing a source then pressing Enter on the focused Cancel button closes the dialog');
+      cy.get('[data-test=link-tile-select]').select('Table Data 1');
+      // The select re-focuses itself on a timer after onChange; flush it before
+      // moving focus to Cancel so the timer can't steal focus back to the select.
+      cy.wait(100);
+      xyTile.getCustomModal().find('.modal-button').contains('Cancel').focus();
+      cy.realPress('Enter');
+      xyTile.getCustomModal().should('not.exist');
+
+      cy.log('Re-opening shows the source still under "Link Source" — Cancel did not graph it');
+      xyTile.getTile().click();
+      clueCanvas.clickToolbarButton('graph', 'link-tile-multiple');
+      xyTile.getCustomModal().should('be.visible');
+      xyTile.getCustomModal().find('optgroup[label="Unlink Source"]').should('not.exist');
+      xyTile.getCustomModal().find('optgroup[label="Link Source"]').should('exist');
 
       cy.log('Escape closes the dialog');
       cy.realPress('Escape');

--- a/src/components/tiles/tile-component.scss
+++ b/src/components/tiles/tile-component.scss
@@ -25,10 +25,19 @@
     outline: none;
   }
 
-  &:focus-visible:not(.selected) {
+  // Use a pseudo-element overlay rather than an inset box-shadow on the tile
+  // itself: some tiles (e.g. graph) have opaque-backgrounded descendants that
+  // extend to the tile edges and would paint over an inset shadow.
+  // z-index must beat any positioned descendants — graph uses up to 1000.
+  &:focus-visible:not(.selected)::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: 9999;
     box-shadow:
       inset 0 0 0 3px white,
-      inset 0 0 0 5px rgb(9, 87, 208);
+      inset 0 0 0 5px $focus-ring-color;
   }
 
   &.hovered {

--- a/src/hooks/use-custom-modal.test.tsx
+++ b/src/hooks/use-custom-modal.test.tsx
@@ -1,0 +1,110 @@
+import React from "react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import Modal from "react-modal";
+import { ModalProvider } from "react-modal-hook";
+import { IModalButton, useCustomModal } from "./use-custom-modal";
+
+// jsdom doesn't implement HTMLSelectElement.showPicker; the modal calls it to
+// open a focused select on Enter, so we install a spy to observe that path.
+const showPickerMock = jest.fn();
+
+const Content: React.FC<any> = () => (
+  <div>
+    <select data-testid="select" defaultValue="">
+      <option value="">Choose</option>
+      <option value="a">A</option>
+      <option value="b">B</option>
+    </select>
+    <textarea data-testid="textarea" />
+    <input data-testid="input" />
+  </div>
+);
+
+interface IHarnessProps {
+  onDefaultClick: () => void;
+  defaultDisabled?: boolean;
+}
+
+const Harness: React.FC<IHarnessProps> = ({ onDefaultClick, defaultDisabled }) => {
+  const buttons: IModalButton[] = [
+    { label: "Cancel" },
+    { label: "Graph It!", isDefault: true, isDisabled: defaultDisabled, onClick: onDefaultClick }
+  ];
+  const [showModal] = useCustomModal({ className: "test", title: "Test", Content, contentProps: {}, buttons });
+  React.useEffect(() => { (showModal as () => void)(); }, [showModal]);
+  return <div className="app" />;
+};
+
+// react-modal calls onAfterOpen inside a requestAnimationFrame, and the modal's
+// keydown listener only attaches once that fires (it needs the content element).
+// jsdom's rAF is timer-backed, so flush it (and the post-open focus setTimeout)
+// before interacting.
+const openModal = async (props: IHarnessProps) => {
+  render(<ModalProvider><Harness {...props} /></ModalProvider>);
+  await act(async () => { await new Promise(resolve => setTimeout(resolve, 50)); });
+};
+
+describe("useCustomModal Enter-key handling", () => {
+  beforeAll(() => {
+    Modal.setAppElement("body");
+    (HTMLSelectElement.prototype as any).showPicker = showPickerMock;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("opens the select's picker when Enter is pressed on a focused select", async () => {
+    await openModal({ onDefaultClick: jest.fn() });
+    const select = screen.getByTestId("select");
+    select.focus();
+    fireEvent.keyDown(select, { key: "Enter" });
+    expect(showPickerMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not submit and keeps the dialog open when Enter is pressed on a focused select", async () => {
+    const onDefaultClick = jest.fn();
+    await openModal({ onDefaultClick });
+    const select = screen.getByTestId("select");
+    select.focus();
+    fireEvent.keyDown(select, { key: "Enter" });
+    expect(onDefaultClick).not.toHaveBeenCalled();
+    expect(screen.getByTestId("select")).toBeInTheDocument();
+  });
+
+  it("does not fire the default action when Enter is pressed on a focused button", async () => {
+    const onDefaultClick = jest.fn();
+    await openModal({ onDefaultClick });
+    const cancel = screen.getByText("Cancel");
+    cancel.focus();
+    fireEvent.keyDown(cancel, { key: "Enter" });
+    expect(onDefaultClick).not.toHaveBeenCalled();
+  });
+
+  it("does not fire the default action when Enter is pressed in a textarea", async () => {
+    const onDefaultClick = jest.fn();
+    await openModal({ onDefaultClick });
+    const textarea = screen.getByTestId("textarea");
+    textarea.focus();
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    expect(onDefaultClick).not.toHaveBeenCalled();
+  });
+
+  it("fires the default action on Enter when focus is on a plain input", async () => {
+    const onDefaultClick = jest.fn();
+    await openModal({ onDefaultClick });
+    const input = screen.getByTestId("input");
+    input.focus();
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onDefaultClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire the default action on Enter when the default button is disabled", async () => {
+    const onDefaultClick = jest.fn();
+    await openModal({ onDefaultClick, defaultDisabled: true });
+    const input = screen.getByTestId("input");
+    input.focus();
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onDefaultClick).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/use-custom-modal.tsx
+++ b/src/hooks/use-custom-modal.tsx
@@ -51,15 +51,34 @@ export const useCustomModal = <IContentProps,>({
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Enter" && !(e.target instanceof HTMLTextAreaElement)) {
-        const defaultButton = buttons.find(b => b.isDefault);
-        if (defaultButton && !defaultButton.isDisabled) {
-          blurModal();
-          // useRef to avoid circular dependencies
-          invokeButton(defaultButton, handleCloseRef.current);
-          e.stopPropagation();
-          e.preventDefault();
-        }
+      if (e.key !== "Enter") return;
+
+      // Enter on a focused <select> opens its menu rather than submitting the
+      // dialog. Native selects don't reliably open on Enter (esp. macOS), so
+      // open it explicitly. showPicker() may be absent in older browsers, in which
+      // case nothing happens, but the user can still use Space or ArrowDown to
+      // open the menu.
+      if (e.target instanceof HTMLSelectElement) {
+        e.stopPropagation();
+        e.preventDefault();
+        e.target.showPicker?.();
+        return;
+      }
+
+      // Enter in a <textarea> inserts a newline; don't hijack it to submit.
+      if (e.target instanceof HTMLTextAreaElement) return;
+
+      // A focused button handles Enter itself (activating that button); don't
+      // also fire the default button, or Enter on Cancel/Close would still submit.
+      if (e.target instanceof HTMLButtonElement) return;
+
+      const defaultButton = buttons.find(b => b.isDefault);
+      if (defaultButton && !defaultButton.isDisabled) {
+        blurModal();
+        // useRef to avoid circular dependencies
+        invokeButton(defaultButton, handleCloseRef.current);
+        e.stopPropagation();
+        e.preventDefault();
       }
     };
 

--- a/src/hooks/use-link-consumer-tile-dialog.tsx
+++ b/src/hooks/use-link-consumer-tile-dialog.tsx
@@ -144,6 +144,7 @@ export const useLinkConsumerTileDialog =
     className: "link-tile",
     Icon,
     title: tileType ? actionName : "Link or Unlink Tile",
+    focusElement: "select",
     Content,
     contentProps: { linkedTiles, selectValue, tileTitle, tileType, unlinkedTiles, setSelectValue },
     buttons

--- a/src/hooks/use-link-provider-tile-dialog.tsx
+++ b/src/hooks/use-link-provider-tile-dialog.tsx
@@ -91,6 +91,7 @@ export const useLinkProviderTileDialog = ({
     className: "link-tile",
     Icon: LinkGraphIcon,
     title: "Add Data and Variables",
+    focusElement: "select",
     Content,
     contentProps: { labelFunction, unlinkedSharedModels, linkedSharedModels,
       selectValue, tileTitle, setSelectValue },

--- a/src/hooks/use-merge-data-dialog.tsx
+++ b/src/hooks/use-merge-data-dialog.tsx
@@ -68,6 +68,7 @@ export const useMergeTileDialog = ({ mergableTiles, model, onMergeTile }: IProps
     className: "merge-tile",
     Icon: MergeInIcon,
     title: "Add data from...",
+    focusElement: "select",
     Content,
     contentProps: { model, selectValue, hostTileTitle, mergableTiles, setSelectValue },
     buttons: [


### PR DESCRIPTION
[CLUE-502](https://concord-consortium.atlassian.net/browse/CLUE-502)

This is a follow up to #2877 that fixes some bugs.

- When an XY Plot tile has focus but its focus trap has not been entered, it now has a visible focus ring
- When the link data dialog is opened, focus automatically moves to the dialog's `<select>` element
- Pressing `Enter` when the `<select>` is in focus opens the menu
- Pressing `Enter` on the dialog's X (close) and Cancel buttons no longer invokes the default button 

[CLUE-502]: https://concord-consortium.atlassian.net/browse/CLUE-502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ