### PR TITLE
CLUE-562: base comment-control visibility on tab identity, not order

### DIFF
--- a/src/components/navigation/nav-tab-panel.tsx
+++ b/src/components/navigation/nav-tab-panel.tsx
@@ -15,6 +15,7 @@ import ChatIcon from "../../assets/chat-icon.svg";
 import { SortWorkView } from "../document/sort-work-view";
 import { NavTabPanelInfoProvider } from "../../hooks/use-nav-tab-panel-info";
 import { getAriaLabels } from "../../hooks/use-aria-labels";
+import { shouldHideChat } from "./should-hide-chat";
 
 import "react-tabs/style/react-tabs.css";
 import "./nav-tab-panel.scss";
@@ -51,7 +52,7 @@ export class NavTabPanel extends BaseComponent<IProps> {
     const tabs = this.stores.tabsToDisplay;
     const selectedTabIndex = tabs?.findIndex(t => t.tab === activeNavTab);
     const isChatEnabled = appConfig.showCommentPanelFor(user.type) &&
-      !this.shouldHideChat(selectedTabIndex, user.type);
+      !shouldHideChat(activeNavTab, user.type);
     const openChatPanel = isChatEnabled && showChatPanel;
     const focusTileId = selectedTileIds?.length === 1 ? selectedTileIds[0] : undefined;
     const ariaLabels = getAriaLabels();
@@ -216,12 +217,4 @@ export class NavTabPanel extends BaseComponent<IProps> {
     persistentUI.setDividerPosition(kDividerMin);
   };
 
-  private hideChatRules: Array<(tabIndex: number, userType: string) => boolean> = [
-    // Hide chat for students on the problems tab
-    (tabIndex, userType) => userType === "student" && tabIndex === 0
-  ];
-
-  private shouldHideChat = (tabIndex: number, userType?: string) => {
-    return userType && this.hideChatRules.some(rule => rule(tabIndex, userType));
-  };
 }

--- a/src/components/navigation/should-hide-chat.test.ts
+++ b/src/components/navigation/should-hide-chat.test.ts
@@ -1,0 +1,25 @@
+import { ENavTab } from "../../models/view/nav-tabs";
+import { shouldHideChat } from "./should-hide-chat";
+
+describe("shouldHideChat", () => {
+  // CLUE-562: keyed on tab identity, not position. aplus orders class-work first and Problems
+  // third, so an index-based rule hid chat on class-work and showed it on Problems — backwards.
+  it("hides chat for students on the Problems tab regardless of its position", () => {
+    expect(shouldHideChat(ENavTab.kProblems, "student")).toBe(true);
+  });
+
+  it("does NOT hide chat for students on other tabs (e.g. class-work, which can be first)", () => {
+    expect(shouldHideChat(ENavTab.kClassWork, "student")).toBe(false);
+    expect(shouldHideChat(ENavTab.kSortWork, "student")).toBe(false);
+    expect(shouldHideChat(ENavTab.kMyWork, "student")).toBe(false);
+  });
+
+  it("does not hide chat for teachers on the Problems tab", () => {
+    expect(shouldHideChat(ENavTab.kProblems, "teacher")).toBe(false);
+  });
+
+  it("returns false when the active tab or user type is undefined", () => {
+    expect(shouldHideChat(undefined, "student")).toBe(false);
+    expect(shouldHideChat(ENavTab.kProblems, undefined)).toBe(false);
+  });
+});

--- a/src/components/navigation/should-hide-chat.ts
+++ b/src/components/navigation/should-hide-chat.ts
@@ -1,0 +1,18 @@
+import { ENavTab } from "../../models/view/nav-tabs";
+
+type HideChatRule = (activeTab: string, userType: string) => boolean;
+
+// Rules that hide the comment/chat control for a given user on a given tab. These are keyed on the
+// active tab's identity (ENavTab), NOT its position in the nav bar. An earlier version keyed the
+// students-can't-comment-on-Problems rule on tabIndex === 0, which assumed Problems was always the
+// first tab; units that order tabs differently (e.g. aplus, where Problems is third) broke as a
+// result (CLUE-562).
+const hideChatRules: HideChatRule[] = [
+  // Students cannot comment on the Problems tab.
+  (activeTab, userType) => userType === "student" && activeTab === ENavTab.kProblems,
+];
+
+export function shouldHideChat(activeTab: string | undefined, userType: string | undefined): boolean {
+  if (!activeTab || !userType) return false;
+  return hideChatRules.some(rule => rule(activeTab, userType));
+}

--- a/src/components/navigation/should-hide-chat.ts
+++ b/src/components/navigation/should-hide-chat.ts
@@ -1,6 +1,7 @@
 import { ENavTab } from "../../models/view/nav-tabs";
+import { UserType } from "../../models/stores/user-types";
 
-type HideChatRule = (activeTab: string, userType: string) => boolean;
+type HideChatRule = (activeTab: ENavTab | string, userType: UserType) => boolean;
 
 // Rules that hide the comment/chat control for a given user on a given tab. These are keyed on the
 // active tab's identity (ENavTab), NOT its position in the nav bar. An earlier version keyed the
@@ -12,7 +13,7 @@ const hideChatRules: HideChatRule[] = [
   (activeTab, userType) => userType === "student" && activeTab === ENavTab.kProblems,
 ];
 
-export function shouldHideChat(activeTab: string | undefined, userType: string | undefined): boolean {
+export function shouldHideChat(activeTab: ENavTab | string | undefined, userType: UserType | undefined): boolean {
   if (!activeTab || !userType) return false;
   return hideChatRules.some(rule => rule(activeTab, userType));
 }


### PR DESCRIPTION
## Problem

The comment/chat control's visibility for students was gated on **tab position** rather than which tab is active. The rule hiding chat for students on the Problems tab was keyed on `tabIndex === 0`, assuming Problems is always the first tab.

This breaks for units that order their tabs differently. On **aplus** (tab order: `class-work, sort-work, problems, …`), the control was:
- **hidden on Class Work** (index 0) — where students *should* be able to comment, and
- **shown on Problems** (index 2) — where they *should not*.

## Fix

Base the decision on **tab identity** instead of position — the pattern already used elsewhere (e.g. `persistent-ui.ts` compares `activeNavTab === ENavTab.kProblems`).

- New pure helper `should-hide-chat.ts`: `shouldHideChat(activeTab, userType)` hides chat for students when `activeTab === ENavTab.kProblems`, regardless of order.
- `nav-tab-panel.tsx` now calls `shouldHideChat(activeNavTab, user.type)`; the old index-based private `hideChatRules`/`shouldHideChat` are removed.

## Testing

- New unit tests for `shouldHideChat` (Problems hidden for students regardless of position; class-work/sort-work not hidden; teachers unaffected; undefined-safe).
- `npm run check:types` and eslint clean.
- Manually verified on the **aplus** unit as a student: comment control now shows on Class Work and is hidden on Problems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)