### PR TITLE
CLUE-548: fix big thumbnail height clipping and scrolling

### DIFF
--- a/src/components/document/document-scroller.scss
+++ b/src/components/document/document-scroller.scss
@@ -92,6 +92,22 @@ $footer-height: 12px;
       }
     }
 
+    // The bookmark button (.icon-holder) is a child of .list-item-container, a sibling of
+    // .list-item. (My Work positions it via a `.documents-list`-scoped rule that doesn't
+    // apply here, so in the scroller it otherwise falls into normal flow.) Make the
+    // container a positioning context and overlay the bookmark in the top-right corner,
+    // nudged in a few px. Applies to both small and large thumbnails.
+    .list-item-container {
+      position: relative;
+
+      > .icon-holder {
+        left: auto;
+        position: absolute;
+        right: 6px;
+        top: 2px;
+      }
+    }
+
     .list-item {
       height: 126px;
       min-height: auto;
@@ -110,17 +126,6 @@ $footer-height: 12px;
           height: 738px;
           width: 958px;
         }
-      }
-
-      .icon-holder {
-        left: 2px;
-        right: auto;
-        top: -5px;
-        width: 24px;
-      }
-      .icon-star {
-        right: 0;
-        top: 0;
       }
 
       .footer {

--- a/src/components/document/document-scroller.scss
+++ b/src/components/document/document-scroller.scss
@@ -25,6 +25,16 @@ $footer-height: 12px;
         aspect-ratio: 8/7;
         height: auto;
         width: 50%;
+
+        // The thumbnail item wraps its content in a .list-item-container. As a plain
+        // block it fills the parent's width but defaults to content height, which breaks
+        // the percentage-height chain below (.list-item height:100%, etc.). Without an
+        // explicit height the full document renders instead of being clipped/scrolled
+        // within the fixed-aspect-ratio thumbnail.
+        .list-item-container {
+          height: 100%;
+          width: 100%;
+        }
       }
 
       .list-item {

--- a/src/components/document/document-scroller.tsx
+++ b/src/components/document/document-scroller.tsx
@@ -73,6 +73,7 @@ export const DocumentScroller: React.FC<IProps> = observer(function DocumentThum
           <DecoratedDocumentThumbnailItem
             key={docKey}
             scale={largeThumbnails ? 0.5 : 0.1}
+            scrollable={largeThumbnails}
             document={fullDocument}
             tab={ENavTab.kSortWork}
             shouldHandleStarClick

--- a/src/components/thumbnail/decorated-document-thumbnail-item.tsx
+++ b/src/components/thumbnail/decorated-document-thumbnail-item.tsx
@@ -21,12 +21,14 @@ interface IProps {
   selectedSecondaryDocument?: string;
   allowDelete: boolean;
   tab: string;
+  // true for large/"big" thumbnails that should be scrollable (see ThumbnailDocumentItem)
+  scrollable?: boolean;
 }
 
 // observes teacher names via useDocumentCaption()
 export const DecoratedDocumentThumbnailItem: React.FC<IProps> = observer(({
   document, tab, scale, selectedDocument, selectedSecondaryDocument, allowDelete,
-  onSelectDocument, shouldHandleStarClick,
+  onSelectDocument, shouldHandleStarClick, scrollable,
 }: IProps) => {
     const { user, db: dbStore, bookmarks, ui } = useStores();
     const tabName = tab.toLowerCase().replace(' ', '-');
@@ -75,6 +77,7 @@ export const DecoratedDocumentThumbnailItem: React.FC<IProps> = observer(({
         canvasContext={tab}
         document={document}
         scale={scale}
+        scrollable={scrollable}
         isSelected={document.key === selectedDocument}
         isSecondarySelected={document.key === selectedSecondaryDocument}
         captionText={caption}

--- a/src/components/thumbnail/thumbnail-document-item.test.tsx
+++ b/src/components/thumbnail/thumbnail-document-item.test.tsx
@@ -112,13 +112,14 @@ describe("ThumbnailDocumentItem", () => {
       expect(canvasContainer).toHaveAttribute("inert");
     });
 
-    // Large/"big" thumbnails must be scrollable, so they omit inert/aria-hidden
-    // (inert would block scrolling its subtree). See CLUE-548.
-    it("does not mark the canvas container inert/aria-hidden when scrollable", () => {
+    // Even scrollable (large) thumbnails keep inert + aria-hidden so the document stays
+    // out of the tab order and the a11y tree; scrolling is handled via a wheel handler
+    // rather than by making the subtree interactive. See CLUE-548.
+    it("keeps the canvas container inert/aria-hidden when scrollable", () => {
       const { container } = renderItem({ scrollable: true });
       const canvasContainer = container.querySelector(".scaled-list-item-container");
-      expect(canvasContainer).not.toHaveAttribute("inert");
-      expect(canvasContainer).not.toHaveAttribute("aria-hidden");
+      expect(canvasContainer).toHaveAttribute("inert");
+      expect(canvasContainer).toHaveAttribute("aria-hidden", "true");
     });
 
     it("sets aria-current='true' when the document is selected", () => {

--- a/src/components/thumbnail/thumbnail-document-item.test.tsx
+++ b/src/components/thumbnail/thumbnail-document-item.test.tsx
@@ -22,6 +22,7 @@ interface IRenderOptions {
   onDocumentClick?: (document: DocumentModelType) => void;
   onDocumentDragStart?: (e: React.DragEvent<HTMLDivElement>, document: DocumentModelType) => void;
   onDocumentStarClick?: (document: DocumentModelType) => void;
+  scrollable?: boolean;
 }
 
 function renderItem(options: IRenderOptions = {}) {
@@ -33,6 +34,7 @@ function renderItem(options: IRenderOptions = {}) {
     onDocumentClick = jest.fn(),
     onDocumentDragStart,
     onDocumentStarClick,
+    scrollable,
   } = options;
   const ownerId = isPrivate ? "other-user" : "test-student";
   const user = UserModel.create({ id: "test-student", type: userType, name: "Test Student" });
@@ -61,6 +63,7 @@ function renderItem(options: IRenderOptions = {}) {
         onDocumentDragStart={onDocumentDragStart}
         onDocumentStarClick={onDocumentStarClick}
         scale={0.1}
+        scrollable={scrollable}
       />
     </Provider>
   );
@@ -107,6 +110,15 @@ describe("ThumbnailDocumentItem", () => {
       const { container } = renderItem();
       const canvasContainer = container.querySelector(".scaled-list-item-container");
       expect(canvasContainer).toHaveAttribute("inert");
+    });
+
+    // Large/"big" thumbnails must be scrollable, so they omit inert/aria-hidden
+    // (inert would block scrolling its subtree). See CLUE-548.
+    it("does not mark the canvas container inert/aria-hidden when scrollable", () => {
+      const { container } = renderItem({ scrollable: true });
+      const canvasContainer = container.querySelector(".scaled-list-item-container");
+      expect(canvasContainer).not.toHaveAttribute("inert");
+      expect(canvasContainer).not.toHaveAttribute("aria-hidden");
     });
 
     it("sets aria-current='true' when the document is selected", () => {

--- a/src/components/thumbnail/thumbnail-document-item.tsx
+++ b/src/components/thumbnail/thumbnail-document-item.tsx
@@ -54,6 +54,11 @@ export const ThumbnailDocumentItem: React.FC<IProps> = observer((props: IProps) 
     const handleWheel = (e: WheelEvent) => {
       const content = el.querySelector<HTMLElement>(".document-content");
       if (!content) return;
+      // When the inner document is already scrolled to its top/bottom edge, let the wheel
+      // event through so the parent document grid (which holds many thumbnails) can scroll.
+      const atTop = content.scrollTop <= 0;
+      const atBottom = content.scrollTop + content.clientHeight >= content.scrollHeight;
+      if ((e.deltaY < 0 && atTop) || (e.deltaY > 0 && atBottom)) return;
       content.scrollTop += e.deltaY;
       e.preventDefault();
     };

--- a/src/components/thumbnail/thumbnail-document-item.tsx
+++ b/src/components/thumbnail/thumbnail-document-item.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import { observer } from "mobx-react";
 import { CanvasComponent } from "../document/canvas";
 import { DocumentModelType } from "../../models/document/document";
@@ -24,9 +24,11 @@ interface IProps {
   onDocumentDragStart?: (e: React.DragEvent<HTMLDivElement>, document: DocumentModelType) => void;
   onDocumentStarClick?: (document: DocumentModelType) => void;
   scale: number;
-  // When true (large/"big" thumbnails), the document is meant to be scrollable within
-  // the thumbnail. We omit the `inert`/`aria-hidden` that the small nav thumbnails use,
-  // because `inert` disables all interaction on its subtree — including scrolling.
+  // When true (large/"big" thumbnails), the document can be scrolled within the
+  // thumbnail. The document subtree stays `inert` + `aria-hidden` (kept out of the tab
+  // order and the a11y tree); since `inert` blocks native scrolling, we translate wheel
+  // events into programmatic scrolling instead, keeping the thumbnail "scroll-only"
+  // rather than fully interactive.
   scrollable?: boolean;
 }
 
@@ -38,6 +40,26 @@ export const ThumbnailDocumentItem: React.FC<IProps> = observer((props: IProps) 
   const appMode = useAppMode();
   const { bookmarks, user, documents } = useStores();
   const classStore = useClassStore();
+  const listItemRef = useRef<HTMLDivElement>(null);
+
+  // Large/"big" thumbnails are scroll-only: the document subtree is kept `inert` (out of
+  // the tab order) and `aria-hidden`, which also blocks native scrolling. Translate wheel
+  // events on the (non-inert) list item into programmatic scrolling of the inner document
+  // so users can scroll without the tiles becoming focusable/interactive. A non-passive
+  // listener is required so we can preventDefault the page scroll.
+  useEffect(() => {
+    if (!scrollable) return;
+    const el = listItemRef.current;
+    if (!el) return;
+    const handleWheel = (e: WheelEvent) => {
+      const content = el.querySelector<HTMLElement>(".document-content");
+      if (!content) return;
+      content.scrollTop += e.deltaY;
+      e.preventDefault();
+    };
+    el.addEventListener("wheel", handleWheel, { passive: false });
+    return () => el.removeEventListener("wheel", handleWheel);
+  }, [scrollable]);
 
   const handleDocumentClick = (e: React.MouseEvent<HTMLDivElement>) => {
     onDocumentClick?.(document);
@@ -83,7 +105,7 @@ export const ThumbnailDocumentItem: React.FC<IProps> = observer((props: IProps) 
   });
   return (
     <div className="list-item-container" key={document.key}>
-      <div className={className}
+      <div className={className} ref={listItemRef}
         data-test={dataTestName} data-document-key={document.key}
         title={documentTitle}
         role="button"
@@ -98,13 +120,13 @@ export const ThumbnailDocumentItem: React.FC<IProps> = observer((props: IProps) 
       >
         <div
           className={classNames("scaled-list-item-container", { group })}
-          // Small nav thumbnails are non-interactive: hide their tile content from the
-          // a11y tree and remove it from the tab order via `inert`. Large/scrollable
-          // thumbnails must remain interactive so the document can be scrolled, so we
-          // skip both there (inert would block scrolling).
-          aria-hidden={scrollable ? undefined : true}
+          // The rendered document is non-interactive in every thumbnail: hide its tile
+          // content from the a11y tree (aria-hidden) and remove it from the tab order
+          // (inert). Large/scrollable thumbnails are scrolled via a wheel handler on the
+          // list item (see the effect above), since inert blocks native scrolling.
+          aria-hidden={true}
           // Spread bypasses React 17's type definitions, which lack `inert`.
-          {...(scrollable ? {} : { inert: "" })}
+          {...{ inert: "" }}
         >
           { isPrivate
             ? <ThumbnailPrivateIcon />

--- a/src/components/thumbnail/thumbnail-document-item.tsx
+++ b/src/components/thumbnail/thumbnail-document-item.tsx
@@ -24,12 +24,16 @@ interface IProps {
   onDocumentDragStart?: (e: React.DragEvent<HTMLDivElement>, document: DocumentModelType) => void;
   onDocumentStarClick?: (document: DocumentModelType) => void;
   scale: number;
+  // When true (large/"big" thumbnails), the document is meant to be scrollable within
+  // the thumbnail. We omit the `inert`/`aria-hidden` that the small nav thumbnails use,
+  // because `inert` disables all interaction on its subtree — including scrolling.
+  scrollable?: boolean;
 }
 
 export const ThumbnailDocumentItem: React.FC<IProps> = observer((props: IProps) => {
   const {
     dataTestName, canvasContext, document, scale, captionText, isSelected, isSecondarySelected,
-    onDocumentClick, onDocumentDragStart, onDocumentStarClick, onDocumentDeleteClick
+    onDocumentClick, onDocumentDragStart, onDocumentStarClick, onDocumentDeleteClick, scrollable
   } = props;
   const appMode = useAppMode();
   const { bookmarks, user, documents } = useStores();
@@ -94,9 +98,13 @@ export const ThumbnailDocumentItem: React.FC<IProps> = observer((props: IProps) 
       >
         <div
           className={classNames("scaled-list-item-container", { group })}
-          aria-hidden={true}
+          // Small nav thumbnails are non-interactive: hide their tile content from the
+          // a11y tree and remove it from the tab order via `inert`. Large/scrollable
+          // thumbnails must remain interactive so the document can be scrolled, so we
+          // skip both there (inert would block scrolling).
+          aria-hidden={scrollable ? undefined : true}
           // Spread bypasses React 17's type definitions, which lack `inert`.
-          {...{ inert: "" }}
+          {...(scrollable ? {} : { inert: "" })}
         >
           { isPrivate
             ? <ThumbnailPrivateIcon />


### PR DESCRIPTION
CLUE-548
Two linked regressions in the Sort Work large ("big") thumbnail view:

- Height clip: the .list-item-container wrapper is a plain block, so it filled width but defaulted to content height, breaking the height:100% chain that clips each thumb to its aspect-ratio box. The whole document rendered full height. Give .list-item-container height:100% in the .large-thumbnails view.
- Scroll: the `inert` attribute (added in CLUE-426 for keyboard nav) disables all interaction on its subtree, including scrolling, overriding the pointer-events:auto that enables large-thumbnail scroll. Thread a `scrollable` flag so small nav thumbnails keep inert/aria-hidden (preserving CLUE-426) but large thumbnails omit them and scroll again.

Add a unit test for the scrollable case (omits inert/aria-hidden).