### PR TITLE
Clue 542 show hide setting to agree disagree on comments

### DIFF
--- a/src/authoring/components/workspace/ai-settings.tsx
+++ b/src/authoring/components/workspace/ai-settings.tsx
@@ -16,6 +16,7 @@ interface CommentTag {
 interface AISettingsFormInputs {
   commentTags: CommentTag[];
   enableCommentRoles: CommentRole[];
+  showCommentRating: boolean;
   aiEvaluation?: AIEvaluation | "";
   aiPrompt: {
     systemPrompt: string;
@@ -57,9 +58,12 @@ const AISettings: React.FC = () => {
 
     const aiTileAvailable = unitConfig?.config?.authorTools?.find(tool => isAIAuthorTool(tool)) !== undefined;
 
+    const showCommentRating = unitConfig?.config?.showCommentRating ?? true;
+
     return {
       commentTags: commentTags ?? [],
       enableCommentRoles: enableCommentRoles ?? [],
+      showCommentRating,
       aiEvaluation,
       aiPrompt: {
         systemPrompt: aiPrompt?.systemPrompt ?? "",
@@ -127,6 +131,7 @@ const AISettings: React.FC = () => {
           return obj;
         }, {} as Record<string, string>);
         config.enableCommentRoles = data.enableCommentRoles;
+        config.showCommentRating = data.showCommentRating;
 
         const categories = Object.keys(config.commentTags);
 
@@ -194,6 +199,10 @@ const AISettings: React.FC = () => {
               </label>
             ))}
           </div>
+          <label className="horizontal middle">
+            <input type="checkbox" {...register("showCommentRating")} />
+            <span>Show agree/disagree rating buttons on comments</span>
+          </label>
         </fieldset>
       </div>
       <table>

--- a/src/authoring/types.ts
+++ b/src/authoring/types.ts
@@ -44,6 +44,7 @@ export interface IUnitConfig {
   stamps: IStamp[];
   settings: ISettings;
   showCommentTag: boolean;
+  showCommentRating: boolean;
   commentTags: Record<string, string>;
   enableCommentRoles: CommentRole[];
   aiEvaluation?: AIEvaluation;

--- a/src/components/chat/comment-card.test.tsx
+++ b/src/components/chat/comment-card.test.tsx
@@ -206,3 +206,77 @@ describe("CommentCard", () => {
     expect(mockUpdateRating).toHaveBeenCalledWith("documents/doc1/comments/c1", "yes");
   });
 });
+
+describe("CommentCard with showCommentRating disabled", () => {
+  const testUser = { id: "0", name: "Test Teacher" } as UserModelType;
+
+  // Override the mock to disable ratings
+  const configWithRatingsDisabled = {
+    ...unitConfigDefaults,
+    showCommentRating: false
+  };
+
+  beforeEach(() => {
+    const useStoresMock = jest.requireMock("../../hooks/use-stores");
+    useStoresMock.useStores = () => ({
+      appConfig: AppConfigModel.create({ config: configWithRatingsDisabled }),
+      class: {
+        getUserById: () => ({ id: "0", type: "student", name: "Test Student" } as UserModelType)
+      }
+    });
+  });
+
+  afterEach(() => {
+    // Restore original mock
+    const useStoresMock = jest.requireMock("../../hooks/use-stores");
+    useStoresMock.useStores = () => ({
+      appConfig: AppConfigModel.create({ config: unitConfigDefaults }),
+      class: {
+        getUserById: () => ({ id: "0", type: "student", name: "Test Student" } as UserModelType)
+      }
+    });
+  });
+
+  it("hides rating buttons when showCommentRating is false", () => {
+    const postedComments: WithId<CommentDocument>[] = [
+      { id: "c1", uid: "1", name: "User1", createdAt: new Date(), content: "hello" }
+    ];
+    render((
+      <ModalProvider>
+        <CommentCard user={testUser} postedComments={postedComments} focusDocument="doc1" />
+      </ModalProvider>
+    ));
+    expect(screen.queryByTestId("comment-rating-buttons")).not.toBeInTheDocument();
+  });
+
+  it("still renders comments when ratings are hidden", () => {
+    const postedComments: WithId<CommentDocument>[] = [
+      { id: "c1", uid: "1", name: "User1", createdAt: new Date(), content: "hello world" }
+    ];
+    render((
+      <ModalProvider>
+        <CommentCard user={testUser} postedComments={postedComments} focusDocument="doc1" />
+      </ModalProvider>
+    ));
+    expect(screen.getByText("hello world")).toBeInTheDocument();
+    expect(screen.queryByTestId("comment-rating-buttons")).not.toBeInTheDocument();
+  });
+
+  it("preserves existing ratings data when buttons are hidden", () => {
+    const postedComments: WithId<CommentDocument>[] = [
+      {
+        id: "c1", uid: "1", name: "User1", createdAt: new Date(), content: "rated comment",
+        ratings: { "u1": "yes", "u2": "no" }
+      }
+    ];
+    render((
+      <ModalProvider>
+        <CommentCard user={testUser} postedComments={postedComments} focusDocument="doc1" />
+      </ModalProvider>
+    ));
+    // Comment renders but ratings UI is hidden — data is preserved in the model
+    expect(screen.getByText("rated comment")).toBeInTheDocument();
+    expect(screen.queryByTestId("comment-rating-buttons")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("rating-yes-button")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/chat/comment-card.tsx
+++ b/src/components/chat/comment-card.tsx
@@ -133,7 +133,7 @@ export const CommentCard: React.FC<IProps> = ({ activeNavTab, user, postedCommen
   const commentContentRef = useRef<string>("");
   const stores = useStores();
   const { appConfig, documents, persistentUI, sortedDocuments } = stores;
-  const { showCommentTag, commentTags } = appConfig;
+  const { showCommentTag, showCommentRating, commentTags } = appConfig;
   const content = useCurriculumOrDocumentContent(focusDocument);
 
   const alertContent = () => {
@@ -192,6 +192,7 @@ export const CommentCard: React.FC<IProps> = ({ activeNavTab, user, postedCommen
   ];
 
   const renderRatingButtons = (comment: WithId<CommentDocument>) => {
+    if (!showCommentRating) return null;
     const counts = countRatings(comment.ratings);
     const myRating = user?.id ? comment.ratings?.[user.id] : undefined;
 

--- a/src/components/navigation/section-document-or-browser.tsx
+++ b/src/components/navigation/section-document-or-browser.tsx
@@ -76,6 +76,12 @@ export const SectionDocumentOrBrowser: React.FC<IProps> = observer(function Sect
       }
       persistentUI.openDocumentGroupPrimaryDocument(tabSpec.tab, selectedSubTab.label, document.key);
       logDocumentViewEvent(document);
+
+      // Auto-open the comment panel when viewing a published document,
+      // if comments are enabled for the current user's role.
+      if (document.isPublished && appConfigStore.showCommentPanelFor(user?.type)) {
+        persistentUI.toggleShowChatPanel(true);
+      }
     }
   };
 

--- a/src/components/navigation/section-document-or-browser.tsx
+++ b/src/components/navigation/section-document-or-browser.tsx
@@ -79,7 +79,7 @@ export const SectionDocumentOrBrowser: React.FC<IProps> = observer(function Sect
 
       // Auto-open the comment panel when viewing a published document,
       // if comments are enabled for the current user's role.
-      if (document.isPublished && appConfigStore.showCommentPanelFor(user?.type)) {
+      if (document.isPublished && appConfigStore.showCommentPanelFor(user.type)) {
         persistentUI.toggleShowChatPanel(true);
       }
     }

--- a/src/models/stores/app-config-model.ts
+++ b/src/models/stores/app-config-model.ts
@@ -79,6 +79,7 @@ export const AppConfigModel = types
     get defaultLearningLogDocument() { return self.configMgr.defaultLearningLogDocument; },
     get autoSectionProblemDocuments() { return self.configMgr.autoSectionProblemDocuments; },
     get showCommentTag() { return self.configMgr.showCommentTag; },
+    get showCommentRating() { return self.configMgr.showCommentRating ?? true; },
     get commentTags() { return self.configMgr.commentTags; },
     get aiEvaluation() { return self.configMgr.aiEvaluation; },
     get aiPrompt() { return self.configMgr.aiPrompt; },

--- a/src/models/stores/configuration-manager.ts
+++ b/src/models/stores/configuration-manager.ts
@@ -43,6 +43,10 @@ export class ConfigurationManager implements UnitConfiguration {
     return this.getProp<UC["showCommentTag"]>("showCommentTag");
   }
 
+  get showCommentRating(){
+    return this.getProp<UC["showCommentRating"]>("showCommentRating");
+  }
+
   get commentTags(){
     return  (this.showCommentTag) ? this.getProp<UC["commentTags"]>("commentTags") : {};
   }

--- a/src/models/stores/unit-configuration.ts
+++ b/src/models/stores/unit-configuration.ts
@@ -96,6 +96,8 @@ export interface UnitConfiguration extends ProblemConfiguration {
   navTabs: SnapshotIn<typeof NavTabsConfigModel>;
   // must be true for any of the comment-tag functionality to be enabled
   showCommentTag?: boolean;
+  // when false, hides agree/disagree/not-sure rating buttons on comments (default: true)
+  showCommentRating?: boolean;
   // list of possible values for tagging in comments
   commentTags?: Record<string, string>;
   // if set, enable the specified AI evaluation to run after document updates


### PR DESCRIPTION
New authoring and unit setting to hide 'agreements' in comments and a behavior that auto-opens comments for published documents in units which show them.