### PR TITLE
fix: teacher guide ordinal defaults to 1, auto-save teacher guide con…

### DIFF
--- a/src/authoring/components/workspace/container-config/container-config-helpers.test.ts
+++ b/src/authoring/components/workspace/container-config/container-config-helpers.test.ts
@@ -6,6 +6,7 @@ import {
   isProblem,
   buildProblemSectionsFormData,
   parseItemPath,
+  coerceFirstOrdinal,
 } from "./container-config-helpers";
 
 const makeProblem = (ordinal: number, title: string, sections: string[] = []): IProblem => ({
@@ -283,5 +284,27 @@ describe("buildProblemSectionsFormData", () => {
     expect(result.every(s => s.type !== "unknownType")).toBe(true);
     expect(result).toHaveLength(3); // just the 3 available sections, all disabled
     expect(result.every(s => !s.enabled)).toBe(true);
+  });
+});
+
+describe("coerceFirstOrdinal", () => {
+  it("returns a finite number unchanged", () => {
+    expect(coerceFirstOrdinal(0)).toBe(0);
+    expect(coerceFirstOrdinal(1)).toBe(1);
+    expect(coerceFirstOrdinal(5)).toBe(5);
+    expect(coerceFirstOrdinal(-2)).toBe(-2);
+  });
+
+  it("defaults to 1 for NaN (e.g. an empty number input via valueAsNumber)", () => {
+    expect(coerceFirstOrdinal(NaN)).toBe(1);
+  });
+
+  it("defaults to 1 for undefined", () => {
+    expect(coerceFirstOrdinal(undefined)).toBe(1);
+  });
+
+  it("defaults to 1 for non-finite values", () => {
+    expect(coerceFirstOrdinal(Infinity)).toBe(1);
+    expect(coerceFirstOrdinal(-Infinity)).toBe(1);
   });
 });

--- a/src/authoring/components/workspace/container-config/container-config-helpers.ts
+++ b/src/authoring/components/workspace/container-config/container-config-helpers.ts
@@ -2,6 +2,15 @@ import { IInvestigation, IProblem, ISection, IUnit } from "../../../types";
 import { CurriculumItem, getSectionTypeFromPath } from "../../../utils/nav-path";
 import { ProblemSectionFormItem } from "./container-config-types";
 
+// The firstOrdinal is required, but an empty number input yields NaN
+// (the field is registered with valueAsNumber: true), and NaN ?? 1 doesn't
+// trigger the fallback. Stale content may also have persisted a NaN ordinal.
+// This guards both the form defaults and the submit handler so the ordinal is
+// always a real number.
+export function coerceFirstOrdinal(value: number | undefined): number {
+  return Number.isFinite(value) ? value as number : 1;
+}
+
 export function isUnit(item: CurriculumItem): item is IUnit {
   return "investigations" in item && Array.isArray(item.investigations);
 }

--- a/src/authoring/components/workspace/container-config/container-config.tsx
+++ b/src/authoring/components/workspace/container-config/container-config.tsx
@@ -9,7 +9,7 @@ import {
 import { WritableDraft } from "immer";
 import { IProblemFormInputs, IUnitParentFormInputs, UnitChild } from "./container-config-types";
 import {
-  isUnit, isInvestigation, isProblem, buildProblemSectionsFormData, parseItemPath,
+  isUnit, isInvestigation, isProblem, buildProblemSectionsFormData, parseItemPath, coerceFirstOrdinal,
 } from "./container-config-helpers";
 import { UnitItemChildren } from "./unit-item-children";
 import { ProblemSections } from "./problem-sections";
@@ -87,7 +87,7 @@ export const ContainerConfig: React.FC<Props> = ({ path }) => {
       childType: _childType,
       defaultValues: {
         title: item.title,
-        firstOrdinal: Number.isFinite(firstOrdinal) ? firstOrdinal : 1,
+        firstOrdinal: coerceFirstOrdinal(firstOrdinal),
         children
       }
     };
@@ -188,9 +188,7 @@ export const ContainerConfig: React.FC<Props> = ({ path }) => {
       if (!currentItem) return;
 
       currentItem.title = data.title;
-      // The firstOrdinal is required, but an empty number input yields NaN
-      // (valueAsNumber: true), and NaN ?? 1 doesn't trigger the fallback.
-      const firstOrdinal = (Number.isFinite(data.firstOrdinal) ? data.firstOrdinal : 1) as number;
+      const firstOrdinal = coerceFirstOrdinal(data.firstOrdinal);
 
       if (isUnit(currentItem)) {
         // update investigations

--- a/src/authoring/components/workspace/container-config/container-config.tsx
+++ b/src/authoring/components/workspace/container-config/container-config.tsx
@@ -87,7 +87,7 @@ export const ContainerConfig: React.FC<Props> = ({ path }) => {
       childType: _childType,
       defaultValues: {
         title: item.title,
-        firstOrdinal,
+        firstOrdinal: firstOrdinal ?? 1,
         children
       }
     };
@@ -188,8 +188,9 @@ export const ContainerConfig: React.FC<Props> = ({ path }) => {
       if (!currentItem) return;
 
       currentItem.title = data.title;
-      // The firstOrdinal is required, but just to be safe we default to 1
-      const firstOrdinal = data.firstOrdinal ?? 1;
+      // The firstOrdinal is required, but an empty number input yields NaN
+      // (valueAsNumber: true), and NaN ?? 1 doesn't trigger the fallback.
+      const firstOrdinal = (Number.isFinite(data.firstOrdinal) ? data.firstOrdinal : 1) as number;
 
       if (isUnit(currentItem)) {
         // update investigations

--- a/src/authoring/components/workspace/container-config/container-config.tsx
+++ b/src/authoring/components/workspace/container-config/container-config.tsx
@@ -87,7 +87,7 @@ export const ContainerConfig: React.FC<Props> = ({ path }) => {
       childType: _childType,
       defaultValues: {
         title: item.title,
-        firstOrdinal: firstOrdinal ?? 1,
+        firstOrdinal: Number.isFinite(firstOrdinal) ? firstOrdinal : 1,
         children
       }
     };

--- a/src/authoring/hooks/use-curriculum.tsx
+++ b/src/authoring/hooks/use-curriculum.tsx
@@ -60,7 +60,7 @@ export const CurriculumProvider: React.FC<{children: React.ReactNode}> = ({ chil
   const [unit, _setUnit] = useImmer<string | undefined>(undefined);
   const [path, setPath] = useImmer<string | undefined>(undefined);
   const [unitConfig, _setUnitConfig] = useImmer<IUnit | undefined>(undefined);
-  const [teacherGuideConfig, setTeacherGuideConfig] = useImmer<IUnit | undefined>(undefined);
+  const [teacherGuideConfig, _setTeacherGuideConfig] = useImmer<IUnit | undefined>(undefined);
   const [files, setFiles] = useImmer<IUnitFiles | undefined>(undefined);
   const [error, setError] = useImmer<string | undefined>(undefined);
   const lastUnitRef = useRef<string | undefined>(undefined);
@@ -69,6 +69,7 @@ export const CurriculumProvider: React.FC<{children: React.ReactNode}> = ({ chil
   const [branchMetadata, setBranchMetadata] = useImmer<BranchMetadata>({});
   const [exemplarFiles, setExemplarFiles] = useImmer<ExemplarFile[]>([]);
   const saveUnitConfigRef = useRef(false);
+  const saveTeacherGuideConfigRef = useRef(false);
   const saveStateClearTimeoutRef = useRef<number>();
 
   const reset = useCallback(() => {
@@ -84,6 +85,11 @@ export const CurriculumProvider: React.FC<{children: React.ReactNode}> = ({ chil
   const setUnitConfig: Updater<IUnit | undefined> = (draft) => {
     saveUnitConfigRef.current = true;
     _setUnitConfig(draft);
+  };
+
+  const setTeacherGuideConfig: Updater<IUnit | undefined> = (draft) => {
+    saveTeacherGuideConfigRef.current = true;
+    _setTeacherGuideConfig(draft);
   };
 
   const setUnit = useCallback(
@@ -209,20 +215,20 @@ export const CurriculumProvider: React.FC<{children: React.ReactNode}> = ({ chil
         .get("/getContent", { branch, unit, path: "teacher-guide/content.json" })
         .then((contentResponse) => {
           if (!contentResponse.success) {
-            setTeacherGuideConfig(undefined);
+            _setTeacherGuideConfig(undefined);
             return;
           }
-          setTeacherGuideConfig(contentResponse.content);
+          _setTeacherGuideConfig(contentResponse.content);
         })
-        .catch((err) => {
-          setTeacherGuideConfig(undefined);
+        .catch(() => {
+          _setTeacherGuideConfig(undefined);
         });
     }
 
     // Note: we don't have a cleanup function to turn off the listener
     // because we want to keep listening for changes until branch or unit changes.
     // The filesRef.current?.off() above is what turns off the previous listener.
-  }, [api, branch, setError, setFiles, _setUnitConfig, setTeacherGuideConfig, unit]);
+  }, [api, branch, setError, setFiles, _setUnitConfig, _setTeacherGuideConfig, unit]);
 
   const saveContent = useCallback(async (contentPath: string, updatedContent: any) => {
     if (!branch || !unit) {
@@ -268,6 +274,14 @@ export const CurriculumProvider: React.FC<{children: React.ReactNode}> = ({ chil
       saveContent("content.json", unitConfig);
     }
   }, [branch, unit, unitConfig, saveContent]);
+
+  useEffect(() => {
+    // save teacher guide config changes
+    if (teacherGuideConfig && saveTeacherGuideConfigRef.current && branch && unit) {
+      saveTeacherGuideConfigRef.current = false;
+      saveContent("teacher-guide/content.json", teacherGuideConfig);
+    }
+  }, [branch, unit, teacherGuideConfig, saveContent]);
 
   useEffect(() => {
     const newExemplarFiles = Object.entries(files || {})


### PR DESCRIPTION
CLUE-536

Two fixes for teacher guide problems not showing up in preview in authoring:

1. Ordinal bug: empty number input yields NaN via valueAsNumber, and NaN ?? 1 doesn't trigger the fallback. Changed to Number.isFinite() check and defaulted firstOrdinal to 1 for new containers.

2. Auto-save: teacherGuideConfig changes were never persisted. Added saveTeacherGuideConfigRef + useEffect mirroring the unitConfig pattern, saving to teacher-guide/content.json on change.