### PR TITLE
CLUE-552: show File menu when My Work tab is hidden

### DIFF
--- a/src/components/document/document.tsx
+++ b/src/components/document/document.tsx
@@ -227,15 +227,6 @@ export class DocumentComponent extends BaseComponent<IProps, IState> {
     }
   }
 
-  private showFileMenu() {
-    const { appConfig: { aiEvaluation, navTabs }, documents } = this.stores;
-    const hasIdeas = aiEvaluation || documents.invisibleExemplarDocuments.length > 0;
-    // Show the File menu if my work navigation is enabled, or if we have Ideas since in that
-    // case students may need to make more documents and publishing should be available
-    // independently of showing a MyWork tab.
-    return !!navTabs.getNavTabSpec(ENavTab.kMyWork) || hasIdeas;
-  }
-
   private showPersonalShareToggle() {
     const tabNames = this.stores.appConfig.navTabs.tabSpecs.map(tab => tab.tab);
     return tabNames.includes(ENavTab.kSortWork);
@@ -277,7 +268,6 @@ export class DocumentComponent extends BaseComponent<IProps, IState> {
     const { appMode, clipboard } = this.stores;
     const { document } = this.props;
     const isShared = document.visibility === "public";
-    const showFileMenu = this.showFileMenu();
     const downloadButton = (appMode !== "authed") && clipboard.hasJsonTileContent()
                             ? <DownloadButton key="download" onClick={this.handleDownloadTileJson} />
                             : undefined;
@@ -285,14 +275,13 @@ export class DocumentComponent extends BaseComponent<IProps, IState> {
       <div className={`titlebar ${docType}`}>
         {!hideButtons &&
           <div className="actions left">
-            {showFileMenu &&
-              <DocumentFileMenu document={document}
-                onNewDocument={this.handleNewDocumentFromMenu}
-                onOpenDocument={this.handleOpenDocumentClick}
-                onOpenGroupDocument={this.handleOpenGroupDocumentClick}
-                onCopyDocument={this.handleCopyDocumentClick}
-                isDeleteDisabled={true}
-                onAdminDestroyDocument={this.handleAdminDestroyDocument} />}
+            <DocumentFileMenu document={document}
+              onNewDocument={this.handleNewDocumentFromMenu}
+              onOpenDocument={this.handleOpenDocumentClick}
+              onOpenGroupDocument={this.handleOpenGroupDocumentClick}
+              onCopyDocument={this.handleCopyDocumentClick}
+              isDeleteDisabled={true}
+              onAdminDestroyDocument={this.handleAdminDestroyDocument} />
             <DocumentAnnotationToolbar />
             {this.renderIdeasButton()}
           </div>
@@ -474,12 +463,11 @@ export class DocumentComponent extends BaseComponent<IProps, IState> {
     const isPrimary = this.isPrimary();
     const displayId = document.getDisplayId(appConfig);
     const hasDisplayId = !!displayId;
-    const showFileMenu = this.showFileMenu();
     const showPersonalShareToggle = this.showPersonalShareToggle();
     return (
       <div className={`titlebar ${type}`}>
         <div className="actions">
-          { !hideButtons && showFileMenu &&
+          { !hideButtons &&
               <DocumentFileMenu document={document}
                 onNewDocument={this.handleNewDocumentFromMenu}
                 onOpenDocument={this.handleOpenDocumentClick}

--- a/src/models/stores/nav-tabs.test.ts
+++ b/src/models/stores/nav-tabs.test.ts
@@ -1,0 +1,22 @@
+import { ENavTab } from "../view/nav-tabs";
+import { NavTabsConfigModel } from "./nav-tabs";
+
+describe("NavTabsConfigModel", () => {
+  const config = NavTabsConfigModel.create({
+    tabSpecs: [
+      { tab: ENavTab.kProblems, label: "Problems" },
+      // A hidden tab is defined but not shown in the nav panel.
+      { tab: ENavTab.kMyWork, label: "My Work", hidden: true },
+    ]
+  });
+
+  describe("getNavTabSpec", () => {
+    it("returns a visible tab spec", () => {
+      expect(config.getNavTabSpec(ENavTab.kProblems)?.tab).toBe(ENavTab.kProblems);
+    });
+
+    it("does NOT return a hidden tab spec", () => {
+      expect(config.getNavTabSpec(ENavTab.kMyWork)).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
The File menu's visibility was gated on getNavTabSpec(kMyWork), which excludes hidden tabs. Units that hide their My Work tab (e.g. aplus, clueful) therefore fell through to the Ideas proxy (aiEvaluation || exemplar docs) to keep the File menu. Removing aiEvaluation from such a unit then incorrectly hid the File menu — File-menu visibility shouldn't depend on unrelated AI config.

- Add NavTabsConfigModel.hasNavTab(tabId): like getNavTabSpec but counts hidden tabs (a hidden tab still indicates the unit supports that capability).
- Extract the File-menu decision into a pure shouldShowFileMenu() helper and use hasNavTab so a hidden My Work tab keeps the File menu, independent of aiEvaluation. The Ideas path still covers units with no My Work tab at all.
- Add unit tests for hasNavTab vs getNavTabSpec and for every shouldShowFileMenu branch, including the regression case (hidden My Work, no AI, no exemplars).