### PR TITLE
Clue 534

### DIFF
--- a/cypress/e2e/functional/tile_tests/dataflow_tile_keyboard_spec.js
+++ b/cypress/e2e/functional/tile_tests/dataflow_tile_keyboard_spec.js
@@ -25,6 +25,7 @@ context('Dataflow keyboard accessibility (CLUE-455)', function () {
     ['data-testid', 'zoom-out-button'],
     ['data-testid', 'add-sensor-button'],
     ['class', 'data-set-view'],
+    ['class', 'tool-tile-drag-handle-wrapper'],
     ['class', 'tool-tile-resize-handle-wrapper'],
   ];
 

--- a/cypress/e2e/functional/tile_tests/geometry_tool_keyboard_spec.js
+++ b/cypress/e2e/functional/tile_tests/geometry_tool_keyboard_spec.js
@@ -28,7 +28,7 @@ context('Coordinate Grid keyboard accessibility', function () {
   }
 
   // The empty Coordinate Grid tile has this trap cycle:
-  //   title → SVG board (content) → toolbar (single tab stop) → resize → wrap.
+  //   title → SVG board (content) → toolbar (single tab stop) → drag handle → resize → wrap.
   // The SVG board is the JSXGraph root, decorated with role="group" + tabindex="0"
   // in handleCreateBoard so the trap visits it as the sole content tab stop.
   // The toolbar uses the standard CLUE pattern of one tab stop + internal arrow-key

--- a/cypress/e2e/functional/tile_tests/geometry_tool_keyboard_spec.js
+++ b/cypress/e2e/functional/tile_tests/geometry_tool_keyboard_spec.js
@@ -36,6 +36,7 @@ context('Coordinate Grid keyboard accessibility', function () {
   const emptyFocusOrder = [
     ['css',   '.geometry-content [role="group"]'],  // JSXGraph SVG root
     ['class', 'toolbar-button'],                    // first toolbar button
+    ['class', 'tool-tile-drag-handle-wrapper'],     // drag handle
     ['class', 'tool-tile-resize-handle-wrapper'],   // resize handle
   ];
 

--- a/cypress/e2e/functional/tile_tests/xy_plot_tool_keyboard_spec.js
+++ b/cypress/e2e/functional/tile_tests/xy_plot_tool_keyboard_spec.js
@@ -27,7 +27,7 @@ context('XY Plot keyboard accessibility', function () {
 
   // The empty XY-Plot in qa unit (CLUE-legend mode) has this trap cycle:
   //   title → X-label → Y-label → X-min → X-max → Y-min → Y-max
-  //         → add-series (palette) → toolbar → resize → wrap.
+  //         → add-series (palette) → toolbar → drag handle → resize → wrap.
   //  - The dots-group surrogate is in the DOM but 0×0 on an empty plot, so the
   //    trap's visibility filter skips it. Once a dataset is linked it becomes
   //    a real Tab stop (between the labels and the min/max bound controls).

--- a/cypress/e2e/functional/tile_tests/xy_plot_tool_keyboard_spec.js
+++ b/cypress/e2e/functional/tile_tests/xy_plot_tool_keyboard_spec.js
@@ -51,6 +51,7 @@ context('XY Plot keyboard accessibility', function () {
     ['class', 'editable-border-box'],                // Y-axis max
     ['class', 'add-series-button'],                  // legend palette
     ['class', 'toolbar-button'],                     // toolbar (either end of the roving range)
+    ['class', 'tool-tile-drag-handle-wrapper'],      // drag handle
     ['class', 'tool-tile-resize-handle-wrapper'],    // resize handle
   ];
 

--- a/src/components/document/document-content.tsx
+++ b/src/components/document/document-content.tsx
@@ -628,12 +628,27 @@ export class DocumentContentComponent extends BaseComponent<IProps, IState> {
 
     const currentIndex = ui.focusedDropZoneIndex;
 
+    // Find the drop zone nearest the picked-up tile's current position.
+    // Used as the starting point when no zone is focused yet.
+    const findTileZoneIndex = () => {
+      const tileId = ui.pickedUpTileId;
+      if (!tileId || !content) return 0;
+      const rowId = content.findRowIdContainingTile(tileId);
+      if (!rowId) return 0;
+      // Find the first zone whose rowId matches the tile's row
+      const idx = zones.findIndex(z => z.rowId === rowId);
+      return idx >= 0 ? idx : 0;
+    };
+
     switch (e.key) {
       case "ArrowDown":
       case "ArrowRight": {
         e.preventDefault();
         if (currentIndex === undefined) {
-          this.setFocusedZone(zones, 0);
+          // Start from the tile's current position
+          const startIdx = findTileZoneIndex();
+          const nextIdx = Math.min(startIdx + 1, zones.length - 1);
+          this.setFocusedZone(zones, nextIdx);
         } else if (currentIndex < zones.length - 1) {
           this.setFocusedZone(zones, currentIndex + 1);
         }
@@ -643,7 +658,10 @@ export class DocumentContentComponent extends BaseComponent<IProps, IState> {
       case "ArrowLeft": {
         e.preventDefault();
         if (currentIndex === undefined) {
-          this.setFocusedZone(zones, zones.length - 1);
+          // Start from the tile's current position
+          const startIdx = findTileZoneIndex();
+          const prevIdx = Math.max(startIdx - 1, 0);
+          this.setFocusedZone(zones, prevIdx);
         } else if (currentIndex > 0) {
           this.setFocusedZone(zones, currentIndex - 1);
         }

--- a/src/components/tiles/tile-api.tsx
+++ b/src/components/tiles/tile-api.tsx
@@ -47,6 +47,10 @@ export interface ITileFocusableElements {
   // Any slot listed here owns its own tabindex — the trap won't touch its
   // descendants' tabindex on mount.
   tabHandlers?: Record<string, (e: KeyboardEvent, reverse: boolean) => TabHandlerResult>;
+  // Drag handle element for keyboard tile pick-up. Visited between toolbar and
+  // resize in the focus trap cycle. Uses tabIndex={-1} like resize — the trap
+  // controls when it receives focus.
+  dragHandleElement?: HTMLElement;
 }
 
 export interface ITileApi {

--- a/src/components/tiles/tile-component.scss
+++ b/src/components/tiles/tile-component.scss
@@ -101,6 +101,12 @@
     }
   }
 
+  // Show drag handle when the focus trap cycles to it (programmatic focus).
+  // Uses :focus (not :focus-visible) because the trap calls .focus() directly.
+  .tool-tile-drag-handle-wrapper:focus .tool-tile-drag-handle {
+    opacity: 1;
+  }
+
   .tool-tile-resize-handle-wrapper {
     appearance: none;
     background: none;

--- a/src/components/tiles/tile-component.test.tsx
+++ b/src/components/tiles/tile-component.test.tsx
@@ -839,58 +839,63 @@ describe("TileComponent focus trap", () => {
     });
   });
 
+  // Shared helper: renders a tile with isUserResizable=true so both resize
+  // handle and drag handle are present. Used by resize and drag-handle tests.
+  function renderResizableTile() {
+    mockTitleElement = document.createElement("input");
+    mockContentElement = document.createElement("div");
+    mockContentElement.setAttribute("tabindex", "-1");
+    mockToolbarElement = document.createElement("div");
+    mockToolbarElement.setAttribute("role", "toolbar");
+    const btn = document.createElement("button");
+    btn.textContent = "Tool";
+    btn.setAttribute("tabindex", "0");
+    mockToolbarElement.appendChild(btn);
+    document.body.appendChild(mockToolbarElement);
+
+    const stores = specStores();
+    const tileContent = TestFocusTrapContent.create();
+    const tileModel = TileModel.create({ content: tileContent });
+    const tileApiInterface = new TileApiInterface();
+    const onRequestRowHeight = jest.fn();
+
+    const result = render(
+      <Provider stores={stores}>
+        <TileApiInterfaceContext.Provider value={tileApiInterface}>
+          <div className="document-content">
+            <TileComponent
+              context="context"
+              docId="docId"
+              documentContent={null}
+              isUserResizable={true}
+              height={250}
+              model={tileModel}
+              onResizeRow={jest.fn()}
+              onSetCanAcceptDrop={jest.fn()}
+              onRequestRowHeight={onRequestRowHeight}
+            />
+          </div>
+        </TileApiInterfaceContext.Provider>
+      </Provider>
+    );
+
+    const tileElement = screen.getByTestId("tool-tile");
+    if (mockTitleElement) tileElement.appendChild(mockTitleElement);
+    if (mockContentElement) tileElement.appendChild(mockContentElement);
+
+    const resizeHandle = tileElement.querySelector(
+      ".tool-tile-resize-handle-wrapper"
+    ) as HTMLElement;
+    const dragHandle = tileElement.querySelector(
+      '[data-testid="tool-tile-drag-handle"]'
+    ) as HTMLElement;
+
+    return {
+      stores, tileModel, tileElement, resizeHandle, dragHandle, onRequestRowHeight, ...result,
+    };
+  }
+
   describe("keyboard resize handle", () => {
-    function renderResizableTile() {
-      mockTitleElement = document.createElement("input");
-      mockContentElement = document.createElement("div");
-      mockContentElement.setAttribute("tabindex", "-1");
-      mockToolbarElement = document.createElement("div");
-      mockToolbarElement.setAttribute("role", "toolbar");
-      const btn = document.createElement("button");
-      btn.textContent = "Tool";
-      btn.setAttribute("tabindex", "0");
-      mockToolbarElement.appendChild(btn);
-      document.body.appendChild(mockToolbarElement);
-
-      const stores = specStores();
-      const tileContent = TestFocusTrapContent.create();
-      const tileModel = TileModel.create({ content: tileContent });
-      const tileApiInterface = new TileApiInterface();
-      const onRequestRowHeight = jest.fn();
-
-      const result = render(
-        <Provider stores={stores}>
-          <TileApiInterfaceContext.Provider value={tileApiInterface}>
-            <div className="document-content">
-              <TileComponent
-                context="context"
-                docId="docId"
-                documentContent={null}
-                isUserResizable={true}
-                height={250}
-                model={tileModel}
-                onResizeRow={jest.fn()}
-                onSetCanAcceptDrop={jest.fn()}
-                onRequestRowHeight={onRequestRowHeight}
-              />
-            </div>
-          </TileApiInterfaceContext.Provider>
-        </Provider>
-      );
-
-      const tileElement = screen.getByTestId("tool-tile");
-      if (mockTitleElement) tileElement.appendChild(mockTitleElement);
-      if (mockContentElement) tileElement.appendChild(mockContentElement);
-
-      const resizeHandle = tileElement.querySelector(
-        ".tool-tile-resize-handle-wrapper"
-      ) as HTMLElement;
-
-      return {
-        stores, tileModel, tileElement, resizeHandle, onRequestRowHeight, ...result,
-      };
-    }
-
     it("resize handle renders as button with aria-label", () => {
       const { resizeHandle } = renderResizableTile();
       expect(resizeHandle).toBeTruthy();
@@ -964,50 +969,7 @@ describe("TileComponent focus trap", () => {
     });
 
     it("Tab from drag handle goes to resize", () => {
-      // Use a resizable tile so the resize handle is present
-      mockTitleElement = document.createElement("input");
-      mockContentElement = document.createElement("div");
-      mockContentElement.setAttribute("tabindex", "-1");
-      mockToolbarElement = document.createElement("div");
-      mockToolbarElement.setAttribute("role", "toolbar");
-      const btn = document.createElement("button");
-      btn.textContent = "Tool";
-      btn.setAttribute("tabindex", "0");
-      mockToolbarElement.appendChild(btn);
-      document.body.appendChild(mockToolbarElement);
-
-      const stores = specStores();
-      const tileContent = TestFocusTrapContent.create();
-      const tileModel = TileModel.create({ content: tileContent });
-      const tileApiInterface = new TileApiInterface();
-
-      render(
-        <Provider stores={stores}>
-          <TileApiInterfaceContext.Provider value={tileApiInterface}>
-            <div className="document-content">
-              <TileComponent
-                context="context"
-                docId="docId"
-                documentContent={null}
-                isUserResizable={true}
-                height={250}
-                model={tileModel}
-                onResizeRow={jest.fn()}
-                onSetCanAcceptDrop={jest.fn()}
-                onRequestRowHeight={jest.fn()}
-              />
-            </div>
-          </TileApiInterfaceContext.Provider>
-        </Provider>
-      );
-
-      const tileElement = screen.getByTestId("tool-tile");
-      if (mockTitleElement) tileElement.appendChild(mockTitleElement);
-      if (mockContentElement) tileElement.appendChild(mockContentElement);
-
-      const dragHandle = tileElement.querySelector('[data-testid="tool-tile-drag-handle"]') as HTMLElement;
-      const resizeHandle = tileElement.querySelector(".tool-tile-resize-handle-wrapper") as HTMLElement;
-
+      const { stores, tileModel, dragHandle, resizeHandle } = renderResizableTile();
       act(() => { stores.ui.setSelectedTileId(tileModel.id); });
       act(() => { dragHandle.focus(); });
       fireEvent.keyDown(dragHandle, { key: "Tab" });
@@ -1015,50 +977,7 @@ describe("TileComponent focus trap", () => {
     });
 
     it("Shift+Tab from resize goes to drag handle", () => {
-      // Use a resizable tile so the resize handle is present
-      mockTitleElement = document.createElement("input");
-      mockContentElement = document.createElement("div");
-      mockContentElement.setAttribute("tabindex", "-1");
-      mockToolbarElement = document.createElement("div");
-      mockToolbarElement.setAttribute("role", "toolbar");
-      const btn = document.createElement("button");
-      btn.textContent = "Tool";
-      btn.setAttribute("tabindex", "0");
-      mockToolbarElement.appendChild(btn);
-      document.body.appendChild(mockToolbarElement);
-
-      const stores = specStores();
-      const tileContent = TestFocusTrapContent.create();
-      const tileModel = TileModel.create({ content: tileContent });
-      const tileApiInterface = new TileApiInterface();
-
-      render(
-        <Provider stores={stores}>
-          <TileApiInterfaceContext.Provider value={tileApiInterface}>
-            <div className="document-content">
-              <TileComponent
-                context="context"
-                docId="docId"
-                documentContent={null}
-                isUserResizable={true}
-                height={250}
-                model={tileModel}
-                onResizeRow={jest.fn()}
-                onSetCanAcceptDrop={jest.fn()}
-                onRequestRowHeight={jest.fn()}
-              />
-            </div>
-          </TileApiInterfaceContext.Provider>
-        </Provider>
-      );
-
-      const tileElement = screen.getByTestId("tool-tile");
-      if (mockTitleElement) tileElement.appendChild(mockTitleElement);
-      if (mockContentElement) tileElement.appendChild(mockContentElement);
-
-      const dragHandle = tileElement.querySelector('[data-testid="tool-tile-drag-handle"]') as HTMLElement;
-      const resizeHandle = tileElement.querySelector(".tool-tile-resize-handle-wrapper") as HTMLElement;
-
+      const { stores, tileModel, dragHandle, resizeHandle } = renderResizableTile();
       act(() => { stores.ui.setSelectedTileId(tileModel.id); });
       act(() => { resizeHandle.focus(); });
       fireEvent.keyDown(resizeHandle, { key: "Tab", shiftKey: true });

--- a/src/components/tiles/tile-component.test.tsx
+++ b/src/components/tiles/tile-component.test.tsx
@@ -330,14 +330,15 @@ describe("TileComponent focus trap", () => {
       expect(document.activeElement).toBe(titleElement);
     });
 
-    it("Shift+Tab on selected tile enters focus trap on the toolbar's active item", () => {
-      const { stores, tileModel, tileElement, toolbarButtons } = renderFocusTrapTile();
+    it("Shift+Tab on selected tile enters focus trap on the drag handle", () => {
+      const { stores, tileModel, tileElement } = renderFocusTrapTile();
       act(() => { stores.ui.setSelectedTileId(tileModel.id); });
       act(() => { tileElement.focus(); });
       fireEvent.keyDown(tileElement, { key: "Tab", shiftKey: true });
-      // Reverse entry: resize (absent) → toolbar; lands on the roving-active
-      // button (the one with tabindex="0"), which is the first button by default.
-      expect(document.activeElement).toBe(toolbarButtons[0]);
+      // Reverse entry: resize (absent) → dragHandle; lands on the drag handle
+      // (tabIndex=-1, focusable programmatically by the trap).
+      const dragHandle = tileElement.querySelector('[data-testid="tool-tile-drag-handle"]');
+      expect(document.activeElement).toBe(dragHandle);
     });
 
     it("Tab on selected tile without title/content enters focus trap and reaches toolbar", () => {
@@ -370,23 +371,26 @@ describe("TileComponent focus trap", () => {
       expect(document.activeElement).toBe(toolbarButtons[0]);
     });
 
-    it("Tab from content with no title/toolbar calls preventDefault (defensive)", () => {
-      const { stores, tileModel, contentElement } = renderFocusTrapTile({
+    it("Tab from content with no title/toolbar goes to drag handle", () => {
+      const { stores, tileModel, tileElement, contentElement } = renderFocusTrapTile({
         hasTitle: false, hasToolbar: false,
       });
       act(() => { stores.ui.setSelectedTileId(tileModel.id); });
       act(() => { contentElement!.focus(); });
-      const result = fireEvent.keyDown(contentElement!, { key: "Tab" });
-      expect(result).toBe(false);
-      expect(document.activeElement).toBe(contentElement);
+      fireEvent.keyDown(contentElement!, { key: "Tab" });
+      // dragHandle is always present even when title/toolbar are absent
+      const dragHandle = tileElement.querySelector('[data-testid="tool-tile-drag-handle"]');
+      expect(document.activeElement).toBe(dragHandle);
     });
 
-    it("Tab from content with no toolbar wraps to title", () => {
-      const { stores, tileModel, contentElement, titleElement } = renderFocusTrapTile({ hasToolbar: false });
+    it("Tab from content with no toolbar goes to drag handle", () => {
+      const { stores, tileModel, tileElement, contentElement } = renderFocusTrapTile({ hasToolbar: false });
       act(() => { stores.ui.setSelectedTileId(tileModel.id); });
       act(() => { contentElement!.focus(); });
       fireEvent.keyDown(contentElement!, { key: "Tab" });
-      expect(document.activeElement).toBe(titleElement);
+      // dragHandle is always present even when toolbar is absent
+      const dragHandle = tileElement.querySelector('[data-testid="tool-tile-drag-handle"]');
+      expect(document.activeElement).toBe(dragHandle);
     });
   });
 
@@ -401,25 +405,26 @@ describe("TileComponent focus trap", () => {
       expect(document.activeElement).toBe(titleElement);
     });
 
-    it("Shift+Tab from title wraps backward to the toolbar's active item", () => {
-      const { stores, tileModel, titleElement, toolbarButtons } = renderFocusTrapTile();
+    it("Shift+Tab from title wraps backward to the drag handle", () => {
+      const { stores, tileModel, tileElement, titleElement } = renderFocusTrapTile();
       act(() => { stores.ui.setSelectedTileId(tileModel.id); });
       act(() => { titleElement!.focus(); });
       fireEvent.keyDown(titleElement!, { key: "Tab", shiftKey: true });
-      // Reverse: title → resize (absent) → toolbar; lands on the roving-active
-      // button (the one with tabindex="0"), which is the first button by default.
-      expect(document.activeElement).toBe(toolbarButtons[0]);
+      // Reverse: title → (wrap to end) → resize (absent) → dragHandle
+      const dragHandle = tileElement.querySelector('[data-testid="tool-tile-drag-handle"]');
+      expect(document.activeElement).toBe(dragHandle);
     });
 
-    it("Shift+Tab from content with no title/toolbar calls preventDefault", () => {
-      const { stores, tileModel, contentElement } = renderFocusTrapTile({
+    it("Shift+Tab from content with no title/toolbar goes to drag handle", () => {
+      const { stores, tileModel, tileElement, contentElement } = renderFocusTrapTile({
         hasTitle: false, hasToolbar: false,
       });
       act(() => { stores.ui.setSelectedTileId(tileModel.id); });
       act(() => { contentElement!.focus(); });
-      const result = fireEvent.keyDown(contentElement!, { key: "Tab", shiftKey: true });
-      expect(result).toBe(false);
-      expect(document.activeElement).toBe(contentElement);
+      fireEvent.keyDown(contentElement!, { key: "Tab", shiftKey: true });
+      // Reverse: content → title(absent) → (wrap) → resize(absent) → dragHandle(present)
+      const dragHandle = tileElement.querySelector('[data-testid="tool-tile-drag-handle"]');
+      expect(document.activeElement).toBe(dragHandle);
     });
   });
 
@@ -538,18 +543,18 @@ describe("TileComponent focus trap", () => {
     });
 
     it("Escape on selected tile container deselects (no focusable content case)", () => {
-      // No title, content, or toolbar — simulates sketch/table tile on first frame
-      // (toolbar renders via MobX after setSelectedTileId, so it's not in DOM yet)
+      // No title, content, or toolbar — but drag handle is always present
       const { stores, tileModel, tileElement } = renderFocusTrapTile({
         hasTitle: false, hasContent: false, hasToolbar: false,
       });
       act(() => { tileElement.focus(); });
-      // Enter selects but enterFocusTrap fails — focus stays on container
+      // Enter selects and enters trap — focus moves to drag handle
       fireEvent.keyDown(tileElement, { key: "Enter" });
       expect(stores.ui.selectedTileIds).toContain(tileModel.id);
-      expect(document.activeElement).toBe(tileElement);
-      // Escape should still deselect even though focus is on the container
-      fireEvent.keyDown(tileElement, { key: "Escape" });
+      const dragHandle = tileElement.querySelector('[data-testid="tool-tile-drag-handle"]') as HTMLElement;
+      expect(document.activeElement).toBe(dragHandle);
+      // Escape should deselect
+      fireEvent.keyDown(dragHandle, { key: "Escape" });
       expect(stores.ui.selectedTileIds).not.toContain(tileModel.id);
       expect(document.activeElement).toBe(tileElement);
     });
@@ -700,19 +705,16 @@ describe("TileComponent focus trap", () => {
       expect(liveRegion?.textContent).toBe("Editing tile. Press Escape to exit.");
     });
 
-    it("Enter on tile without focusable content selects tile, focus stays on container", () => {
+    it("Enter on tile without focusable content enters trap via drag handle", () => {
       const { stores, tileModel, tileElement } = renderFocusTrapTile({
         hasTitle: false, hasContent: false, hasToolbar: false,
       });
       act(() => { tileElement.focus(); });
       fireEvent.keyDown(tileElement, { key: "Enter" });
-      // Tile is selected even though enterFocusTrap failed
+      // Tile is selected and focus moves to drag handle (always present)
       expect(stores.ui.selectedTileIds).toContain(tileModel.id);
-      // Focus stays on container
-      expect(document.activeElement).toBe(tileElement);
-      // Fallback announcement
-      const liveRegion = tileElement.querySelector("[role='status'][aria-live='polite']");
-      expect(liveRegion?.textContent).toBe("Tile selected. Press Tab to access toolbar, Escape to exit.");
+      const dragHandle = tileElement.querySelector('[data-testid="tool-tile-drag-handle"]');
+      expect(document.activeElement).toBe(dragHandle);
     });
 
     it("Enter→Escape→Enter round-trip: selection toggles correctly", () => {
@@ -928,6 +930,139 @@ describe("TileComponent focus trap", () => {
       // Focus should stay on resize handle, not exit to tile container
       expect(document.activeElement).toBe(resizeHandle);
       expect(document.activeElement).not.toBe(tileElement);
+    });
+  });
+
+  // --- Drag Handle in Focus Trap ---
+
+  describe("drag handle in focus trap", () => {
+    it("drag handle has tabIndex -1", () => {
+      const { tileElement } = renderFocusTrapTile();
+      const dragHandle = tileElement.querySelector('[data-testid="tool-tile-drag-handle"]');
+      expect(dragHandle).toBeTruthy();
+      expect(dragHandle!.getAttribute("tabindex")).toBe("-1");
+    });
+
+    it("Tab from toolbar goes to drag handle", () => {
+      const { stores, tileModel, tileElement, contentElement } = renderFocusTrapTile();
+      act(() => { stores.ui.setSelectedTileId(tileModel.id); });
+      // Tab from content goes to toolbar (tested elsewhere); Tab again from the
+      // toolbar slot should reach dragHandle. Since the mock toolbar is outside the
+      // tile DOM (FloatingPortal pattern), simulate by focusing content and tabbing
+      // forward twice: content → toolbar → dragHandle.
+      act(() => { contentElement!.focus(); });
+      // First Tab: content → toolbar
+      fireEvent.keyDown(contentElement!, { key: "Tab" });
+      // Second Tab: toolbar → dragHandle (toolbar's own Tab handler runs in
+      // production; here the focus trap controller handles it for the mock toolbar
+      // element registered as an external element in the toolbar slot).
+      // The mock toolbar button is outside tile DOM, so dispatch natively.
+      const activeBtn = document.activeElement as HTMLElement;
+      activeBtn.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab", bubbles: true }));
+      const dragHandle = tileElement.querySelector('[data-testid="tool-tile-drag-handle"]');
+      expect(document.activeElement).toBe(dragHandle);
+    });
+
+    it("Tab from drag handle goes to resize", () => {
+      // Use a resizable tile so the resize handle is present
+      mockTitleElement = document.createElement("input");
+      mockContentElement = document.createElement("div");
+      mockContentElement.setAttribute("tabindex", "-1");
+      mockToolbarElement = document.createElement("div");
+      mockToolbarElement.setAttribute("role", "toolbar");
+      const btn = document.createElement("button");
+      btn.textContent = "Tool";
+      btn.setAttribute("tabindex", "0");
+      mockToolbarElement.appendChild(btn);
+      document.body.appendChild(mockToolbarElement);
+
+      const stores = specStores();
+      const tileContent = TestFocusTrapContent.create();
+      const tileModel = TileModel.create({ content: tileContent });
+      const tileApiInterface = new TileApiInterface();
+
+      render(
+        <Provider stores={stores}>
+          <TileApiInterfaceContext.Provider value={tileApiInterface}>
+            <div className="document-content">
+              <TileComponent
+                context="context"
+                docId="docId"
+                documentContent={null}
+                isUserResizable={true}
+                height={250}
+                model={tileModel}
+                onResizeRow={jest.fn()}
+                onSetCanAcceptDrop={jest.fn()}
+                onRequestRowHeight={jest.fn()}
+              />
+            </div>
+          </TileApiInterfaceContext.Provider>
+        </Provider>
+      );
+
+      const tileElement = screen.getByTestId("tool-tile");
+      if (mockTitleElement) tileElement.appendChild(mockTitleElement);
+      if (mockContentElement) tileElement.appendChild(mockContentElement);
+
+      const dragHandle = tileElement.querySelector('[data-testid="tool-tile-drag-handle"]') as HTMLElement;
+      const resizeHandle = tileElement.querySelector(".tool-tile-resize-handle-wrapper") as HTMLElement;
+
+      act(() => { stores.ui.setSelectedTileId(tileModel.id); });
+      act(() => { dragHandle.focus(); });
+      fireEvent.keyDown(dragHandle, { key: "Tab" });
+      expect(document.activeElement).toBe(resizeHandle);
+    });
+
+    it("Shift+Tab from resize goes to drag handle", () => {
+      // Use a resizable tile so the resize handle is present
+      mockTitleElement = document.createElement("input");
+      mockContentElement = document.createElement("div");
+      mockContentElement.setAttribute("tabindex", "-1");
+      mockToolbarElement = document.createElement("div");
+      mockToolbarElement.setAttribute("role", "toolbar");
+      const btn = document.createElement("button");
+      btn.textContent = "Tool";
+      btn.setAttribute("tabindex", "0");
+      mockToolbarElement.appendChild(btn);
+      document.body.appendChild(mockToolbarElement);
+
+      const stores = specStores();
+      const tileContent = TestFocusTrapContent.create();
+      const tileModel = TileModel.create({ content: tileContent });
+      const tileApiInterface = new TileApiInterface();
+
+      render(
+        <Provider stores={stores}>
+          <TileApiInterfaceContext.Provider value={tileApiInterface}>
+            <div className="document-content">
+              <TileComponent
+                context="context"
+                docId="docId"
+                documentContent={null}
+                isUserResizable={true}
+                height={250}
+                model={tileModel}
+                onResizeRow={jest.fn()}
+                onSetCanAcceptDrop={jest.fn()}
+                onRequestRowHeight={jest.fn()}
+              />
+            </div>
+          </TileApiInterfaceContext.Provider>
+        </Provider>
+      );
+
+      const tileElement = screen.getByTestId("tool-tile");
+      if (mockTitleElement) tileElement.appendChild(mockTitleElement);
+      if (mockContentElement) tileElement.appendChild(mockContentElement);
+
+      const dragHandle = tileElement.querySelector('[data-testid="tool-tile-drag-handle"]') as HTMLElement;
+      const resizeHandle = tileElement.querySelector(".tool-tile-resize-handle-wrapper") as HTMLElement;
+
+      act(() => { stores.ui.setSelectedTileId(tileModel.id); });
+      act(() => { resizeHandle.focus(); });
+      fireEvent.keyDown(resizeHandle, { key: "Tab", shiftKey: true });
+      expect(document.activeElement).toBe(dragHandle);
     });
   });
 });

--- a/src/components/tiles/tile-component.tsx
+++ b/src/components/tiles/tile-component.tsx
@@ -133,7 +133,7 @@ const DragTileButton = (
       onClick={onPickUpClick}
       onKeyDown={handleKeyDown}
       draggable={true}
-      tabIndex={0}
+      tabIndex={-1}
       role="button"
       aria-label={isPickedUp ? "Cancel move" : "Move tile"}
       data-testid="tool-tile-drag-handle"
@@ -557,6 +557,7 @@ class InternalTileComponent extends BaseComponent<IProps, IState> {
       getToolbarElement: () => this.toolbarElement ?? undefined,
       getTopbarElement: () => this.getFocusTrapElements().topbarElement ?? undefined,
       getPaletteElement: () => this.getFocusTrapElements().paletteElement ?? undefined,
+      getDragHandleElement: () => this.dragElement ?? undefined,
       getResizeElement: () => this.resizeElement ?? undefined,
       focusContent: (context) => this.getFocusTrapElements().focusContent?.(context) ?? false,
       onTabWhenInactive: (e, reverse) => this.navigateToSiblingTile(e, reverse),

--- a/src/components/toolbar/tile-toolbar.tsx
+++ b/src/components/toolbar/tile-toolbar.tsx
@@ -163,7 +163,7 @@ export const TileToolbar = observer(
           //   title → topbar → content → palette → toolbar → dragHandle → resize → (wrap)
           // Try candidates in order, skipping any that can't actually receive focus.
           if (e.shiftKey) {
-            // Shift+Tab: toolbar → palette → last content child → title → resize → tile
+            // Shift+Tab: toolbar → palette → last content child → title → resize → dragHandle → tile
             if (!tryFocusPalette()) {
               const focusedLastChild = (() => {
                 if (!contentElement) return false;
@@ -178,7 +178,9 @@ export const TileToolbar = observer(
                 if (!tryFocusContent("reverse")) {
                   if (titleElement) { titleElement.focus(); }
                   if (document.activeElement !== titleElement) {
-                    if (!tryFocusResize()) { tileElement.focus(); }
+                    if (!tryFocusResize()) {
+                      if (!tryFocusDragHandle()) { tileElement.focus(); }
+                    }
                   }
                 }
               }

--- a/src/components/toolbar/tile-toolbar.tsx
+++ b/src/components/toolbar/tile-toolbar.tsx
@@ -112,6 +112,9 @@ export const TileToolbar = observer(
           const titleElement = focusable?.titleElement;
           const focusContentFn = focusable?.focusContent;
           const paletteElement = focusable?.paletteElement;
+          const dragHandle = tileElement.querySelector(
+            ".tool-tile-drag-handle-wrapper"
+          ) as HTMLElement | null;
           const resizeHandle = tileElement.querySelector(
             ".tool-tile-resize-handle-wrapper"
           ) as HTMLElement | null;
@@ -124,6 +127,14 @@ export const TileToolbar = observer(
             if (contentElement) {
               contentElement.focus();
               return document.activeElement === contentElement;
+            }
+            return false;
+          };
+
+          const tryFocusDragHandle = () => {
+            if (dragHandle) {
+              dragHandle.focus();
+              return document.activeElement === dragHandle;
             }
             return false;
           };
@@ -149,7 +160,7 @@ export const TileToolbar = observer(
           };
 
           // Cycle (matches the focus-trap controller's cycleOrder):
-          //   title → topbar → content → palette → toolbar → resize → (wrap)
+          //   title → topbar → content → palette → toolbar → dragHandle → resize → (wrap)
           // Try candidates in order, skipping any that can't actually receive focus.
           if (e.shiftKey) {
             // Shift+Tab: toolbar → palette → last content child → title → resize → tile
@@ -173,11 +184,13 @@ export const TileToolbar = observer(
               }
             }
           } else {
-            // Tab: toolbar → resize → title → content → tile
-            if (!tryFocusResize()) {
-              if (titleElement) { titleElement.focus(); }
-              if (document.activeElement !== titleElement) {
-                if (!tryFocusContent("forward")) { tileElement.focus(); }
+            // Tab: toolbar → dragHandle → resize → title → content → tile
+            if (!tryFocusDragHandle()) {
+              if (!tryFocusResize()) {
+                if (titleElement) { titleElement.focus(); }
+                if (document.activeElement !== titleElement) {
+                  if (!tryFocusContent("forward")) { tileElement.focus(); }
+                }
               }
             }
           }

--- a/src/hooks/create-clue-tile-strategy.ts
+++ b/src/hooks/create-clue-tile-strategy.ts
@@ -23,6 +23,8 @@ export function createClueTileStrategy(config: ClueFocusTrapConfig): FocusTrapSt
     ?? (() => config.paletteRef?.current ?? undefined);
   const getResize = config.getResizeElement
     ?? (() => config.resizeRef?.current ?? undefined);
+  const getDragHandle = config.getDragHandleElement
+    ?? (() => config.dragHandleRef?.current ?? undefined);
 
   const ariaLabels = getAriaLabels();
   // Prefer the user-facing displayName ("Coordinate Grid" for `geometry`); the
@@ -36,14 +38,13 @@ export function createClueTileStrategy(config: ClueFocusTrapConfig): FocusTrapSt
       toolbar: getToolbar(),
       topbar: getTopbar(),
       palette: getPalette(),
+      dragHandle: getDragHandle(),
       resize: getResize(),
     }),
     focusContent: config.focusContent,
-    // topbar: optional controls strip above the editor (e.g. dataflow).
-    // palette: inline secondary toolbar — single tab stop with arrow roving.
-    // Slots with undefined elements are skipped, so tiles without
-    // topbar/palette are unaffected.
-    cycleOrder: ["title", "topbar", "content", "palette", "toolbar", "resize"],
+    // dragHandle sits between toolbar and resize for keyboard tile pick-up.
+    // Slots with undefined elements are skipped.
+    cycleOrder: ["title", "topbar", "content", "palette", "toolbar", "dragHandle", "resize"],
     // Default within-slot Tab routing covers topbar + content. Tiles can opt
     // palette in via config when its controls are heterogeneous (XY Plot's
     // legend), or leave it out for arrow-roved palettes (dataflow's Add-block).
@@ -54,6 +55,7 @@ export function createClueTileStrategy(config: ClueFocusTrapConfig): FocusTrapSt
       const toolbar = getToolbar();
       return toolbar ? [toolbar] : [];
     },
+    externalElementsSlot: "toolbar",
     onTabWhenInactive: config.onTabWhenInactive,
     escapeHandlers: config.escapeHandlers,
     tabHandlers: config.tabHandlers,

--- a/src/hooks/use-clue-accessibility.test.tsx
+++ b/src/hooks/use-clue-accessibility.test.tsx
@@ -59,7 +59,7 @@ describe("createClueTileStrategy", () => {
     expect(elements.toolbar).toBeUndefined();
   });
 
-  it("sets cycle order to title/topbar/content/palette/toolbar/resize", () => {
+  it("sets cycle order to title/topbar/content/palette/toolbar/dragHandle/resize", () => {
     const strategy = createClueTileStrategy({
       onRegisterTileApi: jest.fn(),
       onUnregisterTileApi: jest.fn(),
@@ -71,7 +71,7 @@ describe("createClueTileStrategy", () => {
     // and toolbar so it can be a single tab stop. Tiles that don't provide topbar
     // or palette elements have those slots skipped by the trap's findNextSlot.
     expect(strategy.cycleOrder).toEqual(
-      ["title", "topbar", "content", "palette", "toolbar", "resize"]);
+      ["title", "topbar", "content", "palette", "toolbar", "dragHandle", "resize"]);
   });
 
   it("falls back to the tile type id in announcements when no displayName is registered", () => {

--- a/src/hooks/use-clue-accessibility.ts
+++ b/src/hooks/use-clue-accessibility.ts
@@ -49,6 +49,10 @@ export interface ClueFocusTrapConfig {
   paletteRef?: RefObject<HTMLElement | null>;
   getPaletteElement?: () => HTMLElement | undefined;
 
+  // Drag handle element for keyboard tile pick-up
+  dragHandleRef?: RefObject<HTMLElement | null>;
+  getDragHandleElement?: () => HTMLElement | undefined;
+
   // Resize handle element
   resizeRef?: RefObject<HTMLElement | null>;
   getResizeElement?: () => HTMLElement | undefined;
@@ -155,6 +159,7 @@ export function useClueAccessibility(options: ClueAccessibilityOptions): Accessi
         focusContent: strategy.focusContent,
         topbarElement: elements.topbar,
         paletteElement: elements.palette,
+        dragHandleElement: elements.dragHandle,
         tabWithinSlots: strategy.tabWithinSlots,
         tabHandlers: strategy.tabHandlers,
         escapeHandlers: strategy.escapeHandlers,


### PR DESCRIPTION
This PR adds the dragger handle on the worksheet tiles to the focus ring in each tile type. As with the work on CLUE-531, these can be activated by Enter and the tiles can then be moved around in the document using arrow keys and enter to drop. 