### PR TITLE
fix: dataflow block titles uneditable, demo output images draggable (…

### DIFF
--- a/src/plugins/dataflow/nodes/controls/demo-output-control.scss
+++ b/src/plugins/dataflow/nodes/controls/demo-output-control.scss
@@ -3,6 +3,11 @@
 .demo-output-control {
   position: relative;
 
+  img {
+    -webkit-user-drag: none;
+    user-drag: none;
+  }
+
   .demo-output-image {
     position: absolute;
   }

--- a/src/plugins/dataflow/nodes/controls/demo-output-control.tsx
+++ b/src/plugins/dataflow/nodes/controls/demo-output-control.tsx
@@ -59,7 +59,11 @@ export const DemoOutputControlComponent: React.FC<{ data: DemoOutputControl }> =
   });
 
   return (
-    <div className={`demo-output-control ${controlClassName}`}>
+    <div
+      className={`demo-output-control ${controlClassName}`}
+      draggable={false}
+      onDragStart={e => e.preventDefault()}
+    >
       { type === "Light Bulb" &&
         <img
           src={ value1 ? lightBulbOn : lightBulbOff }

--- a/src/plugins/dataflow/nodes/editable-node-name.tsx
+++ b/src/plugins/dataflow/nodes/editable-node-name.tsx
@@ -54,6 +54,7 @@ export const EditableNodeName: React.FC<EditableNodeNameProps> = observer(
           onBlur={saveNodeName}
           readOnly={node.readOnly}
           onKeyDown={handleKeyDown}
+          onPointerDown={e => e.stopPropagation()}
         />
       </div>
     );

--- a/src/plugins/dataflow/nodes/editable-node-name.tsx
+++ b/src/plugins/dataflow/nodes/editable-node-name.tsx
@@ -2,6 +2,7 @@ import React, { useRef, useState } from 'react';
 import { IBaseNode } from './base-node';
 import { observer } from 'mobx-react';
 import { handleBlockChildKeyDown } from './dataflow-node';
+import { useStopEventPropagation } from './controls/custom-hooks';
 
 interface EditableNodeNameProps {
   node: IBaseNode;
@@ -43,9 +44,14 @@ export const EditableNodeName: React.FC<EditableNodeNameProps> = observer(
 
     const valueString = node.readOnly ? node.model.orderedDisplayName : nodeName;
 
+    const inputRef = useRef<HTMLInputElement>(null);
+    useStopEventPropagation(inputRef, "pointerdown");
+    useStopEventPropagation(inputRef, "dblclick");
+
     return (
       <div className="node-name">
         <input
+          ref={inputRef}
           className="node-name-input"
           aria-label="Block name"
           tabIndex={-1}
@@ -54,7 +60,6 @@ export const EditableNodeName: React.FC<EditableNodeNameProps> = observer(
           onBlur={saveNodeName}
           readOnly={node.readOnly}
           onKeyDown={handleKeyDown}
-          onPointerDown={e => e.stopPropagation()}
         />
       </div>
     );


### PR DESCRIPTION
…CLUE-540)

Two fixes:

1. Block title inputs couldn't receive focus from mouse clicks because rete's area plugin pointerdown handler (for node dragging) captured the event before the input. Fixed by stopping pointer propagation on the input element.

2. Demo Output node images could be dragged out and dropped into image or sketch tiles. Fixed by preventing dragStart on the container and disabling user-drag on images via CSS.