### PR TITLE
fix: reduce daily regression CI flakiness (CLUE-551)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,8 @@
 engine-strict=true
+
+# Retry package fetches more aggressively so transient registry errors
+# (e.g. ECONNRESET from registry.npmjs.org) don't fail CI installs.
+fetch-retries=5
+fetch-retry-factor=2
+fetch-retry-mintimeout=10000
+fetch-retry-maxtimeout=60000

--- a/cypress/e2e/functional/tile_tests/bar_graph_tile_spec.js
+++ b/cypress/e2e/functional/tile_tests/bar_graph_tile_spec.js
@@ -542,9 +542,7 @@ context('Bar Graph Tile', function () {
     cy.get(`body [data-testid="color-menu-list"]:visible`).should('not.exist');
     barGraph.getBar().eq(0).should('have.attr', 'fill', clueDataColors[1]);
     barGraph.getBar().eq(1).should('have.attr', 'fill', clueDataColors[0]);
-    barGraph.getBarColorButton().eq(1).click({force: true});
-    barGraph.getBarColorMenu(workspace, tileIndex).should('be.visible');
-    barGraph.getBarColorMenuButtons(workspace, tileIndex).eq(2).click({force: true});
+    barGraph.selectBarColor(1, 2, workspace, tileIndex);
     barGraph.getBar().eq(0).should('have.attr', 'fill', clueDataColors[1]);
     barGraph.getBar().eq(1).should('have.attr', 'fill', clueDataColors[2]);
 
@@ -556,17 +554,11 @@ context('Bar Graph Tile', function () {
     barGraph.getBar().eq(0).should('have.attr', 'fill', clueDataColors[0]);
     barGraph.getBar().eq(1).should('have.attr', 'fill', clueDataColors[1]);
     barGraph.getBar().eq(2).should('have.attr', 'fill', clueDataColors[2]);
-    barGraph.getBarColorButton().eq(0).click({force: true});
-    barGraph.getBarColorMenu(workspace, tileIndex).should('be.visible');
-    barGraph.getBarColorMenuButtons(workspace, tileIndex).eq(1).click({force: true});
+    barGraph.selectBarColor(0, 1, workspace, tileIndex);
     barGraph.getBar().eq(0).should('have.attr', 'fill', clueDataColors[1]);
-    barGraph.getBarColorButton().eq(1).click({force: true});
-    barGraph.getBarColorMenu(workspace, tileIndex).should('be.visible');
-    barGraph.getBarColorMenuButtons(workspace, tileIndex).eq(2).click({force: true});
+    barGraph.selectBarColor(1, 2, workspace, tileIndex);
     barGraph.getBar().eq(1).should('have.attr', 'fill', clueDataColors[2]);
-    barGraph.getBarColorButton().eq(2).click({force: true});
-    barGraph.getBarColorMenu(workspace, tileIndex).should('be.visible');
-    barGraph.getBarColorMenuButtons(workspace, tileIndex).eq(3).click({force: true});
+    barGraph.selectBarColor(2, 3, workspace, tileIndex);
     barGraph.getBar().eq(2).should('have.attr', 'fill', clueDataColors[3]);
 
     cy.log('Check undo/redo of color changes.');

--- a/cypress/support/elements/tile/BarGraphTile.js
+++ b/cypress/support/elements/tile/BarGraphTile.js
@@ -101,7 +101,10 @@ class BarGraphTile {
   // getBarColorMenuButtons() indexes color swatches across both of them.
   selectBarColor(barIndex, colorIndex, workspaceClass, tileIndex = 0) {
     this.getBarColorButton(workspaceClass, tileIndex).eq(barIndex).click({ force: true });
-    this.getBarColorMenu(workspaceClass, tileIndex).should('be.visible');
+    // Require exactly one open menu before indexing swatches: `:visible` can briefly
+    // match more than one menu during a Chakra exit transition, and eq() would then
+    // index across both.
+    this.getBarColorMenu(workspaceClass, tileIndex).should('have.length', 1).and('be.visible');
     this.getBarColorMenuButtons(workspaceClass, tileIndex).eq(colorIndex).click({ force: true });
     this.getBarColorMenu(workspaceClass, tileIndex).should('not.exist');
   }

--- a/cypress/support/elements/tile/BarGraphTile.js
+++ b/cypress/support/elements/tile/BarGraphTile.js
@@ -95,5 +95,16 @@ class BarGraphTile {
     return this.getBarColorMenu(workspaceClass, tileIndex).find(`[data-testid="color-menu-list-item"]`);
   }
 
+  // Selecting a color closes the portaled Chakra menu, but the menu has an exit
+  // transition that keeps it `:visible` briefly. Wait for it to fully close before
+  // opening the next color menu; otherwise two menus are momentarily open and
+  // getBarColorMenuButtons() indexes color swatches across both of them.
+  selectBarColor(barIndex, colorIndex, workspaceClass, tileIndex = 0) {
+    this.getBarColorButton(workspaceClass, tileIndex).eq(barIndex).click({ force: true });
+    this.getBarColorMenu(workspaceClass, tileIndex).should('be.visible');
+    this.getBarColorMenuButtons(workspaceClass, tileIndex).eq(colorIndex).click({ force: true });
+    this.getBarColorMenu(workspaceClass, tileIndex).should('not.exist');
+  }
+
 }
 export default BarGraphTile;


### PR DESCRIPTION
[CLUE-551](https://concord-consortium.atlassian.net/browse/CLUE-551)

The daily regression workflow (`regression-daily.yml`) fails frequently. Investigation of the last ~20 runs found two addressable causes, both fixed here.

## 1. Flaky "Setting bar colors" test (dominant cause)

`bar_graph_tile_spec.js` → "Setting bar colors" timed out after 30s in 5 of 8 test failures. Each bar-color button owns its own Chakra `Menu`, portaled to `document.body`, with an exit transition — so a just-closed menu stays `:visible` for ~200ms. The test clicked color buttons in rapid succession, leaving two menus visible at once. `getBarColorMenuButtons().eq(n)` then indexed color swatches across **both** menus and clicked an item in the *closing* one, so the bar's color never changed and the fill assertion timed out. The failure logs confirm this: the assert right before every failure matched `[<menu-list>, 1 more...]`.

Fix: a new `selectBarColor()` page-object helper that waits for the open menu to fully close (`should('not.exist')`) after each selection before the next menu opens — the same close-wait the test already used once inline. The four rapid inline selections now use the helper.

## 2. npm install network flakiness

One run failed with an ECONNRESET fetching a package from `registry.npmjs.org` during install. Added npm fetch-retry settings to `.npmrc` so transient registry errors retry instead of failing the job.

## Out of scope

Docker image pull timeouts at "Initialize containers" are also a source of failures, but image caching is intentionally not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CLUE-551]: https://concord-consortium.atlassian.net/browse/CLUE-551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ