### PR TITLE
Clue 564 big thumbnails need to allow tile copy 

### DIFF
--- a/src/components/document/document-scroller.scss
+++ b/src/components/document/document-scroller.scss
@@ -35,9 +35,9 @@ $footer-height: 12px;
           height: 100%;
           width: 100%;
 
-          // Large thumbnails fill the box edge-to-edge (no centering gutter), so only the
-          // horizontal anchor needs overriding to a flush 4px; they keep the list-item top
-          // padding, so the base `top: calc($padding + 4px)` already lands on the corner.
+          // Large thumbnails fill the width (no centering gutter), so override the base's
+          // centered-left calc to a flush 4px inset. The flush top (top: 0) comes from the
+          // shared scroller rule below, which also matches this large-thumbnails list.
           > .icon-holder {
             left: 4px;
           }
@@ -129,9 +129,12 @@ $footer-height: 12px;
       }
     }
 
-    // Small scroller thumbnails size the box edge-to-edge (width 96px == list-item) and remove
-    // the list-item top padding, so the box's top-left corner IS the container's corner.
-    // Anchor the bookmark a uniform 4px inset there, overriding the page-view centering/padding.
+    // The scroller lays the thumbnail box flush in its container (width 96px == list-item,
+    // list-item padding removed), so the box's top-left corner IS the container's corner:
+    // anchor the bookmark flush at the top (top: 0) with a 4px left inset, overriding the
+    // page-view centering/padding calc above.
+    // NOTE: this selector also matches the .large-thumbnails list (same class) — intentional,
+    // since large thumbnails want the same flush top placement.
     .list-item-container > .icon-holder {
       left: 4px;
       top: 0;

--- a/src/components/document/document-scroller.scss
+++ b/src/components/document/document-scroller.scss
@@ -34,6 +34,13 @@ $footer-height: 12px;
         .list-item-container {
           height: 100%;
           width: 100%;
+
+          // Large thumbnails fill the box edge-to-edge (no centering gutter), so only the
+          // horizontal anchor needs overriding to a flush 4px; they keep the list-item top
+          // padding, so the base `top: calc($padding + 4px)` already lands on the corner.
+          > .icon-holder {
+            left: 4px;
+          }
         }
       }
 
@@ -92,22 +99,6 @@ $footer-height: 12px;
       }
     }
 
-    // The bookmark button (.icon-holder) is a child of .list-item-container, a sibling of
-    // .list-item. (My Work positions it via a `.documents-list`-scoped rule that doesn't
-    // apply here, so in the scroller it otherwise falls into normal flow.) Make the
-    // container a positioning context and overlay the bookmark in the top-right corner,
-    // nudged in a few px. Applies to both small and large thumbnails.
-    .list-item-container {
-      position: relative;
-
-      > .icon-holder {
-        left: auto;
-        position: absolute;
-        right: 6px;
-        top: 2px;
-      }
-    }
-
     .list-item {
       height: 126px;
       min-height: auto;
@@ -136,6 +127,14 @@ $footer-height: 12px;
           width: 96px;
         }
       }
+    }
+
+    // Small scroller thumbnails size the box edge-to-edge (width 96px == list-item) and remove
+    // the list-item top padding, so the box's top-left corner IS the container's corner.
+    // Anchor the bookmark a uniform 4px inset there, overriding the page-view centering/padding.
+    .list-item-container > .icon-holder {
+      left: 4px;
+      top: 0;
     }
   }
 

--- a/src/components/document/document-scroller.scss
+++ b/src/components/document/document-scroller.scss
@@ -34,13 +34,6 @@ $footer-height: 12px;
         .list-item-container {
           height: 100%;
           width: 100%;
-
-          // Large thumbnails fill the width (no centering gutter), so override the base's
-          // centered-left calc to a flush 4px inset. The flush top (top: 0) comes from the
-          // shared scroller rule below, which also matches this large-thumbnails list.
-          > .icon-holder {
-            left: 4px;
-          }
         }
       }
 
@@ -129,15 +122,12 @@ $footer-height: 12px;
       }
     }
 
-    // The scroller lays the thumbnail box flush in its container (width 96px == list-item,
-    // list-item padding removed), so the box's top-left corner IS the container's corner:
-    // anchor the bookmark flush at the top (top: 0) with a 4px left inset, overriding the
-    // page-view centering/padding calc above.
-    // NOTE: this selector also matches the .large-thumbnails list (same class) — intentional,
-    // since large thumbnails want the same flush top placement.
+    // Scroller thumbnails (both small and large) size the box edge-to-edge with no list-item top
+    // padding, so the box's top-left corner IS the container's corner. Anchor the bookmark 4px
+    // inside the left edge and 4px above the top edge, overriding the page-view centering/padding.
     .list-item-container > .icon-holder {
       left: 4px;
-      top: 0;
+      top: -4px;
     }
   }
 

--- a/src/components/thumbnail/decorated-document-thumbnail-item.test.tsx
+++ b/src/components/thumbnail/decorated-document-thumbnail-item.test.tsx
@@ -1,0 +1,78 @@
+import { fireEvent, render } from "@testing-library/react";
+import { Provider } from "mobx-react";
+import React from "react";
+
+import { DecoratedDocumentThumbnailItem } from "./decorated-document-thumbnail-item";
+import { createDocumentModel } from "../../models/document/document";
+import { ProblemDocument, DocumentDragKey } from "../../models/document/document-types";
+import { specStores } from "../../models/stores/spec-stores";
+import { UserModel } from "../../models/stores/user";
+import { kDragTiles } from "../tiles/tile-component";
+
+jest.mock("../document/canvas", () => ({
+  CanvasComponent: () => <div data-testid="mock-canvas" />,
+}));
+// Isolate the drag logic from firebase sync + caption lookups.
+jest.mock("../../hooks/use-document-sync-to-firebase", () => ({
+  useDocumentSyncToFirebase: () => undefined,
+}));
+jest.mock("../../hooks/use-document-caption", () => ({
+  useDocumentCaption: () => "Caption",
+}));
+
+// Minimal DataTransfer stand-in that tracks set data and exposes `types`.
+function makeDataTransfer(initial: Record<string, string> = {}) {
+  const store: Record<string, string> = { ...initial };
+  return {
+    setData: (type: string, value: string) => { store[type] = value; },
+    getData: (type: string) => store[type] ?? "",
+    get types() { return Object.keys(store); },
+  } as unknown as DataTransfer;
+}
+
+function renderItem() {
+  const user = UserModel.create({ id: "test-student", type: "student", name: "Test Student" });
+  const stores = specStores({ user });
+  const document = createDocumentModel({
+    type: ProblemDocument,
+    title: "Test Document",
+    uid: "test-student",
+    key: "doc-key-1",
+    createdAt: 1,
+    visibility: "private",
+  });
+  const result = render(
+    <Provider stores={stores}>
+      <DecoratedDocumentThumbnailItem
+        document={document}
+        tab="My Work"
+        scale={0.1}
+        allowDelete={false}
+        shouldHandleStarClick={false}
+        scrollable={true}
+      />
+    </Provider>
+  );
+  const listItem = result.container.querySelector(".list-item") as HTMLElement;
+  return { ...result, listItem, document };
+}
+
+describe("DecoratedDocumentThumbnailItem drag distinction", () => {
+  it("tags a plain thumbnail drag as a document drag", () => {
+    const { listItem, document } = renderItem();
+    const dataTransfer = makeDataTransfer();
+    fireEvent.dragStart(listItem, { dataTransfer });
+    expect(dataTransfer.getData(DocumentDragKey)).toBe(document.key);
+  });
+
+  it("does not tag a bubbled tile drag as a document drag", () => {
+    const { listItem } = renderItem();
+    // Simulate a tile drag already in progress: its dragstart (fired first, in the bubble
+    // phase) has populated kDragTiles before reaching the draggable list item.
+    const dataTransfer = makeDataTransfer({
+      [kDragTiles]: JSON.stringify({ sourceDocId: "doc-key-1", tiles: [{ tileId: "t1" }] }),
+    });
+    fireEvent.dragStart(listItem, { dataTransfer });
+    expect(dataTransfer.getData(DocumentDragKey)).toBe("");
+  });
+});

--- a/src/components/thumbnail/decorated-document-thumbnail-item.tsx
+++ b/src/components/thumbnail/decorated-document-thumbnail-item.tsx
@@ -9,6 +9,7 @@ import { useStores } from "../../hooks/use-stores";
 import { DocumentDragKey, SupportPublication } from "../../models/document/document-types";
 import { logDocumentEvent } from "../../models/document/log-document-event";
 import { LogEventName } from "../../lib/logger-types";
+import { kDragTiles } from "../tiles/tile-component";
 
 import "./document-type-collection.scss";
 
@@ -38,6 +39,12 @@ export const DecoratedDocumentThumbnailItem: React.FC<IProps> = observer(({
     useDocumentSyncToFirebase(user, dbStore.firebase, dbStore.firestore, document, true);
 
     function handleDocumentDragStart(e: React.DragEvent<HTMLDivElement>) {
+      // A tile drag started inside a scrollable ("big") thumbnail bubbles up to this draggable
+      // list item. The tile's dragstart runs first (bubble phase) and populates kDragTiles, so
+      // when that data is already present this is a tile copy, not a document drag — don't also
+      // tag it with DocumentDragKey, or drop targets outside a document (e.g. the workspace)
+      // would treat the tile copy as a document drag.
+      if (Array.from(e.dataTransfer.types).includes(kDragTiles)) return;
       e.dataTransfer.setData(DocumentDragKey, document.key);
     }
 

--- a/src/components/thumbnail/document-type-collection.scss
+++ b/src/components/thumbnail/document-type-collection.scss
@@ -88,8 +88,21 @@ $section-padding: 6px;
       cursor: pointer;
       padding: 0;
       position: absolute;
-      right: 78px;
-      top: 4px;
+      // Pin the bookmark a few px inside the TOP-LEFT CORNER OF THE VISIBLE THUMBNAIL BOX
+      // (.scaled-list-item-container) — not the outer .list-item-container it is positioned
+      // against. In these page views (My Work / Class Work / sort-work) the box is centered
+      // inside a wider .list-item (min-width) and pushed down by the list-item's vertical
+      // padding ($padding), so the box's corner is inset from the container by:
+      //   left = half the horizontal leftover (the centering gutter) + 4px
+      //   top  = the list-item's top padding + 4px
+      // Both are derived from the same vars that size the box, so they stay correct if those
+      // change. The scroller sizes the box edge-to-edge with no top padding and overrides these.
+      // The bookmark overlays the document content (z-index) with a white halo (drop-shadow
+      // below) so it stays legible without a boxy background.
+      left: calc((100% - #{$list-item-width * $list-item-scale}) / 2 + 4px);
+      right: auto;
+      top: $padding;
+      z-index: 1;
       @include focus-ring(2px);
 
       &[aria-disabled="true"] {
@@ -102,6 +115,7 @@ $section-padding: 6px;
         fill: $charcoal;
         opacity: .25;
         display: block;
+        filter: drop-shadow(0 0 1px rgba(255, 255, 255, 0.9)) drop-shadow(0 0 1px rgba(255, 255, 255, 0.9));
 
         &.starred {
           opacity: .75;

--- a/src/components/thumbnail/document-type-collection.scss
+++ b/src/components/thumbnail/document-type-collection.scss
@@ -88,20 +88,21 @@ $section-padding: 6px;
       cursor: pointer;
       padding: 0;
       position: absolute;
-      // Anchor the bookmark to the TOP-LEFT CORNER OF THE VISIBLE THUMBNAIL BOX
-      // (.scaled-list-item-container) — not the outer .list-item-container it is positioned
-      // against. In these page views (My Work / Class Work / sort-work) the box is centered
-      // inside a wider .list-item (min-width) and pushed down by the list-item's vertical
-      // padding ($padding), so the box's top-left corner sits at:
-      //   left = half the horizontal leftover (the centering gutter), plus a 4px inset
-      //   top  = the list-item's top padding (bookmark sits flush with the box's top edge)
+      // Anchor the bookmark relative to the VISIBLE THUMBNAIL BOX (.scaled-list-item-container),
+      // not the outer .list-item-container it is positioned against. In these page views (My Work
+      // / Class Work / sort-work) the box is centered inside a wider .list-item (min-width) and
+      // pushed down by the list-item's vertical padding ($padding). Per the design spec the
+      // bookmark sits 4px inside the box's left edge and 4px ABOVE its top edge, so relative to
+      // the container:
+      //   left = the centering gutter (half the horizontal leftover) + 4px
+      //   top  = the list-item's top padding - 4px
       // Both are derived from the same vars that size the box, so they stay correct if those
-      // change. The scroller lays the box flush in its container and overrides these below.
+      // change. The scroller sizes the box edge-to-edge with no top padding and overrides both.
       // The bookmark overlays the document content (z-index) with a white halo (drop-shadow
       // below) so it stays legible without a boxy background.
       left: calc((100% - #{$list-item-width * $list-item-scale}) / 2 + 4px);
       right: auto;
-      top: $padding;
+      top: calc($padding - 4px);
       z-index: 1;
       @include focus-ring(2px);
 

--- a/src/components/thumbnail/document-type-collection.scss
+++ b/src/components/thumbnail/document-type-collection.scss
@@ -88,15 +88,15 @@ $section-padding: 6px;
       cursor: pointer;
       padding: 0;
       position: absolute;
-      // Pin the bookmark a few px inside the TOP-LEFT CORNER OF THE VISIBLE THUMBNAIL BOX
+      // Anchor the bookmark to the TOP-LEFT CORNER OF THE VISIBLE THUMBNAIL BOX
       // (.scaled-list-item-container) — not the outer .list-item-container it is positioned
       // against. In these page views (My Work / Class Work / sort-work) the box is centered
       // inside a wider .list-item (min-width) and pushed down by the list-item's vertical
-      // padding ($padding), so the box's corner is inset from the container by:
-      //   left = half the horizontal leftover (the centering gutter) + 4px
-      //   top  = the list-item's top padding + 4px
+      // padding ($padding), so the box's top-left corner sits at:
+      //   left = half the horizontal leftover (the centering gutter), plus a 4px inset
+      //   top  = the list-item's top padding (bookmark sits flush with the box's top edge)
       // Both are derived from the same vars that size the box, so they stay correct if those
-      // change. The scroller sizes the box edge-to-edge with no top padding and overrides these.
+      // change. The scroller lays the box flush in its container and overrides these below.
       // The bookmark overlays the document content (z-index) with a white halo (drop-shadow
       // below) so it stays legible without a boxy background.
       left: calc((100% - #{$list-item-width * $list-item-scale}) / 2 + 4px);

--- a/src/components/thumbnail/thumbnail-document-item.test.tsx
+++ b/src/components/thumbnail/thumbnail-document-item.test.tsx
@@ -112,14 +112,14 @@ describe("ThumbnailDocumentItem", () => {
       expect(canvasContainer).toHaveAttribute("inert");
     });
 
-    // Even scrollable (large) thumbnails keep inert + aria-hidden so the document stays
-    // out of the tab order and the a11y tree; scrolling is handled via a wheel handler
-    // rather than by making the subtree interactive. See CLUE-548.
-    it("keeps the canvas container inert/aria-hidden when scrollable", () => {
+    // CLUE-564: scrollable (large/"big") thumbnails are the 4-up replacement and must stay
+    // interactive so tiles can be selected and borrowed/copied. They are therefore NOT made
+    // inert/aria-hidden (unlike the small preview thumbnails tested above).
+    it("does not make the canvas container inert/aria-hidden when scrollable", () => {
       const { container } = renderItem({ scrollable: true });
       const canvasContainer = container.querySelector(".scaled-list-item-container");
-      expect(canvasContainer).toHaveAttribute("inert");
-      expect(canvasContainer).toHaveAttribute("aria-hidden", "true");
+      expect(canvasContainer).not.toHaveAttribute("inert");
+      expect(canvasContainer).not.toHaveAttribute("aria-hidden");
     });
 
     it("sets aria-current='true' when the document is selected", () => {

--- a/src/components/thumbnail/thumbnail-document-item.tsx
+++ b/src/components/thumbnail/thumbnail-document-item.tsx
@@ -24,11 +24,12 @@ interface IProps {
   onDocumentDragStart?: (e: React.DragEvent<HTMLDivElement>, document: DocumentModelType) => void;
   onDocumentStarClick?: (document: DocumentModelType) => void;
   scale: number;
-  // When true (large/"big" thumbnails), the document can be scrolled within the
-  // thumbnail. The document subtree stays `inert` + `aria-hidden` (kept out of the tab
-  // order and the a11y tree); since `inert` blocks native scrolling, we translate wheel
-  // events into programmatic scrolling instead, keeping the thumbnail "scroll-only"
-  // rather than fully interactive.
+  // When true (large/"big" thumbnails — the 4-up replacement), the document is interactive:
+  // its read-only tiles can be selected and "picked up"/copied into the user's own document,
+  // so the subtree is NOT made `inert`/`aria-hidden`. The document is also scrollable within
+  // the thumbnail; a wheel handler keeps scrolling consistent (and lets the wheel fall through
+  // to the surrounding grid at the document's top/bottom edge). Small thumbnails are inert,
+  // non-interactive previews.
   scrollable?: boolean;
 }
 
@@ -42,11 +43,10 @@ export const ThumbnailDocumentItem: React.FC<IProps> = observer((props: IProps) 
   const classStore = useClassStore();
   const listItemRef = useRef<HTMLDivElement>(null);
 
-  // Large/"big" thumbnails are scroll-only: the document subtree is kept `inert` (out of
-  // the tab order) and `aria-hidden`, which also blocks native scrolling. Translate wheel
-  // events on the (non-inert) list item into programmatic scrolling of the inner document
-  // so users can scroll without the tiles becoming focusable/interactive. A non-passive
-  // listener is required so we can preventDefault the page scroll.
+  // Large/"big" thumbnails are interactive and scrollable. Translate wheel events on the list
+  // item into programmatic scrolling of the inner document so the wheel reliably scrolls the
+  // document content (and, at its top/bottom edge, falls through to the surrounding thumbnail
+  // grid). A non-passive listener is required so we can preventDefault the page scroll.
   useEffect(() => {
     if (!scrollable) return;
     const el = listItemRef.current;
@@ -125,13 +125,13 @@ export const ThumbnailDocumentItem: React.FC<IProps> = observer((props: IProps) 
       >
         <div
           className={classNames("scaled-list-item-container", { group })}
-          // The rendered document is non-interactive in every thumbnail: hide its tile
-          // content from the a11y tree (aria-hidden) and remove it from the tab order
-          // (inert). Large/scrollable thumbnails are scrolled via a wheel handler on the
-          // list item (see the effect above), since inert blocks native scrolling.
-          aria-hidden={true}
+          // Small thumbnails are non-interactive previews: hide tile content from the a11y
+          // tree (aria-hidden) and remove it from the tab order (inert). Large/scrollable
+          // thumbnails are the 4-up replacement and must stay interactive (tiles selectable
+          // and borrowable), so they are NOT inert/aria-hidden.
+          aria-hidden={scrollable ? undefined : true}
           // Spread bypasses React 17's type definitions, which lack `inert`.
-          {...{ inert: "" }}
+          {...(scrollable ? {} : { inert: "" })}
         >
           { isPrivate
             ? <ThumbnailPrivateIcon />


### PR DESCRIPTION
Made big thumbs allow 4-up style selection and copy of tiles which they need to support. Also tried to make the layout of the bookmark icon consistent because it was wandering all over the thumbs from view to view.