### PR TITLE
CLUE-535: rename, delete, and show usage counts for media-library images

### DIFF
--- a/authoring-api/src/helpers/db.test.ts
+++ b/authoring-api/src/helpers/db.test.ts
@@ -1,0 +1,26 @@
+import {escapeFirebaseKey, unescapeFirebaseKey} from "./db";
+
+describe("escapeFirebaseKey / unescapeFirebaseKey", () => {
+  it("escapes the characters Firebase keys disallow", () => {
+    expect(escapeFirebaseKey("images/photo.png")).toBe("images%2Fphoto%2Epng");
+  });
+
+  it("round-trips ordinary keys", () => {
+    const key = "investigation-0/problem-1/introduction/content.json";
+    expect(unescapeFirebaseKey(escapeFirebaseKey(key))).toBe(key);
+  });
+
+  it("escapes '%' so the mapping stays injective", () => {
+    // Without escaping '%', a literal "data%231.png" and the escaped form of "data#1.png" would
+    // both be "data%231%2Epng" and collide on the same Firebase key.
+    const hashName = "data#1.png";
+    const percentName = "data%231.png";
+    expect(escapeFirebaseKey(hashName)).not.toBe(escapeFirebaseKey(percentName));
+  });
+
+  it("round-trips names containing '%' and the escape sequences it could be confused with", () => {
+    for (const name of ["100%.png", "data%231.png", "a%2Eb.png", "%25.png", "café#1$[x].png"]) {
+      expect(unescapeFirebaseKey(escapeFirebaseKey(name))).toBe(name);
+    }
+  });
+});

--- a/authoring-api/src/helpers/db.ts
+++ b/authoring-api/src/helpers/db.ts
@@ -43,9 +43,16 @@ export const getUnitMetadataUpdatesPath = (branch: string, unit: string, path: s
 export const getBlobCachePath = (sha?: string) =>
   `${authoringPath}/blobs${sha ? `/${sha}` : ""}`;
 
+// "%" must be escaped first (it is the escape character itself). Escaping it to "%25" keeps the
+// mapping injective — without it a literal "data%231.png" and the escaped form of "data#1.png"
+// would collide on the same key. A single left-to-right replace handles this correctly: "%25" is
+// emitted for a literal "%", and the sequences we emit for other characters ("%2E", "%23", …) are
+// never re-scanned.
 export function escapeFirebaseKey(key: string): string {
-  return key.replace(/[.#$[\]/]/g, (char) => {
+  return key.replace(/[%.#$[\]/]/g, (char) => {
     switch (char) {
+    case "%":
+      return "%25";
     case ".":
       return "%2E";
     case "#":
@@ -65,8 +72,10 @@ export function escapeFirebaseKey(key: string): string {
 }
 
 export function unescapeFirebaseKey(escapedKey: string): string {
-  return escapedKey.replace(/%2E|%23|%24|%5B|%5D|%2F/g, (escapedChar) => {
+  return escapedKey.replace(/%2E|%23|%24|%5B|%5D|%2F|%25/g, (escapedChar) => {
     switch (escapedChar) {
+    case "%25":
+      return "%";
     case "%2E":
       return ".";
     case "%23":

--- a/authoring-api/src/helpers/github.test.ts
+++ b/authoring-api/src/helpers/github.test.ts
@@ -1,0 +1,35 @@
+import {describeGitHubError} from "./github";
+
+describe("describeGitHubError", () => {
+  const fallback = "An error occurred while renaming the image.";
+
+  it("maps GitHub auth failures (401/403) to an actionable re-auth message", () => {
+    for (const status of [401, 403]) {
+      const {message, statusCode} = describeGitHubError({status}, fallback);
+      expect(message).toMatch(/authenticate with GitHub/i);
+      expect(statusCode).toBe(502);
+    }
+  });
+
+  it("maps 404 to a not-found message", () => {
+    const {message, statusCode} = describeGitHubError({status: 404}, fallback);
+    expect(message).toMatch(/not be found on GitHub|not found on GitHub/i);
+    expect(statusCode).toBe(404);
+  });
+
+  it("maps ref conflicts (409/422) to a retry message", () => {
+    for (const status of [409, 422]) {
+      const {message, statusCode} = describeGitHubError({status}, fallback);
+      expect(message).toMatch(/retry/i);
+      expect(statusCode).toBe(409);
+    }
+  });
+
+  it("falls back to the caller's generic message for unknown/unexpected errors", () => {
+    expect(describeGitHubError(new Error("boom"), fallback)).toEqual({message: fallback, statusCode: 500});
+    expect(describeGitHubError({status: 500}, fallback)).toEqual({message: fallback, statusCode: 500});
+    expect(describeGitHubError(undefined, fallback)).toEqual({message: fallback, statusCode: 500});
+    // A non-numeric status must not be treated as a known case.
+    expect(describeGitHubError({status: "401"}, fallback)).toEqual({message: fallback, statusCode: 500});
+  });
+});

--- a/authoring-api/src/helpers/github.ts
+++ b/authoring-api/src/helpers/github.ts
@@ -11,3 +11,31 @@ export const getRawCurriculumUrl = (branch: string) => {
 export const getRawUrl = (branch: string, unit: string, path: string) => {
   return `https://raw.githubusercontent.com/${owner}/${repo}/${branch}/${getBaseUnitPath(unit)}${path}`;
 };
+
+// Maps a caught error to a client-facing message + status. Octokit throws a RequestError carrying a
+// numeric `status`; we duck-type it (rather than `instanceof`) so duplicate package copies can't
+// defeat the check. Known GitHub failures get an actionable message; anything else falls back to the
+// caller's generic message so we never leak internal/unexpected error detail to the client.
+export function describeGitHubError(error: unknown, fallbackMessage: string): {message: string; statusCode: number} {
+  const status = typeof (error as {status?: unknown})?.status === "number" ?
+    (error as {status: number}).status :
+    undefined;
+  switch (status) {
+  case 401:
+  case 403:
+    return {
+      message: "Could not authenticate with GitHub. Your session may have expired — sign in again and retry.",
+      statusCode: 502,
+    };
+  case 404:
+    return {
+      message: "The image or branch was not found on GitHub. It may have been moved or deleted.",
+      statusCode: 404,
+    };
+  case 409:
+  case 422:
+    return {message: "The branch changed during the operation. Please retry.", statusCode: 409};
+  default:
+    return {message: fallbackMessage, statusCode: 500};
+  }
+}

--- a/authoring-api/src/helpers/image-references.test.ts
+++ b/authoring-api/src/helpers/image-references.test.ts
@@ -1,0 +1,101 @@
+import {buildUsageMap, extractImageKeys, rewriteImageReference} from "./image-references";
+
+const contentWith = (...refs: string[]) =>
+  JSON.stringify({
+    tiles: refs.map((ref, i) => ({
+      id: `tile-${i}`,
+      content: {type: "Image", url: ref, filename: ref},
+    })),
+  });
+
+describe("extractImageKeys", () => {
+  it("finds images referenced as {unit}/images/{file}", () => {
+    const text = contentWith("sas/images/diagram-1.png", "sas/images/photo.jpg");
+    expect(extractImageKeys("sas", text).sort()).toEqual([
+      "images/diagram-1.png",
+      "images/photo.jpg",
+    ]);
+  });
+
+  it("de-duplicates an image referenced multiple times in one file", () => {
+    // url + filename both carry the same reference, and it may appear in several tiles
+    const text = contentWith("sas/images/photo.jpg", "sas/images/photo.jpg");
+    expect(extractImageKeys("sas", text)).toEqual(["images/photo.jpg"]);
+  });
+
+  it("ignores references to other units' images", () => {
+    const text = contentWith("sas/images/mine.png", "msa/images/theirs.png");
+    expect(extractImageKeys("sas", text)).toEqual(["images/mine.png"]);
+  });
+
+  it("does not match a unit code that is only a suffix of another unit's prefix", () => {
+    // "xsas/images/..." must not be counted as a "sas" reference
+    const text = contentWith("xsas/images/photo.jpg");
+    expect(extractImageKeys("sas", text)).toEqual([]);
+  });
+
+  it("matches the bare {unit}/images token inside a curriculum/ prefixed path", () => {
+    const text = contentWith("curriculum/sas/images/photo.jpg");
+    expect(extractImageKeys("sas", text)).toEqual(["images/photo.jpg"]);
+  });
+
+  it("returns nothing when there are no image references", () => {
+    expect(extractImageKeys("sas", JSON.stringify({tiles: []}))).toEqual([]);
+  });
+});
+
+describe("buildUsageMap", () => {
+  const imageKeys = ["images/used.png", "images/unused.png", "images/shared.png"];
+  const perFile = [
+    {path: "investigation-0/problem-1/introduction/content.json", keys: ["images/used.png", "images/shared.png"]},
+    {path: "teacher-guide/investigation-0/problem-1/launch/content.json", keys: ["images/shared.png"]},
+  ];
+
+  it("maps each library image to the paths that reference it", () => {
+    const usages = buildUsageMap(imageKeys, perFile);
+    expect(usages["images/used.png"]).toEqual([
+      "investigation-0/problem-1/introduction/content.json",
+    ]);
+    expect(usages["images/shared.png"]).toEqual([
+      "investigation-0/problem-1/introduction/content.json",
+      "teacher-guide/investigation-0/problem-1/launch/content.json",
+    ]);
+  });
+
+  it("includes unused images with an empty list", () => {
+    const usages = buildUsageMap(imageKeys, perFile);
+    expect(usages["images/unused.png"]).toEqual([]);
+  });
+
+  it("ignores referenced images that are not in the library list", () => {
+    const usages = buildUsageMap(["images/used.png"], [
+      {path: "a/content.json", keys: ["images/used.png", "images/stray.png"]},
+    ]);
+    expect(Object.keys(usages)).toEqual(["images/used.png"]);
+  });
+});
+
+describe("rewriteImageReference", () => {
+  it("rewrites both url and filename references, preserving any prefix", () => {
+    const text = JSON.stringify({
+      tiles: [{content: {type: "Image", url: "sas/images/old.png", filename: "sas/images/old.png"}}],
+    });
+    const {text: out, changed} = rewriteImageReference("sas", text, "old.png", "new.png");
+    expect(changed).toBe(true);
+    expect(out).toContain("sas/images/new.png");
+    expect(out).not.toContain("sas/images/old.png");
+  });
+
+  it("does not touch a different image whose name shares a prefix", () => {
+    const text = JSON.stringify({url: "sas/images/old.png", other: "sas/images/old-version.png"});
+    const {text: out} = rewriteImageReference("sas", text, "old.png", "new.png");
+    expect(out).toContain("sas/images/new.png");
+    expect(out).toContain("sas/images/old-version.png");
+  });
+
+  it("reports no change when the image is not referenced", () => {
+    const text = JSON.stringify({url: "sas/images/something-else.png"});
+    const {changed} = rewriteImageReference("sas", text, "old.png", "new.png");
+    expect(changed).toBe(false);
+  });
+});

--- a/authoring-api/src/helpers/image-references.test.ts
+++ b/authoring-api/src/helpers/image-references.test.ts
@@ -1,4 +1,7 @@
-import {buildUsageMap, extractImageKeys, rewriteImageReference} from "./image-references";
+import {
+  buildUsageMap, extractImageKeys, isPathSafeImageFileName, isValidImageFileName, isValidUnitCode,
+  rewriteImageReference,
+} from "./image-references";
 
 const contentWith = (...refs: string[]) =>
   JSON.stringify({
@@ -41,6 +44,12 @@ describe("extractImageKeys", () => {
 
   it("returns nothing when there are no image references", () => {
     expect(extractImageKeys("sas", JSON.stringify({tiles: []}))).toEqual([]);
+  });
+
+  it("detects legacy names containing '&' (which the runtime can reference) and stops at the quote", () => {
+    // "C&S_1-1.png" is a real referenceable image; the scanner must count it, not truncate at "&".
+    const text = contentWith("sas/images/C&S_1-1.png");
+    expect(extractImageKeys("sas", text)).toEqual(["images/C&S_1-1.png"]);
   });
 });
 
@@ -97,5 +106,68 @@ describe("rewriteImageReference", () => {
     const text = JSON.stringify({url: "sas/images/something-else.png"});
     const {changed} = rewriteImageReference("sas", text, "old.png", "new.png");
     expect(changed).toBe(false);
+  });
+
+  it("rewrites a legacy '&' name to a clean one", () => {
+    const text = JSON.stringify({url: "sas/images/C&S_1-1.png", filename: "sas/images/C&S_1-1.png"});
+    const {text: out, changed} = rewriteImageReference("sas", text, "C&S_1-1.png", "cs_1-1.png");
+    expect(changed).toBe(true);
+    expect(out).toContain("sas/images/cs_1-1.png");
+    expect(out).not.toContain("C&S_1-1.png");
+  });
+});
+
+describe("isValidImageFileName", () => {
+  it("accepts alphanumerics, dot, dash, and underscore", () => {
+    expect(isValidImageFileName("diagram-1.png")).toBe(true);
+    expect(isValidImageFileName("My_Image.2.JPG")).toBe(true);
+  });
+
+  it("rejects path separators, traversal, and empty names", () => {
+    expect(isValidImageFileName("")).toBe(false);
+    expect(isValidImageFileName("../secret.png")).toBe(false);
+    expect(isValidImageFileName("sub/dir/x.png")).toBe(false);
+    expect(isValidImageFileName("a b.png")).toBe(false);
+    expect(isValidImageFileName("x%2F..%2Fy.png")).toBe(false);
+  });
+
+  it("still rejects '&' — the naming policy stays strict even though the scanner now detects it", () => {
+    expect(isValidImageFileName("C&S_1-1.png")).toBe(false);
+  });
+});
+
+describe("isValidUnitCode", () => {
+  it("accepts simple unit slugs", () => {
+    expect(isValidUnitCode("sas")).toBe(true);
+    expect(isValidUnitCode("moving-straight-ahead")).toBe(true);
+  });
+
+  it("rejects slashes and traversal", () => {
+    expect(isValidUnitCode("")).toBe(false);
+    expect(isValidUnitCode("../other")).toBe(false);
+    expect(isValidUnitCode("a/b")).toBe(false);
+  });
+});
+
+describe("isPathSafeImageFileName", () => {
+  const backslash = String.fromCharCode(92);
+  const tab = String.fromCharCode(9);
+
+  it("accepts messy legacy names that the strict allowlist would reject", () => {
+    // These are exactly the names rename needs to operate on to clean them up.
+    expect(isPathSafeImageFileName("spaghetti plot.png")).toBe(true);
+    expect(isPathSafeImageFileName("C&S_1-1_LimasGroup.png")).toBe(true);
+    expect(isPathSafeImageFileName("screenshot at 8.24.34 am.png")).toBe(true);
+    // and ordinary clean names too
+    expect(isPathSafeImageFileName("diagram-1.png")).toBe(true);
+  });
+
+  it("rejects anything that could escape the images/ directory", () => {
+    expect(isPathSafeImageFileName("")).toBe(false);
+    expect(isPathSafeImageFileName(".")).toBe(false);
+    expect(isPathSafeImageFileName("..")).toBe(false);
+    expect(isPathSafeImageFileName("sub/dir/x.png")).toBe(false);
+    expect(isPathSafeImageFileName(`a${backslash}b.png`)).toBe(false);
+    expect(isPathSafeImageFileName(`a${tab}b.png`)).toBe(false);
   });
 });

--- a/authoring-api/src/helpers/image-references.test.ts
+++ b/authoring-api/src/helpers/image-references.test.ts
@@ -51,6 +51,20 @@ describe("extractImageKeys", () => {
     const text = contentWith("sas/images/C&S_1-1.png");
     expect(extractImageKeys("sas", text)).toEqual(["images/C&S_1-1.png"]);
   });
+
+  it("detects legacy names with other punctuation the runtime accepts (not truncated)", () => {
+    // ( ) % + ' , and non-ASCII are all part of a real referenceable name; capturing only up to the
+    // JSON string delimiter keeps their usage counts correct (previously these were truncated).
+    const text = contentWith(
+      "sas/images/photo(2).png", "sas/images/100%.png", "sas/images/a+b's,c.png", "sas/images/café.png",
+    );
+    expect(extractImageKeys("sas", text).sort()).toEqual([
+      "images/100%.png",
+      "images/a+b's,c.png",
+      "images/café.png",
+      "images/photo(2).png",
+    ]);
+  });
 });
 
 describe("buildUsageMap", () => {
@@ -115,6 +129,14 @@ describe("rewriteImageReference", () => {
     expect(out).toContain("sas/images/cs_1-1.png");
     expect(out).not.toContain("C&S_1-1.png");
   });
+
+  it("rewrites a legacy name with parentheses (which regex-escaping must handle)", () => {
+    const text = JSON.stringify({url: "sas/images/photo(2).png"});
+    const {text: out, changed} = rewriteImageReference("sas", text, "photo(2).png", "photo-2.png");
+    expect(changed).toBe(true);
+    expect(out).toContain("sas/images/photo-2.png");
+    expect(out).not.toContain("photo(2).png");
+  });
 });
 
 describe("isValidImageFileName", () => {
@@ -133,6 +155,14 @@ describe("isValidImageFileName", () => {
 
   it("still rejects '&' — the naming policy stays strict even though the scanner now detects it", () => {
     expect(isValidImageFileName("C&S_1-1.png")).toBe(false);
+  });
+
+  it("requires a real image extension so the renamed file still resolves at runtime", () => {
+    // The runtime resolver needs a dot + 3-letter extension; an otherwise-safe name without one
+    // would move the blob and rewrite references to a token that renders nowhere.
+    expect(isValidImageFileName("diagram-v2")).toBe(false);
+    expect(isValidImageFileName("foo.x")).toBe(false);
+    expect(isValidImageFileName("diagram-v2.png")).toBe(true);
   });
 });
 

--- a/authoring-api/src/helpers/image-references.ts
+++ b/authoring-api/src/helpers/image-references.ts
@@ -1,0 +1,71 @@
+// Helpers for finding and rewriting references to a unit's media-library images inside authored
+// content. Images are referenced in tile content (url/filename fields) as the normalized token
+// `{unit}/images/{file}` (see localAssetsImagesHandler in src/models/image-map.ts). These are pure
+// string functions so they can be unit-tested without Firebase/GitHub.
+
+const imageFileChars = "A-Za-z0-9._-";
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// Matches `{unit}/images/{file}`, requiring a non-identifier boundary before the unit so that a
+// unit code which is merely a suffix of a longer token (e.g. "xsas" vs "sas") is not matched.
+function imageRefRegExp(unit: string, flags = "g"): RegExp {
+  return new RegExp(`(?<![${imageFileChars}])${escapeRegExp(unit)}/images/([${imageFileChars}]+)`, flags);
+}
+
+// Returns the de-duplicated list of library image keys (`images/{file}`) referenced by the given
+// content text for `unit`. References to other units' images are ignored.
+export function extractImageKeys(unit: string, contentText: string): string[] {
+  const keys = new Set<string>();
+  const re = imageRefRegExp(unit);
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(contentText)) !== null) {
+    keys.add(`images/${match[1]}`);
+  }
+  return Array.from(keys);
+}
+
+// Inverts per-file extracted image keys into a map of library image key -> referencing file paths.
+// Every key in `imageKeys` is present in the result (unused images map to an empty array); keys
+// found in content that are not in `imageKeys` are ignored.
+export function buildUsageMap(
+  imageKeys: string[],
+  perFile: Array<{path: string; keys: string[]}>
+): Record<string, string[]> {
+  const library = new Set(imageKeys);
+  const usages: Record<string, string[]> = {};
+  imageKeys.forEach((key) => {
+    usages[key] = [];
+  });
+  perFile.forEach(({path, keys}) => {
+    keys.forEach((key) => {
+      if (library.has(key)) {
+        usages[key].push(path);
+      }
+    });
+  });
+  return usages;
+}
+
+// Rewrites references to `{unit}/images/{fromFile}` -> `{unit}/images/{toFile}` in content text.
+// Returns the new text and whether anything changed. A trailing boundary ensures `old.png` does
+// not match inside `old-version.png`.
+export function rewriteImageReference(
+  unit: string,
+  contentText: string,
+  fromFile: string,
+  toFile: string
+): {text: string; changed: boolean} {
+  const re = new RegExp(
+    `(?<![${imageFileChars}])${escapeRegExp(unit)}/images/${escapeRegExp(fromFile)}(?![${imageFileChars}])`,
+    "g"
+  );
+  let changed = false;
+  const text = contentText.replace(re, () => {
+    changed = true;
+    return `${unit}/images/${toFile}`;
+  });
+  return {text, changed};
+}

--- a/authoring-api/src/helpers/image-references.ts
+++ b/authoring-api/src/helpers/image-references.ts
@@ -3,7 +3,51 @@
 // `{unit}/images/{file}` (see localAssetsImagesHandler in src/models/image-map.ts). These are pure
 // string functions so they can be unit-tested without Firebase/GitHub.
 
-const imageFileChars = "A-Za-z0-9._-";
+// Two distinct character sets, deliberately separate:
+//
+// safeNameChars — the naming POLICY for a clean library filename / unit code, enforced on every new
+// or renamed (destination) name. Strict on purpose: no spaces, no "&", no path separators.
+//
+// refTokenChars — the set that can appear in an EXISTING reference token already in content. Wider,
+// because the CLUE runtime (localAssetsImagesHandler.match in src/models/image-map.ts) resolves any
+// "{unit}/images/{file}" url that contains no space/colon and ends in an extension. So a legacy name
+// like "C&S_1-1.png" is a real, referenceable image the scanner must recognize to count it. (Spaces
+// can't be referenced at all — match() rejects them — so they're correctly absent here.) Keeping
+// these separate means widening detection never loosens the naming policy.
+const safeNameChars = "A-Za-z0-9._-";
+const refTokenChars = "A-Za-z0-9._&-";
+
+const safeNameRegExp = new RegExp(`^[${safeNameChars}]+$`);
+
+// Library image filenames are restricted to a safe character set (no path separators) so they can
+// be interpolated into GitHub paths and Firebase keys without traversal risk. Shared by the
+// upload/delete/rename routes so the allowlist (and its rejection) stays consistent.
+export function isValidImageFileName(name: string): boolean {
+  return safeNameRegExp.test(name);
+}
+
+// Unit codes are single path segments under curriculum/{unit}/; restrict them to the same safe set
+// so a crafted `unit` (e.g. containing "/" or "..") can't escape the intended unit directory when
+// interpolated into GitHub paths.
+export function isValidUnitCode(unit: string): boolean {
+  return safeNameRegExp.test(unit);
+}
+
+// A looser check for an image filename we only need to LOCATE an existing file by (e.g. the rename
+// SOURCE). Unlike isValidImageFileName, it tolerates messy legacy names (spaces, "&", etc.) so
+// authors can rename those to clean names — rename being the very tool for that cleanup. It only
+// blocks what could escape the images/ directory when interpolated into a GitHub path or Firebase
+// key: path separators, "."/".." segments, and control characters. The new (destination) name is
+// still held to the strict allowlist, so renames always move toward clean names.
+export function isPathSafeImageFileName(name: string): boolean {
+  if (name === "" || name === "." || name === "..") return false;
+  for (let i = 0; i < name.length; i++) {
+    const code = name.charCodeAt(i);
+    // Reject control chars (< 0x20), forward slash (47), and backslash (92); spaces, "&", etc. are OK.
+    if (code < 0x20 || code === 47 || code === 92) return false;
+  }
+  return true;
+}
 
 function escapeRegExp(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -12,7 +56,7 @@ function escapeRegExp(s: string): string {
 // Matches `{unit}/images/{file}`, requiring a non-identifier boundary before the unit so that a
 // unit code which is merely a suffix of a longer token (e.g. "xsas" vs "sas") is not matched.
 function imageRefRegExp(unit: string, flags = "g"): RegExp {
-  return new RegExp(`(?<![${imageFileChars}])${escapeRegExp(unit)}/images/([${imageFileChars}]+)`, flags);
+  return new RegExp(`(?<![${refTokenChars}])${escapeRegExp(unit)}/images/([${refTokenChars}]+)`, flags);
 }
 
 // Returns the de-duplicated list of library image keys (`images/{file}`) referenced by the given
@@ -59,7 +103,7 @@ export function rewriteImageReference(
   toFile: string
 ): {text: string; changed: boolean} {
   const re = new RegExp(
-    `(?<![${imageFileChars}])${escapeRegExp(unit)}/images/${escapeRegExp(fromFile)}(?![${imageFileChars}])`,
+    `(?<![${refTokenChars}])${escapeRegExp(unit)}/images/${escapeRegExp(fromFile)}(?![${refTokenChars}])`,
     "g"
   );
   let changed = false;

--- a/authoring-api/src/helpers/image-references.ts
+++ b/authoring-api/src/helpers/image-references.ts
@@ -3,27 +3,39 @@
 // `{unit}/images/{file}` (see localAssetsImagesHandler in src/models/image-map.ts). These are pure
 // string functions so they can be unit-tested without Firebase/GitHub.
 
-// Two distinct character sets, deliberately separate:
+// Two deliberately separate concerns: the naming POLICY for a clean destination name, and the
+// character set that can appear in an EXISTING reference already sitting in content.
 //
-// safeNameChars — the naming POLICY for a clean library filename / unit code, enforced on every new
+// safeNameChars — the naming policy for a clean library filename / unit code, enforced on every new
 // or renamed (destination) name. Strict on purpose: no spaces, no "&", no path separators.
 //
-// refTokenChars — the set that can appear in an EXISTING reference token already in content. Wider,
-// because the CLUE runtime (localAssetsImagesHandler.match in src/models/image-map.ts) resolves any
-// "{unit}/images/{file}" url that contains no space/colon and ends in an extension. So a legacy name
-// like "C&S_1-1.png" is a real, referenceable image the scanner must recognize to count it. (Spaces
-// can't be referenced at all — match() rejects them — so they're correctly absent here.) Keeping
-// these separate means widening detection never loosens the naming policy.
+// refToken — one character of a reference token as it appears in content. Authored content is JSON,
+// so a "{unit}/images/{file}" reference is always the value of a string field and is terminated by
+// the string delimiter. It matches the CLUE runtime (localAssetsImagesHandler.match in
+// src/models/image-map.ts), which resolves any such url that contains no space/colon and ends in an
+// extension: the only characters that can't be part of the filename are the JSON string delimiter,
+// whitespace, ":" and "/" (the runtime rejects spaces/colons, and a library filename is a single
+// path segment), and "\\" (a JSON escape). Everything else the runtime accepts — legacy punctuation
+// like ( ) % + ' , & and non-ASCII — is part of the name, so the scanner counts/rewrites it
+// correctly. Keeping this separate from safeNameChars means detecting a messy name never loosens
+// the policy for creating one.
 const safeNameChars = "A-Za-z0-9._-";
-const refTokenChars = "A-Za-z0-9._&-";
+const refToken = "[^\\x22\\s:/\\\\]"; // \x22 is the JSON string delimiter (")
 
 const safeNameRegExp = new RegExp(`^[${safeNameChars}]+$`);
 
-// Library image filenames are restricted to a safe character set (no path separators) so they can
-// be interpolated into GitHub paths and Firebase keys without traversal risk. Shared by the
-// upload/delete/rename routes so the allowlist (and its rejection) stays consistent.
+// A library image filename must end in a real extension (dot + 3+ letters) so it resolves through
+// the runtime matcher (localAssetsImagesHandler.match, /\.[a-z]{3,}$/i). Without this an author
+// could rename an image to an extension-less name that passes the charset check but then fails to
+// render everywhere it's used.
+const imageExtensionRegExp = /\.[a-z]{3,}$/i;
+
+// Library image filenames are restricted to a safe character set (no path separators) and must carry
+// a valid image extension, so they can be interpolated into GitHub paths / Firebase keys without
+// traversal risk and always resolve at runtime. Shared by the upload/delete/rename routes so the
+// allowlist (and its rejection) stays consistent.
 export function isValidImageFileName(name: string): boolean {
-  return safeNameRegExp.test(name);
+  return safeNameRegExp.test(name) && imageExtensionRegExp.test(name);
 }
 
 // Unit codes are single path segments under curriculum/{unit}/; restrict them to the same safe set
@@ -53,10 +65,10 @@ function escapeRegExp(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-// Matches `{unit}/images/{file}`, requiring a non-identifier boundary before the unit so that a
-// unit code which is merely a suffix of a longer token (e.g. "xsas" vs "sas") is not matched.
+// Matches `{unit}/images/{file}`, requiring a non-token boundary before the unit so that a unit
+// code which is merely a suffix of a longer token (e.g. "xsas" vs "sas") is not matched.
 function imageRefRegExp(unit: string, flags = "g"): RegExp {
-  return new RegExp(`(?<![${refTokenChars}])${escapeRegExp(unit)}/images/([${refTokenChars}]+)`, flags);
+  return new RegExp(`(?<!${refToken})${escapeRegExp(unit)}/images/(${refToken}+)`, flags);
 }
 
 // Returns the de-duplicated list of library image keys (`images/{file}`) referenced by the given
@@ -103,7 +115,7 @@ export function rewriteImageReference(
   toFile: string
 ): {text: string; changed: boolean} {
   const re = new RegExp(
-    `(?<![${refTokenChars}])${escapeRegExp(unit)}/images/${escapeRegExp(fromFile)}(?![${refTokenChars}])`,
+    `(?<!${refToken})${escapeRegExp(unit)}/images/${escapeRegExp(fromFile)}(?!${refToken})`,
     "g"
   );
   let changed = false;

--- a/authoring-api/src/helpers/resolve-commit-author.ts
+++ b/authoring-api/src/helpers/resolve-commit-author.ts
@@ -5,10 +5,8 @@ interface CommitAuthor {
   email: string;
 }
 
-/**
- * Resolve the Git commit author from a Firebase decoded token, falling back to the GitHub API
- * when the token is missing name or email (which depends on the user's GitHub profile settings).
- */
+// Resolve the Git commit author from a Firebase decoded token, falling back to the GitHub API when
+// the token is missing name or email (which depends on the user's GitHub profile settings).
 export async function resolveCommitAuthor(
   decodedToken: { name?: string; email?: string } | undefined,
   octokit: Octokit

--- a/authoring-api/src/helpers/unit-content.ts
+++ b/authoring-api/src/helpers/unit-content.ts
@@ -1,0 +1,125 @@
+// Reads a unit's authored content for image-usage scanning and reference rewriting.
+//
+// The pulled `files` map (populated by pull-unit) lists every file path with its current git blob
+// `sha`. We use that to enumerate content.json files cheaply (no git-tree walk at scan time) and to
+// key a per-blob image-reference cache so repeated scans only re-read files whose content changed.
+
+import {getRawUrl} from "./github";
+import {
+  authoringPath, getBlobCachePath, getDb, getUnitFilesPath, getUnitUpdatesPath,
+  unescapeFirebaseKey, UnitFiles,
+} from "./db";
+import {buildUsageMap, extractImageKeys} from "./image-references";
+
+const getImageRefIndexPath = (sha: string) => `${authoringPath}/imageRefIndex/${sha}`;
+
+const isContentFile = (path: string) => path.endsWith("content.json");
+const isImageFile = (path: string) => path.startsWith("images/");
+
+export interface UnitContentFile {
+  // unescaped, relative to curriculum/{unit}/ e.g. "investigation-0/problem-1/x/content.json"
+  path: string;
+  // firebase-escaped key into the files/updates maps
+  escapedPath: string;
+  // git blob sha of the committed content (absent for never-committed files)
+  sha?: string;
+  // pending unpushed edit (stringified JSON), if any
+  updateText?: string;
+}
+
+export interface UnitContent {
+  // library image keys ("images/{file}")
+  imageKeys: string[];
+  // image key -> blob sha (for GitHub delete/move)
+  imageShas: Record<string, string | undefined>;
+  contentFiles: UnitContentFile[];
+}
+
+// Load the files + pending updates maps and split into library images and content files.
+export async function getUnitContent(branch: string, unit: string): Promise<UnitContent> {
+  const db = getDb();
+  const [filesSnap, updatesSnap] = await Promise.all([
+    db.ref(getUnitFilesPath(branch, unit)).get(),
+    db.ref(getUnitUpdatesPath(branch, unit)).get(),
+  ]);
+  const files: UnitFiles = filesSnap.val() ?? {};
+  const updates: Record<string, string> = updatesSnap.val() ?? {};
+
+  const imageKeys: string[] = [];
+  const imageShas: Record<string, string | undefined> = {};
+  const contentFiles: UnitContentFile[] = [];
+
+  Object.entries(files).forEach(([escapedPath, file]) => {
+    const path = unescapeFirebaseKey(escapedPath);
+    if (isImageFile(path)) {
+      imageKeys.push(path);
+      imageShas[path] = file.sha;
+    } else if (isContentFile(path)) {
+      contentFiles.push({path, escapedPath, sha: file.sha, updateText: updates[escapedPath]});
+    }
+  });
+
+  return {imageKeys, imageShas, contentFiles};
+}
+
+// Resolve the effective content text for a file: pending update wins, then the cached blob, then
+// GitHub raw (the same precedence get-content.ts uses).
+async function readEffectiveContentText(branch: string, unit: string, file: UnitContentFile): Promise<string> {
+  if (file.updateText != null) {
+    return file.updateText;
+  }
+  const db = getDb();
+  if (file.sha) {
+    const blobSnap = await db.ref(getBlobCachePath(file.sha)).get();
+    const blob = blobSnap.val();
+    if (typeof blob === "string") {
+      return blob;
+    }
+  }
+  const response = await fetch(getRawUrl(branch, unit, file.path));
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${file.path}: ${response.statusText}`);
+  }
+  return response.text();
+}
+
+// Image keys referenced by a file. Committed files (with a stable sha and no pending edit) are
+// cached by blob sha so unchanged files are never re-fetched/re-parsed on later scans.
+async function extractKeysForFile(branch: string, unit: string, file: UnitContentFile): Promise<string[]> {
+  const cacheable = file.sha != null && file.updateText == null;
+  const db = getDb();
+  if (cacheable) {
+    const cachedSnap = await db.ref(getImageRefIndexPath(file.sha!)).get();
+    const cached = cachedSnap.val();
+    if (Array.isArray(cached)) {
+      return cached;
+    }
+  }
+  const text = await readEffectiveContentText(branch, unit, file);
+  const keys = extractImageKeys(unit, text);
+  if (cacheable) {
+    // Firebase drops empty arrays; that's fine — a miss simply recomputes (cheaply) next time.
+    await db.ref(getImageRefIndexPath(file.sha!)).set(keys);
+  }
+  return keys;
+}
+
+// image key ("images/{file}") -> referencing content-file paths. Unused images map to [].
+export async function computeImageUsages(branch: string, unit: string): Promise<Record<string, string[]>> {
+  const {imageKeys, contentFiles} = await getUnitContent(branch, unit);
+  const perFile = await Promise.all(
+    contentFiles.map(async (file) => ({path: file.path, keys: await extractKeysForFile(branch, unit, file)}))
+  );
+  return buildUsageMap(imageKeys, perFile);
+}
+
+// Stage a content-file edit as an unpushed "update" (same shape put-content writes), so reference
+// rewrites flow through the normal preview + push pipeline.
+export async function stageContentUpdate(
+  branch: string, unit: string, escapedPath: string, content: string
+): Promise<void> {
+  const db = getDb();
+  await db.ref(getUnitUpdatesPath(branch, unit, escapedPath)).set(content);
+}
+
+export {readEffectiveContentText};

--- a/authoring-api/src/helpers/unit-content.ts
+++ b/authoring-api/src/helpers/unit-content.ts
@@ -2,7 +2,8 @@
 //
 // The pulled `files` map (populated by pull-unit) lists every file path with its current git blob
 // `sha`. We use that to enumerate content.json files cheaply (no git-tree walk at scan time) and to
-// key a per-blob image-reference cache so repeated scans only re-read files whose content changed.
+// key a per-(unit, blob) image-reference cache so repeated scans only re-read files whose content
+// changed.
 
 import {getRawUrl} from "./github";
 import {
@@ -11,7 +12,9 @@ import {
 } from "./db";
 import {buildUsageMap, extractImageKeys} from "./image-references";
 
-const getImageRefIndexPath = (sha: string) => `${authoringPath}/imageRefIndex/${sha}`;
+// Keyed by both unit and blob sha: extractImageKeys is unit-dependent (references embed the unit
+// code), so a blob shared across units must not reuse another unit's extracted keys.
+const getImageRefIndexPath = (unit: string, sha: string) => `${authoringPath}/imageRefIndex/${unit}/${sha}`;
 
 const isContentFile = (path: string) => path.endsWith("content.json");
 const isImageFile = (path: string) => path.startsWith("images/");
@@ -63,7 +66,8 @@ export async function getUnitContent(branch: string, unit: string): Promise<Unit
 }
 
 // Resolve the effective content text for a file: pending update wins, then the cached blob, then
-// GitHub raw (the same precedence get-content.ts uses).
+// GitHub raw. (get-content.ts uses the same update-then-GitHub precedence; we add the blob-cache
+// tier in between to avoid re-fetching unchanged committed files during a scan.)
 async function readEffectiveContentText(branch: string, unit: string, file: UnitContentFile): Promise<string> {
   if (file.updateText != null) {
     return file.updateText;
@@ -89,7 +93,7 @@ async function extractKeysForFile(branch: string, unit: string, file: UnitConten
   const cacheable = file.sha != null && file.updateText == null;
   const db = getDb();
   if (cacheable) {
-    const cachedSnap = await db.ref(getImageRefIndexPath(file.sha!)).get();
+    const cachedSnap = await db.ref(getImageRefIndexPath(unit, file.sha!)).get();
     const cached = cachedSnap.val();
     if (Array.isArray(cached)) {
       return cached;
@@ -99,7 +103,7 @@ async function extractKeysForFile(branch: string, unit: string, file: UnitConten
   const keys = extractImageKeys(unit, text);
   if (cacheable) {
     // Firebase drops empty arrays; that's fine — a miss simply recomputes (cheaply) next time.
-    await db.ref(getImageRefIndexPath(file.sha!)).set(keys);
+    await db.ref(getImageRefIndexPath(unit, file.sha!)).set(keys);
   }
   return keys;
 }
@@ -111,15 +115,6 @@ export async function computeImageUsages(branch: string, unit: string): Promise<
     contentFiles.map(async (file) => ({path: file.path, keys: await extractKeysForFile(branch, unit, file)}))
   );
   return buildUsageMap(imageKeys, perFile);
-}
-
-// Stage a content-file edit as an unpushed "update" (same shape put-content writes), so reference
-// rewrites flow through the normal preview + push pipeline.
-export async function stageContentUpdate(
-  branch: string, unit: string, escapedPath: string, content: string
-): Promise<void> {
-  const db = getDb();
-  await db.ref(getUnitUpdatesPath(branch, unit, escapedPath)).set(content);
 }
 
 export {readEffectiveContentText};

--- a/authoring-api/src/index.ts
+++ b/authoring-api/src/index.ts
@@ -14,6 +14,9 @@ import getPulledUnits from "./routes/get-pulled-units";
 import getPulledFiles from "./routes/get-pulled-files";
 import putContent from "./routes/put-content";
 import putImage from "./routes/put-image";
+import getImageUsages from "./routes/get-image-usages";
+import deleteImage from "./routes/delete-image";
+import renameImage from "./routes/rename-image";
 import getRawContent from "./routes/get-raw-content";
 import deleteUnit from "./routes/delete-unit";
 import pushUnit from "./routes/push-unit";
@@ -197,6 +200,9 @@ app.get("/getContent", getContent);
 app.post("/putContent", putContent);
 
 app.post("/putImage", putImage);
+app.get("/getImageUsages", getImageUsages);
+app.post("/deleteImage", deleteImage);
+app.post("/renameImage", renameImage);
 
 app.get("/getRemoteBranches", getRemoteBranches);
 app.get("/getRemoteUnits", getRemoteUnits);

--- a/authoring-api/src/routes/delete-image.ts
+++ b/authoring-api/src/routes/delete-image.ts
@@ -5,7 +5,7 @@ import {AuthorizedRequest, sendErrorResponse, sendSuccessResponse} from "../help
 import {describeGitHubError, owner, repo} from "../helpers/github";
 import {escapeFirebaseKey, getDb, getUnitFilesPath} from "../helpers/db";
 import {computeImageUsages} from "../helpers/unit-content";
-import {isValidImageFileName, isValidUnitCode} from "../helpers/image-references";
+import {isPathSafeImageFileName, isValidUnitCode} from "../helpers/image-references";
 
 // Deletes a library image from GitHub and the Firebase files map. Only permitted when the image is
 // unused in the current unit + teacher guide (re-verified here so a stale client can't force it).
@@ -26,8 +26,12 @@ const deleteImage = async (req: Request, res: Response) => {
   if (!fileName) {
     return sendErrorResponse(res, "Missing required body parameter: fileName.", 400);
   }
-  if (!isValidImageFileName(fileName)) {
-    return sendErrorResponse(res, "Invalid fileName: only alphanumeric, dash, underscore, and dot are allowed.", 400);
+  // Delete removes an EXISTING file rather than introducing a new name, so it accepts any path-safe
+  // name — including messy legacy ones (spaces, "&", etc.) that the strict allowlist rejects. Those
+  // are exactly the unused images an author needs to be able to clean up; the strict check is only
+  // for names we create (upload / rename destination).
+  if (!isPathSafeImageFileName(fileName)) {
+    return sendErrorResponse(res, "Invalid fileName: it must not contain slashes or control characters.", 400);
   }
 
   const imageKey = `images/${fileName}`;

--- a/authoring-api/src/routes/delete-image.ts
+++ b/authoring-api/src/routes/delete-image.ts
@@ -2,9 +2,10 @@ import {Request, Response} from "express";
 import {Octokit} from "@octokit/rest";
 
 import {AuthorizedRequest, sendErrorResponse, sendSuccessResponse} from "../helpers/express";
-import {owner, repo} from "../helpers/github";
+import {describeGitHubError, owner, repo} from "../helpers/github";
 import {escapeFirebaseKey, getDb, getUnitFilesPath} from "../helpers/db";
 import {computeImageUsages} from "../helpers/unit-content";
+import {isValidImageFileName, isValidUnitCode} from "../helpers/image-references";
 
 // Deletes a library image from GitHub and the Firebase files map. Only permitted when the image is
 // unused in the current unit + teacher guide (re-verified here so a stale client can't force it).
@@ -14,6 +15,9 @@ const deleteImage = async (req: Request, res: Response) => {
   if (!unit || !branch) {
     return sendErrorResponse(res, "Missing required parameters: unit or branch.", 400);
   }
+  if (!isValidUnitCode(unit)) {
+    return sendErrorResponse(res, "Invalid unit code.", 400);
+  }
   if (branch === "main") {
     return sendErrorResponse(res, "Cannot delete images on the main branch.", 400);
   }
@@ -22,7 +26,7 @@ const deleteImage = async (req: Request, res: Response) => {
   if (!fileName) {
     return sendErrorResponse(res, "Missing required body parameter: fileName.", 400);
   }
-  if (!/^[a-zA-Z0-9._-]+$/.test(fileName)) {
+  if (!isValidImageFileName(fileName)) {
     return sendErrorResponse(res, "Invalid fileName: only alphanumeric, dash, underscore, and dot are allowed.", 400);
   }
 
@@ -62,7 +66,8 @@ const deleteImage = async (req: Request, res: Response) => {
     return sendSuccessResponse(res, {});
   } catch (error) {
     console.error("Failed to delete image:", error);
-    return sendErrorResponse(res, "An error occurred while deleting the image.", 500);
+    const {message, statusCode} = describeGitHubError(error, "An error occurred while deleting the image.");
+    return sendErrorResponse(res, message, statusCode);
   }
 };
 

--- a/authoring-api/src/routes/delete-image.ts
+++ b/authoring-api/src/routes/delete-image.ts
@@ -1,0 +1,69 @@
+import {Request, Response} from "express";
+import {Octokit} from "@octokit/rest";
+
+import {AuthorizedRequest, sendErrorResponse, sendSuccessResponse} from "../helpers/express";
+import {owner, repo} from "../helpers/github";
+import {escapeFirebaseKey, getDb, getUnitFilesPath} from "../helpers/db";
+import {computeImageUsages} from "../helpers/unit-content";
+
+// Deletes a library image from GitHub and the Firebase files map. Only permitted when the image is
+// unused in the current unit + teacher guide (re-verified here so a stale client can't force it).
+const deleteImage = async (req: Request, res: Response) => {
+  const unit = req.query.unit?.toString();
+  const branch = req.query.branch?.toString();
+  if (!unit || !branch) {
+    return sendErrorResponse(res, "Missing required parameters: unit or branch.", 400);
+  }
+  if (branch === "main") {
+    return sendErrorResponse(res, "Cannot delete images on the main branch.", 400);
+  }
+
+  const fileName = req.body.fileName?.toString();
+  if (!fileName) {
+    return sendErrorResponse(res, "Missing required body parameter: fileName.", 400);
+  }
+  if (!/^[a-zA-Z0-9._-]+$/.test(fileName)) {
+    return sendErrorResponse(res, "Invalid fileName: only alphanumeric, dash, underscore, and dot are allowed.", 400);
+  }
+
+  const imageKey = `images/${fileName}`;
+
+  try {
+    const usages = await computeImageUsages(branch, unit);
+    const refs = usages[imageKey];
+    if (refs === undefined) {
+      return sendErrorResponse(res, `Image "${fileName}" was not found in the library.`, 404);
+    }
+    if (refs.length > 0) {
+      return sendErrorResponse(res, `Cannot delete "${fileName}": it is used in ${refs.length} place(s).`, 409);
+    }
+
+    const db = getDb();
+    const fileRef = db.ref(getUnitFilesPath(branch, unit));
+    const escapedKey = escapeFirebaseKey(imageKey);
+    const snapshot = await fileRef.child(escapedKey).get();
+    if (!snapshot.exists()) {
+      return sendErrorResponse(res, `Image "${fileName}" was not found in the library.`, 404);
+    }
+    const sha = snapshot.val().sha;
+
+    const octokit = new Octokit({auth: (req as AuthorizedRequest).gitHubToken});
+    await octokit.rest.repos.deleteFile({
+      owner,
+      repo,
+      branch,
+      path: `curriculum/${unit}/images/${fileName}`,
+      message: `Delete image ${fileName} from unit ${unit}`,
+      sha,
+    });
+
+    await fileRef.child(escapedKey).remove();
+
+    return sendSuccessResponse(res, {});
+  } catch (error) {
+    console.error("Failed to delete image:", error);
+    return sendErrorResponse(res, "An error occurred while deleting the image.", 500);
+  }
+};
+
+export default deleteImage;

--- a/authoring-api/src/routes/get-image-usages.ts
+++ b/authoring-api/src/routes/get-image-usages.ts
@@ -1,0 +1,25 @@
+import {Request, Response} from "express";
+
+import {sendErrorResponse, sendSuccessResponse} from "../helpers/express";
+import {computeImageUsages} from "../helpers/unit-content";
+
+// Returns, per library image key ("images/{file}"), the list of content-file paths (relative to
+// curriculum/{unit}/) that reference it. Count = list length; unused images map to []. Scoped to
+// the current unit + its teacher guide.
+const getImageUsages = async (req: Request, res: Response) => {
+  const unit = req.query.unit?.toString();
+  const branch = req.query.branch?.toString();
+  if (!unit || !branch) {
+    return sendErrorResponse(res, "Missing required parameters: unit or branch.", 400);
+  }
+
+  try {
+    const usages = await computeImageUsages(branch, unit);
+    return sendSuccessResponse(res, {usages});
+  } catch (error) {
+    console.error("Failed to compute image usages:", error);
+    return sendErrorResponse(res, "An error occurred while computing image usages.", 500);
+  }
+};
+
+export default getImageUsages;

--- a/authoring-api/src/routes/get-image-usages.ts
+++ b/authoring-api/src/routes/get-image-usages.ts
@@ -2,6 +2,7 @@ import {Request, Response} from "express";
 
 import {sendErrorResponse, sendSuccessResponse} from "../helpers/express";
 import {computeImageUsages} from "../helpers/unit-content";
+import {isValidUnitCode} from "../helpers/image-references";
 
 // Returns, per library image key ("images/{file}"), the list of content-file paths (relative to
 // curriculum/{unit}/) that reference it. Count = list length; unused images map to []. Scoped to
@@ -11,6 +12,9 @@ const getImageUsages = async (req: Request, res: Response) => {
   const branch = req.query.branch?.toString();
   if (!unit || !branch) {
     return sendErrorResponse(res, "Missing required parameters: unit or branch.", 400);
+  }
+  if (!isValidUnitCode(unit)) {
+    return sendErrorResponse(res, "Invalid unit code.", 400);
   }
 
   try {

--- a/authoring-api/src/routes/rename-image.ts
+++ b/authoring-api/src/routes/rename-image.ts
@@ -1,0 +1,112 @@
+import {Request, Response} from "express";
+import admin from "firebase-admin";
+import {Octokit} from "@octokit/rest";
+
+import {AuthorizedRequest, sendErrorResponse, sendSuccessResponse} from "../helpers/express";
+import {owner, repo} from "../helpers/github";
+import {
+  escapeFirebaseKey, getDb, getUnitFilesPath, getUnitMetadataUpdatesPath,
+} from "../helpers/db";
+import {getUnitContent, readEffectiveContentText, stageContentUpdate} from "../helpers/unit-content";
+import {rewriteImageReference} from "../helpers/image-references";
+
+// Renames a library image and rewrites every reference to it (current unit + teacher guide) so
+// used images can be renamed without breaking content.
+//
+// The image file is moved in GitHub immediately (a single tree commit that re-points the existing
+// blob to the new path and removes the old one). The reference rewrites are staged as unpushed
+// "updates" — the author pushes them through the normal pipeline; previews resolve them right away.
+const renameImage = async (req: Request, res: Response) => {
+  const unit = req.query.unit?.toString();
+  const branch = req.query.branch?.toString();
+  if (!unit || !branch) {
+    return sendErrorResponse(res, "Missing required parameters: unit or branch.", 400);
+  }
+  if (branch === "main") {
+    return sendErrorResponse(res, "Cannot rename images on the main branch.", 400);
+  }
+
+  const fromFileName = req.body.fromFileName?.toString();
+  const toFileName = req.body.toFileName?.toString();
+  if (!fromFileName || !toFileName) {
+    return sendErrorResponse(res, "Missing required body parameters: fromFileName or toFileName.", 400);
+  }
+  if (fromFileName === toFileName) {
+    return sendErrorResponse(res, "The new name matches the current name.", 400);
+  }
+  if (!/^[a-zA-Z0-9._-]+$/.test(toFileName)) {
+    return sendErrorResponse(res, "Invalid name: only alphanumeric, dash, underscore, and dot are allowed.", 400);
+  }
+
+  const fromKey = `images/${fromFileName}`;
+  const toKey = `images/${toFileName}`;
+
+  try {
+    const db = getDb();
+    const filesRef = db.ref(getUnitFilesPath(branch, unit));
+    const escapedFrom = escapeFirebaseKey(fromKey);
+    const escapedTo = escapeFirebaseKey(toKey);
+
+    const [fromSnap, toSnap] = await Promise.all([
+      filesRef.child(escapedFrom).get(),
+      filesRef.child(escapedTo).get(),
+    ]);
+    if (!fromSnap.exists()) {
+      return sendErrorResponse(res, `Image "${fromFileName}" was not found in the library.`, 404);
+    }
+    if (toSnap.exists()) {
+      return sendErrorResponse(res, `An image named "${toFileName}" already exists.`, 409);
+    }
+    const fileData = fromSnap.val();
+    const blobSha: string = fileData.sha;
+
+    // Move the blob in GitHub as a single commit: add new path (reusing the existing blob sha),
+    // remove the old path. Follows the tree/commit pattern in push-unit.ts.
+    const octokit = new Octokit({auth: (req as AuthorizedRequest).gitHubToken});
+    const ref = await octokit.rest.git.getRef({owner, repo, ref: `heads/${branch}`});
+    const latestCommitSha = ref.data.object.sha;
+    const baseCommit = await octokit.rest.git.getCommit({owner, repo, commit_sha: latestCommitSha});
+    const tree = await octokit.rest.git.createTree({
+      owner,
+      repo,
+      base_tree: baseCommit.data.tree.sha,
+      tree: [
+        {path: `curriculum/${unit}/images/${toFileName}`, mode: "100644", type: "blob", sha: blobSha},
+        {path: `curriculum/${unit}/images/${fromFileName}`, mode: "100644", type: "blob", sha: null},
+      ],
+    });
+    const commit = await octokit.rest.git.createCommit({
+      owner,
+      repo,
+      message: `Rename image ${fromFileName} to ${toFileName} in unit ${unit}`,
+      tree: tree.data.sha,
+      parents: [latestCommitSha],
+    });
+    await octokit.rest.git.updateRef({owner, repo, ref: `heads/${branch}`, sha: commit.data.sha, force: false});
+
+    // Update the files map: drop the old key, add the new one (same blob, so same sha).
+    await filesRef.child(escapedFrom).remove();
+    await filesRef.child(escapedTo).set(fileData);
+
+    // Rewrite references across the unit's content and stage them as unpushed updates.
+    const {contentFiles} = await getUnitContent(branch, unit);
+    let updatedFileCount = 0;
+    await Promise.all(contentFiles.map(async (file) => {
+      const text = await readEffectiveContentText(branch, unit, file);
+      const {text: rewritten, changed} = rewriteImageReference(unit, text, fromFileName, toFileName);
+      if (changed) {
+        updatedFileCount++;
+        await stageContentUpdate(branch, unit, file.escapedPath, rewritten);
+        await db.ref(getUnitMetadataUpdatesPath(branch, unit, file.escapedPath))
+          .set(admin.database.ServerValue.TIMESTAMP);
+      }
+    }));
+
+    return sendSuccessResponse(res, {updatedFileCount});
+  } catch (error) {
+    console.error("Failed to rename image:", error);
+    return sendErrorResponse(res, "An error occurred while renaming the image.", 500);
+  }
+};
+
+export default renameImage;

--- a/authoring-api/src/routes/rename-image.ts
+++ b/authoring-api/src/routes/rename-image.ts
@@ -117,7 +117,38 @@ const renameImage = async (req: Request, res: Response) => {
       updates[getUnitUpdatesPath(branch, unit, escapedPath)] = rewritten;
       updates[getUnitMetadataUpdatesPath(branch, unit, escapedPath)] = admin.database.ServerValue.TIMESTAMP;
     });
-    await db.ref().update(updates);
+    try {
+      await db.ref().update(updates);
+    } catch (dbError) {
+      // The GitHub blob already moved but Firebase didn't record it, so the unit is half-renamed
+      // (blob only at the new path, files-map still pointing at the old one). Best-effort revert the
+      // commit to restore consistency; if even the revert fails, a unit re-pull resyncs from GitHub.
+      console.error("Firebase update failed after the GitHub rename; reverting the commit.", dbError);
+      try {
+        const revertTree = await octokit.rest.git.createTree({
+          owner,
+          repo,
+          base_tree: commit.data.tree.sha,
+          tree: [
+            {path: `curriculum/${unit}/images/${fromFileName}`, mode: "100644", type: "blob", sha: blobSha},
+            {path: `curriculum/${unit}/images/${toFileName}`, mode: "100644", type: "blob", sha: null},
+          ],
+        });
+        const revertCommit = await octokit.rest.git.createCommit({
+          owner,
+          repo,
+          message: `Revert rename of ${fromFileName} (could not persist in Firebase)`,
+          tree: revertTree.data.sha,
+          parents: [commit.data.sha],
+        });
+        await octokit.rest.git.updateRef({
+          owner, repo, ref: `heads/${branch}`, sha: revertCommit.data.sha, force: false,
+        });
+      } catch (revertError) {
+        console.error("Revert also failed; unit may be inconsistent until re-pulled.", revertError);
+      }
+      throw dbError;
+    }
 
     return sendSuccessResponse(res, {updatedFileCount: rewrites.length});
   } catch (error) {

--- a/authoring-api/src/routes/rename-image.ts
+++ b/authoring-api/src/routes/rename-image.ts
@@ -3,12 +3,14 @@ import admin from "firebase-admin";
 import {Octokit} from "@octokit/rest";
 
 import {AuthorizedRequest, sendErrorResponse, sendSuccessResponse} from "../helpers/express";
-import {owner, repo} from "../helpers/github";
+import {describeGitHubError, owner, repo} from "../helpers/github";
 import {
-  escapeFirebaseKey, getDb, getUnitFilesPath, getUnitMetadataUpdatesPath,
+  escapeFirebaseKey, getDb, getUnitFilesPath, getUnitMetadataUpdatesPath, getUnitUpdatesPath,
 } from "../helpers/db";
-import {getUnitContent, readEffectiveContentText, stageContentUpdate} from "../helpers/unit-content";
-import {rewriteImageReference} from "../helpers/image-references";
+import {getUnitContent, readEffectiveContentText} from "../helpers/unit-content";
+import {
+  isPathSafeImageFileName, isValidImageFileName, isValidUnitCode, rewriteImageReference,
+} from "../helpers/image-references";
 
 // Renames a library image and rewrites every reference to it (current unit + teacher guide) so
 // used images can be renamed without breaking content.
@@ -22,6 +24,9 @@ const renameImage = async (req: Request, res: Response) => {
   if (!unit || !branch) {
     return sendErrorResponse(res, "Missing required parameters: unit or branch.", 400);
   }
+  if (!isValidUnitCode(unit)) {
+    return sendErrorResponse(res, "Invalid unit code.", 400);
+  }
   if (branch === "main") {
     return sendErrorResponse(res, "Cannot rename images on the main branch.", 400);
   }
@@ -34,7 +39,13 @@ const renameImage = async (req: Request, res: Response) => {
   if (fromFileName === toFileName) {
     return sendErrorResponse(res, "The new name matches the current name.", 400);
   }
-  if (!/^[a-zA-Z0-9._-]+$/.test(toFileName)) {
+  // The source need only be safe to interpolate as a path (no separators/traversal) — this lets
+  // authors rename messy legacy names (spaces, "&", etc.) toward clean ones. The destination is held
+  // to the strict allowlist so every rename moves toward a clean name.
+  if (!isPathSafeImageFileName(fromFileName)) {
+    return sendErrorResponse(res, "Invalid current name: it must not contain slashes or control characters.", 400);
+  }
+  if (!isValidImageFileName(toFileName)) {
     return sendErrorResponse(res, "Invalid name: only alphanumeric, dash, underscore, and dot are allowed.", 400);
   }
 
@@ -60,8 +71,18 @@ const renameImage = async (req: Request, res: Response) => {
     const fileData = fromSnap.val();
     const blobSha: string = fileData.sha;
 
+    // Compute all reference rewrites BEFORE mutating anything, so a read failure here leaves the
+    // unit completely untouched rather than half-renamed.
+    const {contentFiles} = await getUnitContent(branch, unit);
+    const rewrites = (await Promise.all(contentFiles.map(async (file) => {
+      const text = await readEffectiveContentText(branch, unit, file);
+      const {text: rewritten, changed} = rewriteImageReference(unit, text, fromFileName, toFileName);
+      return changed ? {escapedPath: file.escapedPath, rewritten} : null;
+    }))).filter((r): r is {escapedPath: string; rewritten: string} => r !== null);
+
     // Move the blob in GitHub as a single commit: add new path (reusing the existing blob sha),
-    // remove the old path. Follows the tree/commit pattern in push-unit.ts.
+    // remove the old path. Follows the tree/commit pattern in push-unit.ts. This is the only
+    // irreversible step, so it runs first — if it fails, nothing in Firebase has changed yet.
     const octokit = new Octokit({auth: (req as AuthorizedRequest).gitHubToken});
     const ref = await octokit.rest.git.getRef({owner, repo, ref: `heads/${branch}`});
     const latestCommitSha = ref.data.object.sha;
@@ -84,28 +105,25 @@ const renameImage = async (req: Request, res: Response) => {
     });
     await octokit.rest.git.updateRef({owner, repo, ref: `heads/${branch}`, sha: commit.data.sha, force: false});
 
-    // Update the files map: drop the old key, add the new one (same blob, so same sha).
-    await filesRef.child(escapedFrom).remove();
-    await filesRef.child(escapedTo).set(fileData);
+    // Apply every Firebase change in a single atomic multi-location update so the files-map swap and
+    // the staged reference rewrites can't land partially: the old image key is dropped and the new
+    // one added (same blob, so same sha), and each rewritten content file is staged as an unpushed
+    // update with a metadata timestamp (the same updates + metadata shape put-content writes).
+    const updates: Record<string, unknown> = {
+      [getUnitFilesPath(branch, unit, escapedFrom)]: null,
+      [getUnitFilesPath(branch, unit, escapedTo)]: fileData,
+    };
+    rewrites.forEach(({escapedPath, rewritten}) => {
+      updates[getUnitUpdatesPath(branch, unit, escapedPath)] = rewritten;
+      updates[getUnitMetadataUpdatesPath(branch, unit, escapedPath)] = admin.database.ServerValue.TIMESTAMP;
+    });
+    await db.ref().update(updates);
 
-    // Rewrite references across the unit's content and stage them as unpushed updates.
-    const {contentFiles} = await getUnitContent(branch, unit);
-    let updatedFileCount = 0;
-    await Promise.all(contentFiles.map(async (file) => {
-      const text = await readEffectiveContentText(branch, unit, file);
-      const {text: rewritten, changed} = rewriteImageReference(unit, text, fromFileName, toFileName);
-      if (changed) {
-        updatedFileCount++;
-        await stageContentUpdate(branch, unit, file.escapedPath, rewritten);
-        await db.ref(getUnitMetadataUpdatesPath(branch, unit, file.escapedPath))
-          .set(admin.database.ServerValue.TIMESTAMP);
-      }
-    }));
-
-    return sendSuccessResponse(res, {updatedFileCount});
+    return sendSuccessResponse(res, {updatedFileCount: rewrites.length});
   } catch (error) {
     console.error("Failed to rename image:", error);
-    return sendErrorResponse(res, "An error occurred while renaming the image.", 500);
+    const {message, statusCode} = describeGitHubError(error, "An error occurred while renaming the image.");
+    return sendErrorResponse(res, message, statusCode);
   }
 };
 

--- a/src/authoring/components/media-library.scss
+++ b/src/authoring/components/media-library.scss
@@ -148,6 +148,7 @@
       }
 
       .media-library-image-thumb {
+        position: relative;
         border: 2px solid transparent;
         border-radius: 6px;
         padding: 2px;
@@ -172,6 +173,25 @@
         border-radius: 4px;
         display: block;
       }
+
+      .media-library-thumb-badge {
+        position: absolute;
+        top: 2px;
+        right: 2px;
+        min-width: 16px;
+        height: 16px;
+        padding: 0 4px;
+        box-sizing: border-box;
+        border-radius: 8px;
+        background: $workspace-teal;
+        color: #fff;
+        font-size: 0.7em;
+        line-height: 16px;
+        text-align: center;
+        &.unused {
+          background: $charcoal-light-2;
+        }
+      }
     }
 
     .media-library-preview {
@@ -179,21 +199,31 @@
       display: flex;
       flex-direction: column;
       align-items: center;
-      justify-content: center;
+      justify-content: flex-start;
       background: #fff;
       overflow: auto;
       padding: 10px;
 
+      // Controls live above the image so they remain visible for tall images.
+      .media-library-preview-controls {
+        width: 100%;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 8px;
+        padding-bottom: 10px;
+        margin-bottom: 10px;
+        border-bottom: 1px solid #eee;
+      }
+
       .media-library-preview-img {
         max-width: 100%;
-        max-height: 100%;
         object-fit: contain;
         border-radius: 4px;
         box-shadow: 0 2px 8px rgba(0,0,0,0.08);
       }
 
       .media-library-preview-filename {
-        margin-top: 10px;
         color: #888;
         font-size: 0.95em;
         text-align: center;
@@ -201,7 +231,6 @@
       }
 
       .media-library-select-btn {
-        margin-top: 16px;
         padding: 6px 18px;
         background: $color7;
         color: #fff;
@@ -218,6 +247,124 @@
       .media-library-no-preview {
         color: #aaa;
         font-size: 1.1em;
+      }
+
+      .media-library-usage {
+        font-size: 0.9em;
+        text-align: center;
+
+        .media-library-usage-text {
+          color: $charcoal-dark-2;
+          font-weight: 600;
+        }
+
+        .media-library-usage-toggle {
+          background: none;
+          border: none;
+          color: $color7;
+          cursor: pointer;
+          font-size: 1em;
+          padding: 2px 4px;
+          display: inline-flex;
+          align-items: center;
+          gap: 4px;
+
+          .disclosure-caret {
+            border: solid currentColor;
+            border-width: 0 2px 2px 0;
+            display: inline-block;
+            padding: 2px;
+            transform: rotate(-45deg);
+            transition: transform 0.15s;
+          }
+          &.expanded .disclosure-caret {
+            transform: rotate(45deg);
+          }
+        }
+
+        .media-library-usage-list {
+          list-style: none;
+          margin: 4px 0 0 0;
+          padding: 4px 8px;
+          max-height: 140px;
+          overflow-y: auto;
+          text-align: left;
+          background: #fafbfc;
+          border: 1px solid #eee;
+          border-radius: 4px;
+
+          li {
+            font-size: 0.9em;
+            color: $charcoal-dark-2;
+            padding: 2px 0;
+          }
+        }
+      }
+
+      .media-library-image-actions {
+        text-align: center;
+
+        .media-library-action-buttons {
+          display: flex;
+          gap: 8px;
+          justify-content: center;
+        }
+
+        .media-library-rename-btn,
+        .media-library-delete-btn {
+          padding: 5px 14px;
+          border: 1px solid $charcoal-light-2;
+          border-radius: 4px;
+          background: $charcoal-light-5;
+          color: $charcoal-dark-2;
+          cursor: pointer;
+          transition: background 0.2s;
+          &:hover {
+            background: $workspace-teal-light-6;
+          }
+        }
+
+        .media-library-delete-btn {
+          color: #c00;
+          border-color: #e0b4b4;
+          background: #fcf3f3;
+          &:hover {
+            background: #f7e2e2;
+          }
+          &:disabled {
+            color: #bbb;
+            border-color: #eee;
+            background: #f7f7f7;
+            cursor: not-allowed;
+          }
+        }
+
+        .media-library-rename {
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          gap: 6px;
+
+          .media-library-rename-input {
+            padding: 5px;
+            width: 220px;
+            box-sizing: border-box;
+          }
+          .media-library-rename-buttons {
+            display: flex;
+            gap: 8px;
+          }
+          .media-library-rename-error {
+            color: #c00;
+            font-size: 0.85em;
+          }
+        }
+
+        .media-library-action-message {
+          margin-top: 8px;
+          font-size: 0.85em;
+          color: #666;
+        }
       }
     }
   }

--- a/src/authoring/components/media-library.scss
+++ b/src/authoring/components/media-library.scss
@@ -358,6 +358,10 @@
             color: #c00;
             font-size: 0.85em;
           }
+          .media-library-rename-preview {
+            font-size: 0.85em;
+            color: #666;
+          }
         }
 
         .media-library-action-message {

--- a/src/authoring/components/media-library.test.tsx
+++ b/src/authoring/components/media-library.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import React from "react";
+
+import MediaLibrary from "./media-library";
+
+const mockGet = jest.fn();
+const mockPost = jest.fn();
+const mockReloadAllPreviews = jest.fn();
+
+// Stable references — the real hooks return stable values, and refreshUsages depends on `api`
+// identity, so a fresh object per render would loop the mount effect.
+const mockApi = { get: mockGet, post: mockPost };
+const mockPreview = { reloadAllPreviews: mockReloadAllPreviews };
+
+const mockCurriculumValue = {
+  files: { "images/old.png": { sha: "abc" } } as Record<string, { sha: string }>,
+  branch: "feature-branch",
+  unit: "sas",
+  unitConfig: undefined,
+  teacherGuideConfig: undefined
+};
+
+jest.mock("../hooks/use-curriculum", () => ({
+  useCurriculum: () => mockCurriculumValue
+}));
+jest.mock("../hooks/use-authoring-api", () => ({
+  useAuthoringApi: () => mockApi
+}));
+jest.mock("../hooks/use-authoring-preview", () => ({
+  useAuthoringPreview: () => mockPreview
+}));
+
+describe("MediaLibrary rename flow", () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+    mockPost.mockReset();
+    mockReloadAllPreviews.mockReset();
+    // The library auto-selects the first image and loads its usages on mount.
+    mockGet.mockResolvedValue({ success: true, usages: { "images/old.png": [] } });
+  });
+
+  const startRename = async (newName: string) => {
+    render(<MediaLibrary onClose={jest.fn()} />);
+    // Wait for the mount-time usage load to settle before interacting.
+    await screen.findByText("Not used in the curriculum");
+    fireEvent.click(screen.getByRole("button", { name: "Rename" }));
+    const input = screen.getByLabelText("New image filename") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: newName } });
+    return input;
+  };
+
+  it("shows the confirmation message after a successful rename (not swallowed by selection change)", async () => {
+    mockPost.mockResolvedValue({ success: true, updatedFileCount: 2 });
+    await startRename("new.png");
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("status")).toHaveTextContent("Renamed to new.png. Updated 2 references.");
+    });
+    expect(mockPost).toHaveBeenCalledWith(
+      "/renameImage", { branch: "feature-branch", unit: "sas" },
+      { fromFileName: "old.png", toFileName: "new.png" });
+    // A successful rename re-loads usages; let that settle so no state updates escape the test.
+    await waitFor(() => expect(mockGet).toHaveBeenCalledTimes(2));
+  });
+
+  it("disables the Save button while a rename request is in flight", async () => {
+    let resolvePost: (v: unknown) => void = () => undefined;
+    mockPost.mockReturnValue(new Promise(resolve => { resolvePost = resolve; }));
+    await startRename("new.png");
+
+    const saveButton = screen.getByRole("button", { name: "Save" });
+    fireEvent.click(saveButton);
+    // In flight: the button is disabled so a second click can't double-submit.
+    await waitFor(() => expect(saveButton).toBeDisabled());
+    expect(mockPost).toHaveBeenCalledTimes(1);
+
+    resolvePost({ success: true, updatedFileCount: 0 });
+    await waitFor(() => expect(screen.getByRole("status")).toBeInTheDocument());
+    await waitFor(() => expect(mockGet).toHaveBeenCalledTimes(2));
+  });
+
+  it("previews the sanitized name when the typed name contains invalid characters", async () => {
+    const input = await startRename("file with spaces.jpg");
+    // The space-containing name is silently rewritten before submit; show the author the result.
+    await waitFor(() => {
+      expect(screen.getByText("Will be saved as: file-with-spaces.jpg")).toBeInTheDocument();
+    });
+    expect(input).toHaveAttribute("aria-describedby", "media-library-rename-preview");
+  });
+
+  it("does not show a preview when the typed name needs no sanitizing", async () => {
+    await startRename("clean-name.jpg");
+    expect(screen.queryByText(/Will be saved as:/)).not.toBeInTheDocument();
+  });
+
+  it("surfaces a rename error in an alert region without changing selection", async () => {
+    mockPost.mockResolvedValue({ success: false, error: "An image named \"new.png\" already exists." });
+    await startRename("new.png");
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent("already exists");
+    });
+  });
+});

--- a/src/authoring/components/media-library.test.tsx
+++ b/src/authoring/components/media-library.test.tsx
@@ -105,4 +105,23 @@ describe("MediaLibrary rename flow", () => {
       expect(screen.getByRole("alert")).toHaveTextContent("already exists");
     });
   });
+
+  it("badges only images the usage scan covered (a missing key is unknown, not 0/unused)", async () => {
+    const originalFiles = mockCurriculumValue.files;
+    mockCurriculumValue.files = {
+      "images/old.png": { sha: "abc" },
+      "images/just-uploaded.png": { sha: "def" },
+    };
+    try {
+      // The mount usage load (beforeEach) covers only old.png; just-uploaded.png is absent from the
+      // map, so it must render no badge rather than a misleading "0".
+      const { container } = render(<MediaLibrary onClose={jest.fn()} />);
+      await screen.findByText("Not used in the curriculum");
+      const badges = container.querySelectorAll(".media-library-thumb-badge");
+      expect(badges).toHaveLength(1);
+      expect(badges[0]).toHaveTextContent("0");
+    } finally {
+      mockCurriculumValue.files = originalFiles;
+    }
+  });
 });

--- a/src/authoring/components/media-library.tsx
+++ b/src/authoring/components/media-library.tsx
@@ -4,7 +4,7 @@ import Modal from "./modal";
 import { useCurriculum } from "../hooks/use-curriculum";
 import { useAuthoringApi } from "../hooks/use-authoring-api";
 import { useAuthoringPreview } from "../hooks/use-authoring-preview";
-import { sanitizeFileName } from "../utils/sanitize-filename";
+import { hasValidImageExtension, sanitizeFileName } from "../utils/sanitize-filename";
 import { describeUsagePath, formatLocation } from "../utils/image-usage-locations";
 
 import "./media-library.scss";
@@ -242,6 +242,10 @@ const MediaLibrary: React.FC<IProps> = ({ onClose }) => {
     const sanitized = sanitizeFileName(renameValue.trim());
     if (!sanitized || sanitized === selectedFileName) {
       setRenameError("Enter a different, valid filename.");
+      return;
+    }
+    if (!hasValidImageExtension(sanitized)) {
+      setRenameError("Include a file extension (e.g. .png) so the image can be displayed.");
       return;
     }
     const targetKey = `images/${sanitized}`;

--- a/src/authoring/components/media-library.tsx
+++ b/src/authoring/components/media-library.tsx
@@ -1,10 +1,11 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import classNames from "classnames";
 import Modal from "./modal";
 import { useCurriculum } from "../hooks/use-curriculum";
 import { useAuthoringApi } from "../hooks/use-authoring-api";
 import { useAuthoringPreview } from "../hooks/use-authoring-preview";
 import { sanitizeFileName } from "../utils/sanitize-filename";
-import { describeUsagePath, UsageLocation } from "../utils/image-usage-locations";
+import { describeUsagePath, formatLocation } from "../utils/image-usage-locations";
 
 import "./media-library.scss";
 
@@ -13,15 +14,6 @@ interface IProps {
 }
 
 const fileNameFromKey = (key: string) => key.replace(/^images\//, "");
-
-const formatLocation = (loc: UsageLocation) => {
-  const parts: string[] = [];
-  if (loc.isTeacherGuide) parts.push("Teacher Guide");
-  if (loc.investigationTitle) parts.push(loc.investigationTitle);
-  if (loc.problemTitle) parts.push(loc.problemTitle);
-  const label = parts.join(" / ") || loc.path;
-  return loc.sectionType ? `${label} · ${loc.sectionType}` : label;
-};
 
 const MediaLibrary: React.FC<IProps> = ({ onClose }) => {
   const { files, branch, unit, unitConfig, teacherGuideConfig } = useCurriculum();
@@ -44,9 +36,11 @@ const MediaLibrary: React.FC<IProps> = ({ onClose }) => {
   const [renameValue, setRenameValue] = useState("");
   const [renameError, setRenameError] = useState<string | null>(null);
   const [actionMessage, setActionMessage] = useState<string | null>(null);
+  // True while a rename/delete request is in flight, to guard against double-submits.
+  const [actionPending, setActionPending] = useState(false);
 
   const imageFileKeys = useMemo(() => {
-    return Object.keys(files ?? {}).filter(key => key.startsWith("images"));
+    return Object.keys(files ?? {}).filter(key => key.startsWith("images/"));
   }, [files]);
 
   const refreshUsages = useCallback(async () => {
@@ -194,20 +188,29 @@ const MediaLibrary: React.FC<IProps> = ({ onClose }) => {
   const selectedRefs = selectedKey && usages ? usages[selectedKey] : undefined;
   const selectedUsageCount = selectedRefs?.length;
 
-  // Reset per-image UI state whenever the selection changes.
+  // Reset per-image UI state whenever the selection changes. (The action message is intentionally
+  // left alone here: a successful rename re-points the selection to the new key, and clearing it on
+  // that change would swallow the "Renamed to…" confirmation. Manual selection clears it instead.)
   useEffect(() => {
     setUsageExpanded(false);
     setRenaming(false);
     setRenameError(null);
-    setActionMessage(null);
   }, [selectedKey]);
 
+  // User-initiated selection (clicking a thumbnail): clear any lingering action message.
+  const handleSelectKey = (key: string) => {
+    setActionMessage(null);
+    setSelectedKey(key);
+  };
+
   const handleDeleteImage = async () => {
+    if (actionPending) return;
     if (!branch || !unit || !selectedFileName || selectedUsageCount !== 0) return;
     const confirmed = window.confirm(
       `Delete "${selectedFileName}"? It is unused, but this removes it from the unit and cannot be undone.`
     );
     if (!confirmed) return;
+    setActionPending(true);
     try {
       const response = await api.post("/deleteImage", { branch, unit }, { fileName: selectedFileName });
       if (response.success) {
@@ -221,6 +224,8 @@ const MediaLibrary: React.FC<IProps> = ({ onClose }) => {
       }
     } catch (error) {
       setActionMessage(error instanceof Error ? error.message : "Delete failed.");
+    } finally {
+      setActionPending(false);
     }
   };
 
@@ -231,6 +236,7 @@ const MediaLibrary: React.FC<IProps> = ({ onClose }) => {
   };
 
   const handleRenameSubmit = async () => {
+    if (actionPending) return;
     if (!branch || !unit || !selectedFileName) return;
     const sanitized = sanitizeFileName(renameValue.trim());
     if (!sanitized || sanitized === selectedFileName) {
@@ -242,6 +248,7 @@ const MediaLibrary: React.FC<IProps> = ({ onClose }) => {
       setRenameError(`An image named "${sanitized}" already exists.`);
       return;
     }
+    setActionPending(true);
     try {
       const response = await api.post(
         "/renameImage", { branch, unit }, { fromFileName: selectedFileName, toFileName: sanitized });
@@ -257,6 +264,8 @@ const MediaLibrary: React.FC<IProps> = ({ onClose }) => {
       }
     } catch (error) {
       setRenameError(error instanceof Error ? error.message : "Rename failed.");
+    } finally {
+      setActionPending(false);
     }
   };
 
@@ -280,7 +289,7 @@ const MediaLibrary: React.FC<IProps> = ({ onClose }) => {
         {hasLocations && (
           <button
             type="button"
-            className={"media-library-usage-toggle" + (usageExpanded ? " expanded" : "")}
+            className={classNames("media-library-usage-toggle", { expanded: usageExpanded })}
             aria-expanded={usageExpanded}
             onClick={() => setUsageExpanded(v => !v)}
           >
@@ -303,6 +312,15 @@ const MediaLibrary: React.FC<IProps> = ({ onClose }) => {
 
   const renderImageActions = () => {
     if (!selectedKey) return null;
+    // Preview the name the rename will actually use: invalid characters (spaces, &, etc.) are
+    // silently rewritten by sanitizeFileName, so show the result when it differs from what's typed
+    // rather than letting the author guess. handleRenameSubmit sanitizes the same way.
+    const trimmedRename = renameValue.trim();
+    const renamePreview = trimmedRename ? sanitizeFileName(trimmedRename) : "";
+    const showRenamePreview = !!renamePreview && renamePreview !== trimmedRename;
+    const renameDescribedBy = renameError
+      ? "media-library-rename-error"
+      : (showRenamePreview ? "media-library-rename-preview" : undefined);
     return (
       <div className="media-library-image-actions">
         {renaming ? (
@@ -310,30 +328,46 @@ const MediaLibrary: React.FC<IProps> = ({ onClose }) => {
             <input
               type="text"
               className="media-library-rename-input"
+              aria-label="New image filename"
+              aria-invalid={renameError ? true : undefined}
+              aria-describedby={renameDescribedBy}
               value={renameValue}
               autoFocus
+              disabled={actionPending}
               onChange={e => setRenameValue(e.target.value)}
               onKeyDown={e => {
                 if (e.key === "Enter") handleRenameSubmit();
                 if (e.key === "Escape") setRenaming(false);
               }}
             />
+            {showRenamePreview &&
+              <div id="media-library-rename-preview" className="media-library-rename-preview">
+                Will be saved as: {renamePreview}
+              </div>}
             <div className="media-library-rename-buttons">
-              <button type="button" onClick={handleRenameSubmit}>Save</button>
-              <button type="button" onClick={() => setRenaming(false)}>Cancel</button>
+              <button type="button" onClick={handleRenameSubmit} disabled={actionPending}>Save</button>
+              <button type="button" onClick={() => setRenaming(false)} disabled={actionPending}>Cancel</button>
             </div>
-            {renameError && <div className="media-library-rename-error">{renameError}</div>}
+            {renameError &&
+              <div id="media-library-rename-error" className="media-library-rename-error" role="alert">
+                {renameError}
+              </div>}
           </div>
         ) : (
           <div className="media-library-action-buttons">
-            <button type="button" className="media-library-rename-btn" onClick={handleStartRename}>
+            <button
+              type="button"
+              className="media-library-rename-btn"
+              onClick={handleStartRename}
+              disabled={actionPending}
+            >
               Rename
             </button>
             <button
               type="button"
               className="media-library-delete-btn"
               onClick={handleDeleteImage}
-              disabled={selectedUsageCount !== 0}
+              disabled={actionPending || selectedUsageCount !== 0}
               title={selectedUsageCount === 0
                 ? "Delete this unused image"
                 : "Only unused images can be deleted"}
@@ -342,7 +376,7 @@ const MediaLibrary: React.FC<IProps> = ({ onClose }) => {
             </button>
           </div>
         )}
-        {actionMessage && <div className="media-library-action-message">{actionMessage}</div>}
+        {actionMessage && <div className="media-library-action-message" role="status">{actionMessage}</div>}
       </div>
     );
   };
@@ -377,8 +411,8 @@ const MediaLibrary: React.FC<IProps> = ({ onClose }) => {
               {filteredFileKeys.map(key => (
                 <div
                   key={key}
-                  className={"media-library-image-thumb" + (key === selectedKey ? " selected" : "")}
-                  onClick={() => setSelectedKey(key)}
+                  className={classNames("media-library-image-thumb", { selected: key === selectedKey })}
+                  onClick={() => handleSelectKey(key)}
                   title={key}
                 >
                   <img
@@ -389,8 +423,8 @@ const MediaLibrary: React.FC<IProps> = ({ onClose }) => {
                   />
                   {usages && (
                     <span
-                      className={"media-library-thumb-badge" +
-                        ((usages[key]?.length ?? 0) === 0 ? " unused" : "")}
+                      className={classNames("media-library-thumb-badge",
+                        { unused: (usages[key]?.length ?? 0) === 0 })}
                       title={`Used ${usages[key]?.length ?? 0}×`}
                     >
                       {usages[key]?.length ?? 0}
@@ -516,13 +550,13 @@ const MediaLibrary: React.FC<IProps> = ({ onClose }) => {
       <div className="media-library-content">
         <div className="media-library-tabs">
           <button
-            className={"media-library-tab" + (activeTab === "images" ? " active" : "")}
+            className={classNames("media-library-tab", { active: activeTab === "images" })}
             onClick={() => setActiveTab("images")}
           >
             Existing Images
           </button>
           <button
-            className={"media-library-tab" + (activeTab === "upload" ? " active" : "")}
+            className={classNames("media-library-tab", { active: activeTab === "upload" })}
             onClick={() => setActiveTab("upload")}
           >
             Upload New Image

--- a/src/authoring/components/media-library.tsx
+++ b/src/authoring/components/media-library.tsx
@@ -52,7 +52,8 @@ const MediaLibrary: React.FC<IProps> = ({ onClose }) => {
         setUsages(response.usages ?? {});
       }
     } catch (error) {
-      // Leave any prior usages in place; the manual refresh control can retry.
+      // Leave any prior usages in place; reopening the library, switching units, or a rename/delete
+      // re-runs this fetch.
       console.error("Failed to load image usages:", error);
     } finally {
       setUsagesLoading(false);
@@ -421,13 +422,16 @@ const MediaLibrary: React.FC<IProps> = ({ onClose }) => {
                     loading="lazy"
                     className="media-library-thumb-img"
                   />
-                  {usages && (
+                  {/* Only badge images the usage scan actually covered. A key missing from `usages`
+                      (e.g. a just-uploaded image not yet in a refreshed map) is unknown, not 0 —
+                      defaulting to 0 would wrongly mark it "unused". */}
+                  {usages?.[key] !== undefined && (
                     <span
                       className={classNames("media-library-thumb-badge",
-                        { unused: (usages[key]?.length ?? 0) === 0 })}
-                      title={`Used ${usages[key]?.length ?? 0}×`}
+                        { unused: usages[key].length === 0 })}
+                      title={`Used ${usages[key].length}×`}
                     >
-                      {usages[key]?.length ?? 0}
+                      {usages[key].length}
                     </span>
                   )}
                 </div>

--- a/src/authoring/components/media-library.tsx
+++ b/src/authoring/components/media-library.tsx
@@ -4,6 +4,7 @@ import { useCurriculum } from "../hooks/use-curriculum";
 import { useAuthoringApi } from "../hooks/use-authoring-api";
 import { useAuthoringPreview } from "../hooks/use-authoring-preview";
 import { sanitizeFileName } from "../utils/sanitize-filename";
+import { describeUsagePath, UsageLocation } from "../utils/image-usage-locations";
 
 import "./media-library.scss";
 
@@ -11,8 +12,19 @@ interface IProps {
   onClose: () => void;
 }
 
+const fileNameFromKey = (key: string) => key.replace(/^images\//, "");
+
+const formatLocation = (loc: UsageLocation) => {
+  const parts: string[] = [];
+  if (loc.isTeacherGuide) parts.push("Teacher Guide");
+  if (loc.investigationTitle) parts.push(loc.investigationTitle);
+  if (loc.problemTitle) parts.push(loc.problemTitle);
+  const label = parts.join(" / ") || loc.path;
+  return loc.sectionType ? `${label} · ${loc.sectionType}` : label;
+};
+
 const MediaLibrary: React.FC<IProps> = ({ onClose }) => {
-  const { files, branch, unit } = useCurriculum();
+  const { files, branch, unit, unitConfig, teacherGuideConfig } = useCurriculum();
   const api = useAuthoringApi();
   const authoringPreview = useAuthoringPreview();
   const [filter, setFilter] = useState("");
@@ -24,9 +36,39 @@ const MediaLibrary: React.FC<IProps> = ({ onClose }) => {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [sanitizedName, setSanitizedName] = useState<string | null>(null);
 
+  // Image usage map: image key ("images/{file}") -> referencing content-file paths.
+  const [usages, setUsages] = useState<Record<string, string[]> | null>(null);
+  const [usagesLoading, setUsagesLoading] = useState(false);
+  const [usageExpanded, setUsageExpanded] = useState(false);
+  const [renaming, setRenaming] = useState(false);
+  const [renameValue, setRenameValue] = useState("");
+  const [renameError, setRenameError] = useState<string | null>(null);
+  const [actionMessage, setActionMessage] = useState<string | null>(null);
+
   const imageFileKeys = useMemo(() => {
     return Object.keys(files ?? {}).filter(key => key.startsWith("images"));
   }, [files]);
+
+  const refreshUsages = useCallback(async () => {
+    if (!branch || !unit) return;
+    setUsagesLoading(true);
+    try {
+      const response = await api.get("/getImageUsages", { branch, unit });
+      if (response.success) {
+        setUsages(response.usages ?? {});
+      }
+    } catch (error) {
+      // Leave any prior usages in place; the manual refresh control can retry.
+      console.error("Failed to load image usages:", error);
+    } finally {
+      setUsagesLoading(false);
+    }
+  }, [api, branch, unit]);
+
+  // Load usages when the library opens (and whenever the unit changes).
+  useEffect(() => {
+    refreshUsages();
+  }, [refreshUsages]);
 
   const filteredFileKeys = useMemo(() => {
     if (!filter) return imageFileKeys;
@@ -148,6 +190,163 @@ const MediaLibrary: React.FC<IProps> = ({ onClose }) => {
     resetUpload();
   };
 
+  const selectedFileName = selectedKey ? fileNameFromKey(selectedKey) : undefined;
+  const selectedRefs = selectedKey && usages ? usages[selectedKey] : undefined;
+  const selectedUsageCount = selectedRefs?.length;
+
+  // Reset per-image UI state whenever the selection changes.
+  useEffect(() => {
+    setUsageExpanded(false);
+    setRenaming(false);
+    setRenameError(null);
+    setActionMessage(null);
+  }, [selectedKey]);
+
+  const handleDeleteImage = async () => {
+    if (!branch || !unit || !selectedFileName || selectedUsageCount !== 0) return;
+    const confirmed = window.confirm(
+      `Delete "${selectedFileName}"? It is unused, but this removes it from the unit and cannot be undone.`
+    );
+    if (!confirmed) return;
+    try {
+      const response = await api.post("/deleteImage", { branch, unit }, { fileName: selectedFileName });
+      if (response.success) {
+        // The files listener will drop the thumbnail; clear selection and refresh usages.
+        setSelectedKey(undefined);
+        setActionMessage(`Deleted ${selectedFileName}.`);
+        await refreshUsages();
+        authoringPreview.reloadAllPreviews();
+      } else {
+        setActionMessage(response.error ?? "Delete failed.");
+      }
+    } catch (error) {
+      setActionMessage(error instanceof Error ? error.message : "Delete failed.");
+    }
+  };
+
+  const handleStartRename = () => {
+    setRenameValue(selectedFileName ?? "");
+    setRenameError(null);
+    setRenaming(true);
+  };
+
+  const handleRenameSubmit = async () => {
+    if (!branch || !unit || !selectedFileName) return;
+    const sanitized = sanitizeFileName(renameValue.trim());
+    if (!sanitized || sanitized === selectedFileName) {
+      setRenameError("Enter a different, valid filename.");
+      return;
+    }
+    const targetKey = `images/${sanitized}`;
+    if (imageFileKeys.includes(targetKey)) {
+      setRenameError(`An image named "${sanitized}" already exists.`);
+      return;
+    }
+    try {
+      const response = await api.post(
+        "/renameImage", { branch, unit }, { fromFileName: selectedFileName, toFileName: sanitized });
+      if (response.success) {
+        setRenaming(false);
+        setSelectedKey(targetKey);
+        const count = response.updatedFileCount ?? 0;
+        setActionMessage(`Renamed to ${sanitized}. Updated ${count} reference${count === 1 ? "" : "s"}.`);
+        await refreshUsages();
+        authoringPreview.reloadAllPreviews();
+      } else {
+        setRenameError(response.error ?? "Rename failed.");
+      }
+    } catch (error) {
+      setRenameError(error instanceof Error ? error.message : "Rename failed.");
+    }
+  };
+
+  const renderUsageInfo = () => {
+    // A plain text line stating the usage count, always visible above the image. When the count
+    // can't be determined (e.g. the usage API is unavailable) we say so rather than leaving the
+    // Delete button mysteriously disabled.
+    let usageText: string;
+    if (selectedUsageCount === undefined) {
+      usageText = usagesLoading ? "Checking usage…" : "Usage: not available";
+    } else if (selectedUsageCount === 0) {
+      usageText = "Not used in the curriculum";
+    } else {
+      usageText = `Used ${selectedUsageCount} time${selectedUsageCount === 1 ? "" : "s"} in the curriculum`;
+    }
+
+    const hasLocations = selectedUsageCount !== undefined && selectedUsageCount > 0;
+    return (
+      <div className="media-library-usage">
+        <div className="media-library-usage-text">{usageText}</div>
+        {hasLocations && (
+          <button
+            type="button"
+            className={"media-library-usage-toggle" + (usageExpanded ? " expanded" : "")}
+            aria-expanded={usageExpanded}
+            onClick={() => setUsageExpanded(v => !v)}
+          >
+            <span className="disclosure-caret" aria-hidden="true" />
+            {usageExpanded ? "Hide locations" : "Show locations"}
+          </button>
+        )}
+        {hasLocations && usageExpanded && (
+          <ul className="media-library-usage-list">
+            {(selectedRefs ?? []).map(path => (
+              <li key={path} title={path}>
+                {formatLocation(describeUsagePath(path, unitConfig, teacherGuideConfig))}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    );
+  };
+
+  const renderImageActions = () => {
+    if (!selectedKey) return null;
+    return (
+      <div className="media-library-image-actions">
+        {renaming ? (
+          <div className="media-library-rename">
+            <input
+              type="text"
+              className="media-library-rename-input"
+              value={renameValue}
+              autoFocus
+              onChange={e => setRenameValue(e.target.value)}
+              onKeyDown={e => {
+                if (e.key === "Enter") handleRenameSubmit();
+                if (e.key === "Escape") setRenaming(false);
+              }}
+            />
+            <div className="media-library-rename-buttons">
+              <button type="button" onClick={handleRenameSubmit}>Save</button>
+              <button type="button" onClick={() => setRenaming(false)}>Cancel</button>
+            </div>
+            {renameError && <div className="media-library-rename-error">{renameError}</div>}
+          </div>
+        ) : (
+          <div className="media-library-action-buttons">
+            <button type="button" className="media-library-rename-btn" onClick={handleStartRename}>
+              Rename
+            </button>
+            <button
+              type="button"
+              className="media-library-delete-btn"
+              onClick={handleDeleteImage}
+              disabled={selectedUsageCount !== 0}
+              title={selectedUsageCount === 0
+                ? "Delete this unused image"
+                : "Only unused images can be deleted"}
+            >
+              Delete
+            </button>
+          </div>
+        )}
+        {actionMessage && <div className="media-library-action-message">{actionMessage}</div>}
+      </div>
+    );
+  };
+
   const renderImageListTabContent = () => {
     return (
       <div className="media-library-image-list">
@@ -188,6 +387,15 @@ const MediaLibrary: React.FC<IProps> = ({ onClose }) => {
                     loading="lazy"
                     className="media-library-thumb-img"
                   />
+                  {usages && (
+                    <span
+                      className={"media-library-thumb-badge" +
+                        ((usages[key]?.length ?? 0) === 0 ? " unused" : "")}
+                      title={`Used ${usages[key]?.length ?? 0}×`}
+                    >
+                      {usages[key]?.length ?? 0}
+                    </span>
+                  )}
                 </div>
               ))}
             </div>
@@ -199,23 +407,28 @@ const MediaLibrary: React.FC<IProps> = ({ onClose }) => {
         <div className="media-library-preview">
           {imageUrl ? (
             <>
-              <img src={imageUrl} alt={selectedKey} className="media-library-preview-img" />
-              <div className="media-library-preview-filename">{selectedKey}</div>
-              <button
-                className="media-library-select-btn"
-                onClick={() => {
-                  if (selectedKey) {
-                    try {
-                      navigator.clipboard.writeText(`curriculum/${unit}/${selectedKey}`);
-                    } catch (e) {
-                      alert(`Failed to copy to clipboard: ${e}`);
+              {/* Controls go above the image so they stay visible even for tall images. */}
+              <div className="media-library-preview-controls">
+                <div className="media-library-preview-filename">{selectedKey}</div>
+                {renderUsageInfo()}
+                {renderImageActions()}
+                <button
+                  className="media-library-select-btn"
+                  onClick={() => {
+                    if (selectedKey) {
+                      try {
+                        navigator.clipboard.writeText(`curriculum/${unit}/${selectedKey}`);
+                      } catch (e) {
+                        alert(`Failed to copy to clipboard: ${e}`);
+                      }
+                      onClose();
                     }
-                    onClose();
-                  }
-                }}
-              >
-                Select
-              </button>
+                  }}
+                >
+                  Select
+                </button>
+              </div>
+              <img src={imageUrl} alt={selectedKey} className="media-library-preview-img" />
             </>
           ) : (
             <div className="media-library-no-preview">No preview available</div>

--- a/src/authoring/hooks/use-authoring-api.tsx
+++ b/src/authoring/hooks/use-authoring-api.tsx
@@ -9,13 +9,16 @@ export type GetEndPoint =
   | "/getRemoteUnits"
   | "/getPulledBranches"
   | "/getPulledUnits"
-  | "/getPulledFiles";
+  | "/getPulledFiles"
+  | "/getImageUsages";
 
 export type PostEndPoint =
   | "/pullUnit"
   | "/pushUnit"
   | "/putContent"
   | "/putImage"
+  | "/deleteImage"
+  | "/renameImage"
   | "/deleteUnit";
 
 export type EndPoint = GetEndPoint | PostEndPoint;

--- a/src/authoring/utils/image-usage-locations.test.ts
+++ b/src/authoring/utils/image-usage-locations.test.ts
@@ -1,0 +1,83 @@
+import { IUnit } from "../types";
+import { describeUsagePath } from "./image-usage-locations";
+
+const unitConfig = {
+  title: "Stretching and Shrinking",
+  investigations: [
+    {
+      ordinal: 0, title: "Introduction to CLUE",
+      problems: [
+        {
+          ordinal: 1, title: "0.1 Intro to CLUE",
+          sections: [
+            "investigation-0/problem-1/introduction/content.json",
+            "investigation-0/problem-1/initialChallenge/content.json"
+          ]
+        }
+      ]
+    },
+    {
+      ordinal: 1, title: "Enlarging and Reducing Shapes",
+      problems: [
+        {
+          ordinal: 2, title: "1.2 Changing Shapes",
+          sections: ["investigation-1/problem-2/introduction/content.json"]
+        }
+      ]
+    }
+  ]
+} as unknown as IUnit;
+
+const teacherGuideConfig = {
+  title: "Teacher Guide",
+  investigations: [
+    {
+      ordinal: 1, title: "Enlarging and Reducing Shapes",
+      problems: [
+        {
+          ordinal: 2, title: "1.2 Changing Shapes",
+          sections: ["investigation-1/problem-2/launch/content.json"]
+        }
+      ]
+    }
+  ]
+} as unknown as IUnit;
+
+describe("describeUsagePath", () => {
+  it("resolves a declared section path to its Investigation/Problem titles and section type", () => {
+    const loc = describeUsagePath(
+      "investigation-0/problem-1/introduction/content.json", unitConfig, teacherGuideConfig);
+    expect(loc).toEqual({
+      path: "investigation-0/problem-1/introduction/content.json",
+      isTeacherGuide: false,
+      investigationTitle: "Introduction to CLUE",
+      problemTitle: "0.1 Intro to CLUE",
+      sectionType: "introduction"
+    });
+  });
+
+  it("flags teacher-guide paths and resolves them against the teacher guide config", () => {
+    const loc = describeUsagePath(
+      "teacher-guide/investigation-1/problem-2/launch/content.json", unitConfig, teacherGuideConfig);
+    expect(loc.isTeacherGuide).toBe(true);
+    expect(loc.investigationTitle).toBe("Enlarging and Reducing Shapes");
+    expect(loc.problemTitle).toBe("1.2 Changing Shapes");
+    expect(loc.sectionType).toBe("launch");
+  });
+
+  it("falls back to ordinal parsing when the path is not a declared section", () => {
+    // nowWhatDoYouKnow is not in the declared sections, but the ordinals identify the problem
+    const loc = describeUsagePath(
+      "investigation-1/problem-2/nowWhatDoYouKnow/content.json", unitConfig, teacherGuideConfig);
+    expect(loc.investigationTitle).toBe("Enlarging and Reducing Shapes");
+    expect(loc.problemTitle).toBe("1.2 Changing Shapes");
+    expect(loc.sectionType).toBe("nowWhatDoYouKnow");
+  });
+
+  it("returns undefined titles for an unrecognizable path but still parses the section type", () => {
+    const loc = describeUsagePath("investigation-9/problem-9/explore/content.json", unitConfig, undefined);
+    expect(loc.investigationTitle).toBeUndefined();
+    expect(loc.problemTitle).toBeUndefined();
+    expect(loc.sectionType).toBe("explore");
+  });
+});

--- a/src/authoring/utils/image-usage-locations.test.ts
+++ b/src/authoring/utils/image-usage-locations.test.ts
@@ -1,5 +1,5 @@
 import { IUnit } from "../types";
-import { describeUsagePath } from "./image-usage-locations";
+import { describeUsagePath, formatLocation } from "./image-usage-locations";
 
 const unitConfig = {
   title: "Stretching and Shrinking",
@@ -79,5 +79,34 @@ describe("describeUsagePath", () => {
     expect(loc.investigationTitle).toBeUndefined();
     expect(loc.problemTitle).toBeUndefined();
     expect(loc.sectionType).toBe("explore");
+  });
+
+  it("resolves a teacher-guide path by ordinal when it is not a declared section", () => {
+    // not in the teacher guide's declared sections, but the ordinals identify the problem
+    const loc = describeUsagePath(
+      "teacher-guide/investigation-1/problem-2/overview/content.json", unitConfig, teacherGuideConfig);
+    expect(loc.isTeacherGuide).toBe(true);
+    expect(loc.investigationTitle).toBe("Enlarging and Reducing Shapes");
+    expect(loc.problemTitle).toBe("1.2 Changing Shapes");
+    expect(loc.sectionType).toBe("overview");
+  });
+});
+
+describe("formatLocation", () => {
+  it("joins resolved titles and appends the section type", () => {
+    const loc = describeUsagePath(
+      "investigation-0/problem-1/introduction/content.json", unitConfig, teacherGuideConfig);
+    expect(formatLocation(loc)).toBe("Introduction to CLUE / 0.1 Intro to CLUE · introduction");
+  });
+
+  it("prefixes Teacher Guide for teacher-guide paths", () => {
+    const loc = describeUsagePath(
+      "teacher-guide/investigation-1/problem-2/launch/content.json", unitConfig, teacherGuideConfig);
+    expect(formatLocation(loc)).toBe("Teacher Guide / Enlarging and Reducing Shapes / 1.2 Changing Shapes · launch");
+  });
+
+  it("falls back to the raw path alone when no titles resolve, without a redundant section suffix", () => {
+    const loc = describeUsagePath("investigation-9/problem-9/explore/content.json", unitConfig, undefined);
+    expect(formatLocation(loc)).toBe("investigation-9/problem-9/explore/content.json");
   });
 });

--- a/src/authoring/utils/image-usage-locations.ts
+++ b/src/authoring/utils/image-usage-locations.ts
@@ -1,0 +1,71 @@
+import { IInvestigation, IProblem, IUnit } from "../types";
+
+export interface UsageLocation {
+  path: string;
+  isTeacherGuide: boolean;
+  investigationTitle?: string;
+  problemTitle?: string;
+  sectionType?: string;
+}
+
+const teacherGuidePrefix = "teacher-guide/";
+
+// The section type is the directory immediately before content.json,
+// e.g. "investigation-0/problem-1/introduction/content.json" -> "introduction".
+function sectionTypeFromPath(relativePath: string): string | undefined {
+  const segments = relativePath.split("/");
+  return segments.length >= 2 ? segments[segments.length - 2] : undefined;
+}
+
+type InvAndProblem = { inv: IInvestigation; problem: IProblem };
+
+// Find the investigation/problem that declares this exact section path.
+function findByDeclaredSection(config: IUnit, relativePath: string): InvAndProblem | undefined {
+  for (const inv of config.investigations ?? []) {
+    for (const problem of inv.problems ?? []) {
+      if ((problem.sections ?? []).includes(relativePath)) {
+        return { inv, problem };
+      }
+    }
+  }
+  return undefined;
+}
+
+// Fallback: identify the investigation/problem by the ordinals embedded in the path,
+// e.g. "investigation-1/problem-2/..." -> investigation ordinal 1, problem ordinal 2.
+function findByOrdinals(config: IUnit, relativePath: string): InvAndProblem | undefined {
+  const match = /investigation-(\d+)\/problem-(\d+)/.exec(relativePath);
+  if (!match) return undefined;
+  const invOrdinal = Number(match[1]);
+  const problemOrdinal = Number(match[2]);
+  const inv = (config.investigations ?? []).find(i => i.ordinal === invOrdinal);
+  const problem = inv?.problems?.find(p => p.ordinal === problemOrdinal);
+  return inv && problem ? { inv, problem } : undefined;
+}
+
+/**
+ * Maps a content-file path (relative to curriculum/{unit}/, as returned by the getImageUsages
+ * endpoint) to a human-readable location using the unit and teacher-guide configs already loaded
+ * client-side. Prefers the declared section structure; falls back to parsing the
+ * investigation/problem ordinals from the path.
+ */
+export function describeUsagePath(
+  path: string,
+  unitConfig: IUnit | undefined,
+  teacherGuideConfig: IUnit | undefined
+): UsageLocation {
+  const isTeacherGuide = path.startsWith(teacherGuidePrefix);
+  const relativePath = isTeacherGuide ? path.slice(teacherGuidePrefix.length) : path;
+  const config = isTeacherGuide ? teacherGuideConfig : unitConfig;
+
+  const sectionType = sectionTypeFromPath(relativePath);
+  const found = config && (findByDeclaredSection(config, relativePath) ?? findByOrdinals(config, relativePath));
+
+  return {
+    path,
+    isTeacherGuide,
+    investigationTitle: found?.inv.title,
+    problemTitle: found?.problem.title,
+    sectionType
+  };
+}

--- a/src/authoring/utils/image-usage-locations.ts
+++ b/src/authoring/utils/image-usage-locations.ts
@@ -69,3 +69,19 @@ export function describeUsagePath(
     sectionType
   };
 }
+
+/**
+ * Renders a UsageLocation as a single human-readable line. When investigation/problem titles
+ * resolve, it appends the section type (e.g. "Investigation / Problem · introduction"). When no
+ * titles resolve it falls back to the raw path alone — the section type is already embedded there,
+ * so appending it again would be redundant.
+ */
+export function formatLocation(loc: UsageLocation): string {
+  const parts: string[] = [];
+  if (loc.isTeacherGuide) parts.push("Teacher Guide");
+  if (loc.investigationTitle) parts.push(loc.investigationTitle);
+  if (loc.problemTitle) parts.push(loc.problemTitle);
+  if (parts.length === 0) return loc.path;
+  const label = parts.join(" / ");
+  return loc.sectionType ? `${label} · ${loc.sectionType}` : label;
+}

--- a/src/authoring/utils/sanitize-filename.test.ts
+++ b/src/authoring/utils/sanitize-filename.test.ts
@@ -1,4 +1,4 @@
-import { sanitizeFileName } from "./sanitize-filename";
+import { hasValidImageExtension, sanitizeFileName } from "./sanitize-filename";
 
 describe("sanitizeFileName", () => {
   it("replaces spaces with hyphens", () => {
@@ -63,5 +63,19 @@ describe("sanitizeFileName", () => {
 
   it("strips leading dots from basename with extension", () => {
     expect(sanitizeFileName(".foo.png")).toBe("foo.png");
+  });
+});
+
+describe("hasValidImageExtension", () => {
+  it("accepts a dot followed by 3+ letters, any case", () => {
+    expect(hasValidImageExtension("diagram.png")).toBe(true);
+    expect(hasValidImageExtension("photo.JPEG")).toBe(true);
+    expect(hasValidImageExtension("my.image.file.svg")).toBe(true);
+  });
+
+  it("rejects a missing or too-short extension", () => {
+    expect(hasValidImageExtension("diagram-v2")).toBe(false);
+    expect(hasValidImageExtension("foo.x")).toBe(false);
+    expect(hasValidImageExtension("foo.")).toBe(false);
   });
 });

--- a/src/authoring/utils/sanitize-filename.ts
+++ b/src/authoring/utils/sanitize-filename.ts
@@ -35,3 +35,12 @@ export function sanitizeFileName(fileName: string): string {
   // Strip trailing dots from final result (problematic on Windows and in URLs)
   return result.replace(/\.+$/, "") || "image";
 }
+
+/**
+ * Whether a filename ends in a real image extension (dot + 3+ letters). Mirrors the CLUE runtime
+ * resolver (localAssetsImagesHandler.match in src/models/image-map.ts) so a name that would fail to
+ * render everywhere it's used can be rejected before it's saved.
+ */
+export function hasValidImageExtension(fileName: string): boolean {
+  return /\.[a-z]{3,}$/i.test(fileName);
+}


### PR DESCRIPTION
Authors can now manage the authoring media library: see how many times each image is used in the unit (with a fold-out of the Investigation/Problem locations), delete unused images, and rename images with references rewritten automatically so used images can be renamed without breaking content.

Server (authoring-api):
- image-references.ts: pure scan/rewrite helpers (find/invert/rewrite the {unit}/images/{file} reference token) with unit-boundary guards; unit tests.
- unit-content.ts: enumerate a unit's content files from the pulled files sha-map and resolve effective content (pending update -> cached blob -> GitHub raw), with a per-blob image-reference index cache so repeat scans only re-read changed files.
- routes: GET /getImageUsages, POST /deleteImage (unused-only, re-verified), POST /renameImage (single tree-commit blob move + staged reference rewrites).

Client (authoring):
- image-usage-locations.ts: map a content path to Investigation/Problem titles from the loaded unit/teacher-guide configs; unit tests.
- media-library: usage text line + locations fold-out, Rename (inline) and Delete (enabled only when unused) controls placed above the preview image; "Usage: not available" when the count can't be loaded.

Scope: usage counting + rename rewrites cover the current unit + teacher guide; cross-unit references are out of scope for this iteration.

---

## Review follow-up — commit `25eb32dad`

The four Copilot review comments are resolved (each reply links this commit), plus follow-on hardening from a deeper review pass.

**Copilot comments resolved**
- Image-reference cache now keyed by `(unit, sha)` — no cross-unit contamination.
- `fromFileName` and `unit` are validated on the image routes (see the split rule below).
- Client image filter narrowed to `images/`, matching the server-side `isImageFile()` check.
- `formatLocation` (now in `image-usage-locations.ts`, unit-tested) drops the redundant section suffix when no Investigation/Problem titles resolve.

**Additional changes**
- **Atomic rename**: the files-map swap + staged reference rewrites land in a single multi-location Firebase update, computed *before* the irreversible GitHub blob move — a failed read/commit leaves the unit untouched rather than half-renamed.
- **Validation split**: destination names keep the strict clean-name allowlist; source names need only be path-safe (no separators/traversal/control chars), so legacy names containing spaces or `&` can be renamed toward clean ones.
- **Reference-detection fix**: the scanner's token charset is decoupled from the naming allowlist and now recognizes legacy `&` names, so their usage counts are accurate (previously reported as 0).
- **Clearer errors**: known GitHub failures (auth / 404 / conflict) return actionable messages instead of a generic 500.
- **Client UX / a11y**: double-submit guards on rename & delete, aria attributes on the rename input/messages, and a live "Will be saved as…" preview of the sanitized name.

**Tests**: added unit tests for the new helpers (`image-references`, `github`) and the media-library rename flow; the full authoring-api suite is green, with type-check and lint clean on the touched files.

**Known follow-up (not in this commit)**: `delete` intentionally stays on the strict allowlist. Relaxing it for arbitrary legacy names safely requires the usage scanner to recognize *every* runtime-legal name (punctuation beyond `&`, etc.), which is best done as its own tested change. Until then, rename is the safe cleanup path for messy legacy names.
