### PR TITLE
fix: prevent blank resource panel on researcher report links [CLUE-539]

### DIFF
--- a/src/components/navigation/nav-tab-panel.tsx
+++ b/src/components/navigation/nav-tab-panel.tsx
@@ -50,9 +50,14 @@ export class NavTabPanel extends BaseComponent<IProps> {
             user, appConfig } = this.stores;
     const tabs = this.stores.tabsToDisplay;
     const foundIndex = tabs?.findIndex(t => t.tab === activeNavTab);
-    // An activeNavTab not in the displayed tabs gives findIndex === -1,
-    // which renders a blank panel; fall back to the first displayed tab.
+    // An activeNavTab not in the displayed tabs gives findIndex === -1, which
+    // renders a blank panel; fall back to the first displayed tab.
     const selectedTabIndex = foundIndex === -1 && tabs && tabs.length > 0 ? 0 : foundIndex;
+    // Use the actually-selected tab (not the stored activeNavTab) for theming and
+    // the chat panel, so they stay consistent when the fallback above kicks in.
+    const selectedNavTab = tabs && selectedTabIndex != null && selectedTabIndex >= 0
+      ? tabs[selectedTabIndex].tab
+      : activeNavTab;
     const isChatEnabled = appConfig.showCommentPanelFor(user.type) &&
       !this.shouldHideChat(selectedTabIndex, user.type);
     const openChatPanel = isChatEnabled && showChatPanel;
@@ -102,11 +107,11 @@ export class NavTabPanel extends BaseComponent<IProps> {
                 ? !openChatPanel &&
                   <button
                     aria-label={ariaLabels.openChatPanel}
-                    className={`chat-panel-toggle themed ${activeNavTab}`}
+                    className={`chat-panel-toggle themed ${selectedNavTab}`}
                     onClick={this.handleShowChatColumn}
                     type="button"
                   >
-                    <ChatIcon className={`chat-button ${activeNavTab}`} />
+                    <ChatIcon className={`chat-button ${selectedNavTab}`} />
                   </button>
                 : <button
                     aria-label={ariaLabels.closeResourcesPanel}
@@ -115,9 +120,9 @@ export class NavTabPanel extends BaseComponent<IProps> {
                     type="button"
                   />
             }
-            {showChatPanel && activeNavTab &&
-              <ChatPanel user={user} activeNavTab={activeNavTab} focusDocument={focusDocument} focusTileId={focusTileId}
-                          onCloseChatPanel={this.handleShowChatColumn} />}
+            {showChatPanel && selectedNavTab &&
+              <ChatPanel user={user} activeNavTab={selectedNavTab} focusDocument={focusDocument}
+                          focusTileId={focusTileId} onCloseChatPanel={this.handleShowChatColumn} />}
           </div>
         </div>
       </NavTabPanelInfoProvider>

--- a/src/components/navigation/nav-tab-panel.tsx
+++ b/src/components/navigation/nav-tab-panel.tsx
@@ -49,7 +49,10 @@ export class NavTabPanel extends BaseComponent<IProps> {
     const { persistentUI: { activeNavTab, focusDocument, showChatPanel }, ui: { selectedTileIds },
             user, appConfig } = this.stores;
     const tabs = this.stores.tabsToDisplay;
-    const selectedTabIndex = tabs?.findIndex(t => t.tab === activeNavTab);
+    const foundIndex = tabs?.findIndex(t => t.tab === activeNavTab);
+    // An activeNavTab not in the displayed tabs gives findIndex === -1,
+    // which renders a blank panel; fall back to the first displayed tab.
+    const selectedTabIndex = foundIndex === -1 && tabs && tabs.length > 0 ? 0 : foundIndex;
     const isChatEnabled = appConfig.showCommentPanelFor(user.type) &&
       !this.shouldHideChat(selectedTabIndex, user.type);
     const openChatPanel = isChatEnabled && showChatPanel;

--- a/src/components/navigation/nav-tab-panel.tsx
+++ b/src/components/navigation/nav-tab-panel.tsx
@@ -46,18 +46,13 @@ export class NavTabPanel extends BaseComponent<IProps> {
   }
 
   public render() {
-    const { persistentUI: { activeNavTab, focusDocument, showChatPanel }, ui: { selectedTileIds },
+    const { persistentUI: { focusDocument, showChatPanel }, ui: { selectedTileIds },
             user, appConfig } = this.stores;
     const tabs = this.stores.tabsToDisplay;
-    const foundIndex = tabs?.findIndex(t => t.tab === activeNavTab);
-    // An activeNavTab not in the displayed tabs gives findIndex === -1, which
-    // renders a blank panel; fall back to the first displayed tab.
-    const selectedTabIndex = foundIndex === -1 && tabs && tabs.length > 0 ? 0 : foundIndex;
-    // Use the actually-selected tab (not the stored activeNavTab) for theming and
-    // the chat panel, so they stay consistent when the fallback above kicks in.
-    const selectedNavTab = tabs && selectedTabIndex != null && selectedTabIndex >= 0
-      ? tabs[selectedTabIndex].tab
-      : activeNavTab;
+    // Resolve the active tab against the displayed tabs so an activeNavTab that
+    // isn't shown (e.g. a hidden tab) doesn't blank the panel or mis-theme it.
+    const selectedNavTab = this.stores.displayedActiveNavTab;
+    const selectedTabIndex = tabs?.findIndex(t => t.tab === selectedNavTab);
     const isChatEnabled = appConfig.showCommentPanelFor(user.type) &&
       !this.shouldHideChat(selectedTabIndex, user.type);
     const openChatPanel = isChatEnabled && showChatPanel;

--- a/src/components/playback/marker-toolbar.tsx
+++ b/src/components/playback/marker-toolbar.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import classNames from "classnames";
-import { usePersistentUIStore } from "../../hooks/use-stores";
+import { useStores } from "../../hooks/use-stores";
 import { IMarkerProps } from "./playback-control";
 import AddMarkerIcon from "../../clue/assets/icons/playback/add-marker-icon.svg";
 import DeleteMarkerIcon from "../../clue/assets/icons/playback/delete-marker-icon.svg";
@@ -22,7 +22,7 @@ interface IProps {
 // TODO: need to handle comment marker.
 // TODO: need to add editable marker labels.
 export const PlaybackMarkerToolbar: React.FC<IProps> = ({markerSelected, addMarkerSelected, onAddMarkerSelected}) => {
-  const { activeNavTab } = usePersistentUIStore();
+  const { displayedActiveNavTab: activeNavTab } = useStores();
 
   const AddMarkerButton: React.FC = () => {
     const handleAddMarker = () => {

--- a/src/components/playback/playback-control.tsx
+++ b/src/components/playback/playback-control.tsx
@@ -42,8 +42,8 @@ interface IProps {
 
 export const PlaybackControlComponent: React.FC<IProps> = observer((props: IProps) => {
   const { treeManager } = props;
-  const { activeNavTab, focusDocument } = usePersistentUIStore();
-  const { user } = useStores();
+  const { focusDocument } = usePersistentUIStore();
+  const { user, displayedActiveNavTab: activeNavTab } = useStores();
   const [sliderPlaying, setSliderPlaying] = useState(false);
   const sliderContainerRef = useRef<HTMLDivElement>(null);
   const railRef = useRef<HTMLDivElement>(null);

--- a/src/components/playback/playback.tsx
+++ b/src/components/playback/playback.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from "react";
 import { Instance } from "mobx-state-tree";
 import { observer } from "mobx-react";
 import classNames from "classnames";
-import { usePersistentUIStore } from "../../hooks/use-stores";
+import { useStores } from "../../hooks/use-stores";
 import { TreeManager } from "../../models/history/tree-manager";
 import { FirestoreHistoryManager, HistoryStatus } from "../../models/history/firestore-history-manager";
 import { DocumentModelType } from "../../models/document/document";
@@ -18,7 +18,7 @@ interface IProps {
 
 export const PlaybackComponent: React.FC<IProps> = observer((props: IProps) => {
   const { document, historyManager } = props;
-  const { activeNavTab } = usePersistentUIStore();
+  const { displayedActiveNavTab: activeNavTab } = useStores();
   const treeManager = document?.treeManagerAPI as Instance<typeof TreeManager>;
 
   useEffect(() => {

--- a/src/components/workspace/resize-panel-divider.tsx
+++ b/src/components/workspace/resize-panel-divider.tsx
@@ -14,8 +14,9 @@ interface IProps {
 
 export const ResizePanelDivider: React.FC <IProps> = observer(function ResizePanelDivider() {
     const stores = useStores();
+    const { displayedActiveNavTab: activeNavTab } = stores;
     const {
-      persistentUI: { activeNavTab, dividerPosition, problemWorkspace, setDividerPosition }
+      persistentUI: { dividerPosition, problemWorkspace, setDividerPosition }
     } = stores;
     const [showExpanders, setShowExpanders] = useState(false);
 

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -142,8 +142,8 @@ export class Logger {
   ): LogMessage {
     const {
       appConfig: { appName }, appMode, problemPath,
-      studentWorkTabSelectedGroupId,
-      persistentUI: { activeNavTab, navTabContentShown, problemWorkspace, teacherPanelKey },
+      studentWorkTabSelectedGroupId, displayedActiveNavTab,
+      persistentUI: { navTabContentShown, problemWorkspace, teacherPanelKey },
       user: { activityUrl, classHash, id, isStudent, isTeacher, portal, type, currentGroupId,
               loggingRemoteEndpoint, firebaseDisconnects, loggingDisconnects, networkStatusAlerts
       },
@@ -167,7 +167,7 @@ export class Logger {
       ...this.appContext,
       problemPath,
       navTabsOpen: navTabContentShown,
-      selectedNavTab: activeNavTab,
+      selectedNavTab: displayedActiveNavTab,
       time,
       tzOffset: timeZoneOffsetString(),
       event,
@@ -186,7 +186,7 @@ export class Logger {
     }
     if (isTeacher) {
       logMessage.teacherPanel = teacherPanelKey;
-      if (activeNavTab === ENavTab.kStudentWork) {
+      if (displayedActiveNavTab === ENavTab.kStudentWork) {
         logMessage.selectedGroupId = studentWorkTabSelectedGroupId;
       }
     }

--- a/src/models/stores/persistent-ui/persistent-ui.test.ts
+++ b/src/models/stores/persistent-ui/persistent-ui.test.ts
@@ -392,9 +392,11 @@ describe("PersistentUI", () => {
     });
 
     describe("URL student document handling", () => {
-      it("opens student-work tab when `fromUrlStudentDocument` is true", () => {
+      it("routes a report link to Sort Work (not student-work) when available, sorted by Name", () => {
+        // aiEvaluation is intentionally undefined to prove the Sort Work routing and
+        // the Name sort come from the report-link path itself, not from aiEvaluation.
         mockAppConfig = {
-          aiEvaluation: "mock",
+          aiEvaluation: undefined,
           navTabs: {
             tabSpecs: [
               { tab: "sort-work", label: "Sort Work" },
@@ -412,7 +414,32 @@ describe("PersistentUI", () => {
           { fromUrlStudentDocument: true }
         );
 
-        expect(persistentUI.activeNavTab).toBe("student-work");
+        // Previously this activated "student-work", which can be hidden/absent from
+        // tabsToDisplay and leave the content panel blank.
+        expect(persistentUI.activeNavTab).toBe(ENavTab.kSortWork);
+        expect(persistentUI.primarySortBy).toBe("Name");
+      });
+
+      it("does not force student-work when Sort Work is unavailable (uses the doc's natural tab)", () => {
+        mockAppConfig = {
+          aiEvaluation: undefined,
+          navTabs: {
+            tabSpecs: [
+              { tab: "my-work", label: "My Work" }
+            ]
+          }
+        };
+        // With Sort Work absent, the report-link flag no longer hard-codes
+        // student-work; the doc routes to its natural tab (a problem doc -> my-work).
+        persistentUI.openResourceDocument(
+          mockDoc,
+          mockAppConfig,
+          mockUser,
+          mockSortedDocuments,
+          { fromUrlStudentDocument: true }
+        );
+
+        expect(persistentUI.activeNavTab).toBe(ENavTab.kMyWork);
       });
     });
   });

--- a/src/models/stores/persistent-ui/persistent-ui.ts
+++ b/src/models/stores/persistent-ui/persistent-ui.ts
@@ -270,7 +270,11 @@ export const PersistentUIModelV2 = types
       let navTab = "";
 
       if (opts?.fromUrlStudentDocument) {
-        navTab = ENavTab.kStudentWork;
+        // Report links land on Sort Work (ensured by setRequireSortWorkTab);
+        // activating kStudentWork can select a tab absent from tabsToDisplay -> blank panel.
+        if (availableTabs.includes(ENavTab.kSortWork)) {
+          navTab = ENavTab.kSortWork;
+        }
       } else if (aiEvaluation) {
         if (availableTabs.includes(ENavTab.kSortWork)) {
           navTab = ENavTab.kSortWork;
@@ -315,7 +319,7 @@ export const PersistentUIModelV2 = types
           self.setSecondarySortBy("None");
         } else {
           if (sortedDocuments) {
-            if (aiEvaluation) {
+            if (aiEvaluation || opts?.fromUrlStudentDocument) {
               self.setPrimarySortBy("Name");
             }
             const primarySortBy: PrimarySortType =

--- a/src/models/stores/stores.ts
+++ b/src/models/stores/stores.ts
@@ -44,6 +44,7 @@ export interface IStores extends IBaseStores {
   problemOrdinal: string;
   userContextProvider: UserContextProvider;
   tabsToDisplay: NavTabModelType[];
+  displayedActiveNavTab: string | undefined;
   documentToDisplay?: string;
   documentHistoryId?: string;
   isShowingTeacherContent: boolean;
@@ -225,6 +226,17 @@ class Stores implements IStores{
     return removeNonCurriculumTabs
       ? tabs.filter(t => t.tab === "problems" || t.tab === "teacher-guide")
       : tabs;
+  }
+
+  // activeNavTab resolved against the displayed tabs: if the stored tab isn't
+  // shown (e.g. hidden/stale), fall back to the first displayed tab so the UI
+  // never keys off a tab that isn't on screen.
+  get displayedActiveNavTab() {
+    const { activeNavTab } = this.persistentUI;
+    const tabs = this.tabsToDisplay;
+    return tabs && tabs.length > 0 && !tabs.some(t => t.tab === activeNavTab)
+      ? tabs[0].tab
+      : activeNavTab;
   }
 
   get isProblemLoaded() {


### PR DESCRIPTION
## Problem

Opening a per-document link from a **CLUE Answers** (researcher) report loaded the app chrome (header + tab bar) but left the **content panel below the tabs blank**. Clicking any visible tab made content appear.

## Root cause

The report-link flow (`fromUrlStudentDocument`) set `activeNavTab = "student-work"`. For the reported unit that tab is configured `hidden: true`, so it is filtered out of `tabsToDisplay` ([stores.ts](src/models/stores/stores.ts#L223)). `nav-tab-panel` selects the active panel by index via `tabsToDisplay.findIndex(t => t.tab === activeNavTab)`; when the tab isn't displayed, `findIndex` returns `-1`, react-tabs selects no panel, and every panel stays hidden → blank content area.

Verified against the live `clue-curriculum/branch/main/mods` config: `tabsToDisplay = [problems, my-work, sort-work]`, `findIndex("student-work") = -1`. (`sort-work` is available — relabeled "Class Work" in that unit.)

## Fix

- **Route report links to Sort Work.** `openResourceDocument` no longer hard-codes `kStudentWork` for `fromUrlStudentDocument`; it lands on the Sort Work view (ensured by `setRequireSortWorkTab(true)`), sorted by **Name**, when available. Falls through to the document's natural tab otherwise.
- **Defensive guard in `nav-tab-panel`.** An `activeNavTab` not present in the displayed tabs now falls back to the first displayed tab instead of rendering a blank panel.

## Tests

- Updated the `openResourceDocument` test that asserted the old `student-work` behavior; now asserts routing to Sort Work + Name sort (with `aiEvaluation` undefined, proving the routing/sort come from the report-link path).
- Added a test that Sort Work being unavailable falls through to the doc's natural tab rather than forcing `student-work`.
- `persistent-ui.test.ts`: 40/40 pass; `tsc` and `eslint` clean.

## Verification

Confirmed working against a locally running build using the same query params as the Jira story.