### PR TITLE
Add iframeUrl url param.

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ There are a number of URL parameters that can aid in testing:
 |`includeModelInAiSummary`|`true`          |When set to true the JSON.stringified raw model is included in the AI summary|
 |`fakeAuthoringAuth`|`true`                |When set to true the authoring system fakes the GitHub login|
 |`authoringBranch`  |string                |When set to a value the runtime knows it should use the authoring api to get content using the specified branch|
+|`iframeUrl`        |string (escaped url)  |Used as the url for iframe interactive tiles, overriding the url specified in the unit's config.
 
 The `unit` parameter can be in 3 forms:
 

--- a/src/plugins/iframe-interactive/iframe-interactive-tile-content.test.ts
+++ b/src/plugins/iframe-interactive/iframe-interactive-tile-content.test.ts
@@ -186,7 +186,7 @@ describe("IframeInteractiveContent", () => {
       delete (urlParams as any).iframeUrl;
     });
 
-    it("uses the iframeUrl url param even when a url is specified in the config", () => {
+    it("uses a legal iframeUrl url param even when a url is specified in the config", () => {
       urlParams.iframeUrl = "https://example.com/from-url-param";
       const appConfig = AppConfigModel.create({
         config: {
@@ -198,8 +198,17 @@ describe("IframeInteractiveContent", () => {
           }
         }
       });
-      const content = defaultIframeInteractiveContent({ appConfig });
+      let content = defaultIframeInteractiveContent({ appConfig });
       expect(content.url).toBe("https://example.com/from-url-param");
+
+      // Does not use illegal urls specified in iframeUrl param
+      urlParams.iframeUrl = "ftp://illegal.com";
+      content = defaultIframeInteractiveContent({ appConfig });
+      expect(content.url).toBe("https://example.com/from-config");
+
+      urlParams.iframeUrl = ["https://legal1.com", "https://legal2.com"] as any;
+      content = defaultIframeInteractiveContent({ appConfig });
+      expect(content.url).toBe("https://example.com/from-config");
     });
   });
 });

--- a/src/plugins/iframe-interactive/iframe-interactive-tile-content.test.ts
+++ b/src/plugins/iframe-interactive/iframe-interactive-tile-content.test.ts
@@ -2,6 +2,7 @@ import { defaultIframeInteractiveContent, IframeInteractiveContentModel } from "
 import { kIframeInteractiveTileType } from "./iframe-interactive-tile-types";
 import { AppConfigModel } from "../../models/stores/app-config-model";
 import { unitConfigDefaults } from "../../test-fixtures/sample-unit-configurations";
+import { urlParams } from "../../utilities/url-params";
 
 describe("IframeInteractiveContent", () => {
   it("has default empty url and states", () => {
@@ -177,6 +178,28 @@ describe("IframeInteractiveContent", () => {
       expect(content.authoredState).toEqual({});
       expect(content.maxHeight).toBe(0);
       expect(content.enableScroll).toBe(false);
+    });
+  });
+
+  describe("iframeUrl url param", () => {
+    afterEach(() => {
+      delete (urlParams as any).iframeUrl;
+    });
+
+    it("uses the iframeUrl url param even when a url is specified in the config", () => {
+      urlParams.iframeUrl = "https://example.com/from-url-param";
+      const appConfig = AppConfigModel.create({
+        config: {
+          ...unitConfigDefaults,
+          settings: {
+            iframeInteractive: {
+              url: "https://example.com/from-config"
+            }
+          }
+        }
+      });
+      const content = defaultIframeInteractiveContent({ appConfig });
+      expect(content.url).toBe("https://example.com/from-url-param");
     });
   });
 });

--- a/src/plugins/iframe-interactive/iframe-interactive-tile-content.ts
+++ b/src/plugins/iframe-interactive/iframe-interactive-tile-content.ts
@@ -4,11 +4,24 @@ import { IDefaultContentOptions } from "../../models/tiles/tile-content-info";
 import { kIframeInteractiveTileType } from "./iframe-interactive-tile-types";
 import stringify from "json-stringify-pretty-compact";
 import { urlParams } from "../../utilities/url-params";
+import { isValidHttpUrl } from "../../utilities/url-utils";
 
 export function defaultIframeInteractiveContent(options?: IDefaultContentOptions): IframeInteractiveContentModelType {
   const settings = options?.appConfig?.getSetting("iframeInteractive") as Record<string, any> | undefined;
+  let url = settings?.url ?? "";
+
+  // Use legal url from urlParams if possible
+  const { iframeUrl } = urlParams;
+  if (iframeUrl != null) {
+    if (typeof iframeUrl === "string" && isValidHttpUrl(iframeUrl)) {
+      url = iframeUrl;
+    } else {
+      console.warn("Illegal iframeUrl parameter", iframeUrl);
+    }
+  }
+
   return IframeInteractiveContentModel.create({
-    url: urlParams.iframeUrl ?? settings?.url ?? "",
+    url,
     interactiveState: settings?.interactiveState ?? {},
     authoredState: settings?.authoredState ?? {},
     maxHeight: settings?.maxHeight ?? 0,

--- a/src/plugins/iframe-interactive/iframe-interactive-tile-content.ts
+++ b/src/plugins/iframe-interactive/iframe-interactive-tile-content.ts
@@ -3,11 +3,12 @@ import { TileContentModel } from "../../models/tiles/tile-content";
 import { IDefaultContentOptions } from "../../models/tiles/tile-content-info";
 import { kIframeInteractiveTileType } from "./iframe-interactive-tile-types";
 import stringify from "json-stringify-pretty-compact";
+import { urlParams } from "../../utilities/url-params";
 
 export function defaultIframeInteractiveContent(options?: IDefaultContentOptions): IframeInteractiveContentModelType {
   const settings = options?.appConfig?.getSetting("iframeInteractive") as Record<string, any> | undefined;
   return IframeInteractiveContentModel.create({
-    url: settings?.url ?? "",
+    url: urlParams.iframeUrl ?? settings?.url ?? "",
     interactiveState: settings?.interactiveState ?? {},
     authoredState: settings?.authoredState ?? {},
     maxHeight: settings?.maxHeight ?? 0,

--- a/src/utilities/url-params.ts
+++ b/src/utilities/url-params.ts
@@ -146,6 +146,8 @@ export interface QueryParams {
 
   // Show the log monitor sidebar
   logMonitor?: boolean;
+  // Url to use for iframe tiles. Supercedes the url specified in config.
+  iframeUrl?: string;
 }
 
 // Make a union of all of the boolean params from the QueryParams

--- a/src/utilities/url-params.ts
+++ b/src/utilities/url-params.ts
@@ -146,7 +146,7 @@ export interface QueryParams {
 
   // Show the log monitor sidebar
   logMonitor?: boolean;
-  // Url to use for iframe tiles. Supercedes the url specified in config.
+  // Url to use for iframe tiles. Supersedes the URL specified in config.
   iframeUrl?: string;
 }
 


### PR DESCRIPTION
This PR adds the `iframeUrl` url parameter, which overrides the url used for iframe interactive tiles.