### PR TITLE
CLUE-563: respect problem term override in sort-work dropdown and headers

### DIFF
--- a/cypress/e2e/functional/teacher_tests/teacher_sort_work_view_9_spec.js
+++ b/cypress/e2e/functional/teacher_tests/teacher_sort_work_view_9_spec.js
@@ -33,11 +33,13 @@ describe("SortWorkView Problem Sort Tests", () => {
     cy.log("verify documents are organized by problem when Problem sort is applied");
     cy.get(".section-header-arrow").click({multiple: true}); // Open the sections
     cy.get(".section-header-label").should("exist");
-    // Verify that section headers contain problem labels (e.g., "Problem 1.1" or "No Problem")
+    // Section headers show the problem's title when the unit provides one (this unit's titles
+    // begin with the "X.Y" ordinal, e.g. "1.1 Unit Toolbar Configuration"), falling back to
+    // "Problem X.Y", or "No Problem" for ungrouped work.
     cy.get(".section-header-label").then($headers => {
       const headerTexts = Array.from($headers).map(el => el.textContent.trim());
       expect(headerTexts.length).to.be.greaterThan(0);
-      const problemRegex = /(Problem \d+\.\d+|No Problem)/;
+      const problemRegex = /(^\d+\.\d+|Problem \d+\.\d+|No Problem)/;
       headerTexts.forEach(headerText => {
         expect(headerText).to.match(problemRegex);
       });
@@ -55,7 +57,7 @@ describe("SortWorkView Problem Sort Tests", () => {
     sortWork.getPrimarySortByProblemOption().should("have.class", "selected");
   });
 
-  it("auto-switches 'Show for' filter from Problem to Investigation when primary sort is set to Problem", () => {
+  it("keeps the 'Show for' scope (no auto-switch) but disables the Problem scope option when sorting by Problem", () => {
     beforeTest(queryParams1);
 
     cy.log("set 'Show for' filter to Problem");
@@ -66,14 +68,14 @@ describe("SortWorkView Problem Sort Tests", () => {
     cy.log("verify Group is the selected primary sort option");
     sortWork.getPrimarySortByGroupOption().should("have.class", "selected");
 
-    cy.log("switch primary sort to Problem - 'Show for' should auto-switch to Investigation");
+    cy.log("switch primary sort to Problem - 'Show for' scope should NOT auto-switch to Investigation");
     sortWork.getPrimarySortByMenu().click();
     sortWork.getPrimarySortByProblemOption().click();
     sortWork.getPrimarySortByProblemOption().should("have.class", "selected");
 
-    cy.log("verify 'Show for' filter has been automatically changed to Investigation");
-    sortWork.getShowForProblemOption().should("not.have.class", "selected");
-    sortWork.getShowForInvestigationOption().should("have.class", "selected");
+    cy.log("verify 'Show for' scope was retained (Problem), not force-switched to Investigation");
+    sortWork.getShowForProblemOption().should("have.class", "selected");
+    sortWork.getShowForInvestigationOption().should("not.have.class", "selected");
 
     cy.log("verify Problem option in 'Show for' menu is disabled when sorting by Problem");
     sortWork.getShowForMenu().click();

--- a/src/components/document/document-scroller-header.tsx
+++ b/src/components/document/document-scroller-header.tsx
@@ -6,7 +6,7 @@ import { useStores } from "../../hooks/use-stores";
 import { DocumentGroup } from "../../models/stores/document-group";
 import { ENavTab } from "../../models/view/nav-tabs";
 import { isSortTypeId } from "../../models/stores/ui-types";
-import { getSortTypeTranslationKey } from "../../utilities/sort-utils";
+import { getFilterTypeDisplayLabel, getSortTypeTranslationKey } from "../../utilities/sort-utils";
 import { upperWords } from "../../utilities/string-utils";
 import { translate } from "../../utilities/translation/translate";
 import { IOpenDocumentsGroupMetadata } from "./sorted-section";
@@ -137,7 +137,7 @@ export const DocumentScrollerHeader = observer(function DocumentScrollerHeader({
         </div>
       </div>
       <div className="header-text">
-        Shown for <span>{persistentUI.docFilter}</span>
+        Shown for <span>{getFilterTypeDisplayLabel(persistentUI.docFilter)}</span>
       </div>
     </div>
   );

--- a/src/components/document/sort-work-view.tsx
+++ b/src/components/document/sort-work-view.tsx
@@ -10,9 +10,7 @@ import { LogEventName } from "../../lib/logger-types";
 import { DocumentGroup } from "../../models/stores/document-group";
 import { DocFilterType, DocFilterTypeIds, PrimarySortType, SecondarySortType } from "../../models/stores/ui-types";
 import { ENavTab } from "../../models/view/nav-tabs";
-import { getFilterTypeTranslationKey } from "../../utilities/sort-utils";
-import { upperWords } from "../../utilities/string-utils";
-import { isTranslationKey, translate } from "../../utilities/translation/translate";
+import { getFilterTypeDisplayLabel } from "../../utilities/sort-utils";
 import { urlParams } from "../../utilities/url-params";
 import { AiSummary } from "../navigation/ai-summary";
 import { SortWorkHeader } from "../navigation/sort-work-header";
@@ -72,13 +70,9 @@ export const SortWorkView: React.FC = observer(function SortWorkView() {
       persistentUI.setSecondarySortBy("None");
     }
 
-    if (sort === "Problem" && docFilter === "Problem") {
-      persistentUI.setDocFilter("Investigation");
-    }
-
     ui.clearHighlightedSortWorkDocument();
     ui.clearExpandedSortWorkSections();
-  }, [persistentUI, validatedPrimarySortBy, validatedSecondarySortBy, docFilter, ui]);
+  }, [persistentUI, validatedPrimarySortBy, validatedSecondarySortBy, ui]);
 
   const handleSecondarySortBySelection = useCallback((sort: SecondarySortType) => {
     Logger.log(LogEventName.SECOND_SORT_CHANGE, {old: validatedSecondarySortBy, new: sort});
@@ -110,11 +104,10 @@ export const SortWorkView: React.FC = observer(function SortWorkView() {
 
   // Disable "Problem" filter option when sorting by Problem
   const docFilterOptions: ICustomDropdownItem[] = filterOptions.map((option) => {
-    const key = getFilterTypeTranslationKey(option);
     return ({
       disabled: option === "Problem" && validatedPrimarySortBy === "Problem",
       selected: option === docFilter,
-      text: isTranslationKey(key) ? upperWords(translate(key)) : option,
+      text: getFilterTypeDisplayLabel(option),
       onClick: () => handleDocFilterSelection(option)
     });
   });
@@ -192,7 +185,6 @@ export const SortWorkView: React.FC = observer(function SortWorkView() {
           <>
             <SortWorkHeader
               key={`sort-work-header-${validatedPrimarySortBy}`}
-              docFilter={docFilter}
               docFilterItems={docFilterOptions}
               primarySortItems={primarySortByOptions}
               secondarySortItems={secondarySortByOptions}

--- a/src/components/navigation/sort-work-header.test.tsx
+++ b/src/components/navigation/sort-work-header.test.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { render, screen, within } from "@testing-library/react";
+import { SortWorkHeader } from "./sort-work-header";
+
+function makeItems(texts: string[], selectedIndex = 0) {
+  return texts.map((text, i) => ({ text, selected: i === selectedIndex, onClick: () => undefined }));
+}
+
+describe("SortWorkHeader", () => {
+  // CLUE-563: the "Show for" dropdown must display the selected option's label, which carries any
+  // term override (e.g. "Model" when contentLevel.problem is overridden), rather than the raw
+  // doc-filter id "Problem". Previously the dropdown title was hard-set to the raw filter id.
+  it("shows the selected filter's (possibly overridden) label, not the raw filter id", () => {
+    render(
+      <SortWorkHeader
+        docFilterItems={makeItems(["Model", "All"])}
+        primarySortItems={makeItems(["Date"])}
+        secondarySortItems={makeItems(["None"])}
+        showContextFilter={true}
+      />
+    );
+    const filterTrigger = screen.getByTestId("filter-work-menu-header");
+    expect(within(filterTrigger).getByText("Model")).toBeInTheDocument();
+    expect(within(filterTrigger).queryByText("Problem")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/navigation/sort-work-header.test.tsx
+++ b/src/components/navigation/sort-work-header.test.tsx
@@ -7,9 +7,6 @@ function makeItems(texts: string[], selectedIndex = 0) {
 }
 
 describe("SortWorkHeader", () => {
-  // CLUE-563: the "Show for" dropdown must display the selected option's label, which carries any
-  // term override (e.g. "Model" when contentLevel.problem is overridden), rather than the raw
-  // doc-filter id "Problem". Previously the dropdown title was hard-set to the raw filter id.
   it("shows the selected filter's (possibly overridden) label, not the raw filter id", () => {
     render(
       <SortWorkHeader

--- a/src/components/navigation/sort-work-header.tsx
+++ b/src/components/navigation/sort-work-header.tsx
@@ -5,7 +5,6 @@ import { CustomSelect, ICustomDropdownItem } from "../../clue/components/custom-
 import "./sort-work-header.scss";
 
 interface ISortHeaderProps{
-  docFilter: string;
   docFilterItems: ICustomDropdownItem[];
   primarySortItems: ICustomDropdownItem[];
   secondarySortItems: ICustomDropdownItem[];
@@ -13,7 +12,7 @@ interface ISortHeaderProps{
 }
 
 export const SortWorkHeader:React.FC<ISortHeaderProps>= observer(function SortWorkView(props){
-  const { docFilter, docFilterItems, primarySortItems, secondarySortItems, showContextFilter = true } = props;
+  const { docFilterItems, primarySortItems, secondarySortItems, showContextFilter = true } = props;
   return (
     <div className="sort-filter-menu-container">
       <div className="sort-work-header">
@@ -43,7 +42,6 @@ export const SortWorkHeader:React.FC<ISortHeaderProps>= observer(function SortWo
             <CustomSelect
               className="filter-work-menu primary-filter-menu"
               dataTest="filter-work-menu"
-              title={docFilter}
               items={docFilterItems}
               showItemChecks={false}
             />

--- a/src/models/stores/document-group.test.ts
+++ b/src/models/stores/document-group.test.ts
@@ -498,7 +498,7 @@ describe('DocumentGroup Model', () => {
     it('labels groups with the problem title when the unit provides one (keeping ordinal order)', () => {
       // Inject a unit that resolves a title for each (investigation, problem) ordinal pair.
       // (rootDocumentGroup holds the raw stores object that byProblem reads.)
-      (sortedDocuments.rootDocumentGroup.stores as unknown as { unit: unknown }).unit = {
+      (sortedDocuments.rootDocumentGroup.stores as any).unit = {
         getInvestigation: (investigationOrdinal: number) => ({
           getProblem: (problemOrdinal: number) => ({ title: `Storm ${investigationOrdinal}-${problemOrdinal}` })
         })

--- a/src/models/stores/document-group.test.ts
+++ b/src/models/stores/document-group.test.ts
@@ -495,6 +495,20 @@ describe('DocumentGroup Model', () => {
       expect(byProblemDocs[2].documents.length).toBe(1);
     });
 
+    it('labels groups with the problem title when the unit provides one (keeping ordinal order)', () => {
+      // Inject a unit that resolves a title for each (investigation, problem) ordinal pair.
+      // (rootDocumentGroup holds the raw stores object that byProblem reads.)
+      (sortedDocuments.rootDocumentGroup.stores as unknown as { unit: unknown }).unit = {
+        getInvestigation: (investigationOrdinal: number) => ({
+          getProblem: (problemOrdinal: number) => ({ title: `Storm ${investigationOrdinal}-${problemOrdinal}` })
+        })
+      };
+      const byProblemDocs = sortedDocuments.sortBy("Problem");
+      expect(byProblemDocs.map(g => g.label)).toEqual(["Storm 1-1", "Storm 1-2", "Storm 2-1"]);
+      // Grouping/ordering is unchanged — only the displayed label differs.
+      expect(byProblemDocs[1].documents.length).toBe(3);
+    });
+
     it('should sort "No Problem" to the end', () => {
       // Modify one document to not have problem info
       const metadataWithNoProblem: SnapshotIn<typeof MetadataDocMapModel> = {

--- a/src/models/stores/document-group.ts
+++ b/src/models/stores/document-group.ts
@@ -11,6 +11,7 @@ import { IDocumentMetadataModel } from "../document/document-metadata-model";
 import { GroupDocument } from "../document/document-types";
 import { getTileComponentInfo } from "../tiles/tile-component-info";
 import { getTileContentInfo } from "../tiles/tile-content-info";
+import { UnitModelType } from "../curriculum/unit";
 import { AppConfigModelType } from "./app-config-model";
 import { Bookmarks } from "./bookmarks";
 import { ClassModelType, ClassUserModelType } from "./class";
@@ -24,6 +25,7 @@ interface IDocumentGroupStores {
   class: ClassModelType;
   appConfig: AppConfigModelType;
   bookmarks: Bookmarks;
+  unit?: UnitModelType;
 }
 
 export type TagWithDocs = {
@@ -291,14 +293,20 @@ export class DocumentGroup {
 
   get byProblem(): DocumentGroup[] {
     const docMap: Map<string, IDocumentMetadataModel[]> = new Map();
+    // Map the ordinal-based grouping key to the problem's actual title, when available, so the
+    // group is displayed with its title (e.g. "Storm Arthur") rather than a generic "Problem 1.1".
+    const titleByLabel: Map<string, string> = new Map();
+    const problemTerm = upperWords(translate("contentLevel.problem"));
     this.documents.forEach((doc) => {
       const investigationOrdinal = doc.investigation;
       const problemOrdinal = doc.problem;
-      const problemTerm = upperWords(translate("contentLevel.problem"));
       let sectionLabel = `No ${problemTerm}`;
 
       if (investigationOrdinal != null && problemOrdinal != null) {
         sectionLabel = `${problemTerm} ${investigationOrdinal}.${problemOrdinal}`;
+        const title = this.stores.unit
+          ?.getInvestigation(Number(investigationOrdinal))?.getProblem(Number(problemOrdinal))?.title;
+        if (title) titleByLabel.set(sectionLabel, title);
       } else if (problemOrdinal != null) {
         sectionLabel = `${problemTerm} ${problemOrdinal}`;
       }
@@ -309,7 +317,13 @@ export class DocumentGroup {
       docMap.get(sectionLabel)?.push(doc);
     });
 
+    // Group/sort by the ordinal-based key, but display the resolved problem title (when available).
     const sortedSectionLabels = sortProblemSectionLabels(Array.from(docMap.keys()));
-    return this.buildDocumentCollection({sortedSectionLabels, sortType: "Problem", docMap});
+    return sortedSectionLabels.map(label => new DocumentGroup({
+      label: titleByLabel.get(label) ?? label,
+      sortType: "Problem",
+      documents: docMap.get(label) ?? [],
+      stores: this.stores
+    }));
   }
 }

--- a/src/models/stores/document-group.ts
+++ b/src/models/stores/document-group.ts
@@ -52,6 +52,10 @@ interface IBuildDocumentCollectionProps {
   docMap: Map<string, IDocumentMetadataModel[]>;
   sortedSectionLabels: string[];
   sortType: SecondarySortType;
+  // Optional per-label display overrides, keyed by the ordinal-based grouping
+  // label. Problem sort uses this to show a problem's title in place of the
+  // generic "Problem 1.1" while still grouping/sorting by the ordinal key.
+  labelMap?: Map<string, string>;
 }
 
 /*
@@ -121,10 +125,10 @@ export class DocumentGroup {
   }
 
   buildDocumentCollection(props: IBuildDocumentCollectionProps): DocumentGroup[] {
-    const { docMap, sortedSectionLabels, sortType } = props;
+    const { docMap, sortedSectionLabels, sortType, labelMap } = props;
     return sortedSectionLabels.map(label => {
       return new DocumentGroup({
-        label,
+        label: labelMap?.get(label) ?? label,
         sortType,
         documents: docMap.get(label) ?? [],
         stores: this.stores
@@ -295,7 +299,7 @@ export class DocumentGroup {
     const docMap: Map<string, IDocumentMetadataModel[]> = new Map();
     // Map the ordinal-based grouping key to the problem's actual title, when available, so the
     // group is displayed with its title (e.g. "Storm Arthur") rather than a generic "Problem 1.1".
-    const titleByLabel: Map<string, string> = new Map();
+    const labelMap: Map<string, string> = new Map();
     const problemTerm = upperWords(translate("contentLevel.problem"));
     this.documents.forEach((doc) => {
       const investigationOrdinal = doc.investigation;
@@ -304,9 +308,9 @@ export class DocumentGroup {
 
       if (investigationOrdinal != null && problemOrdinal != null) {
         sectionLabel = `${problemTerm} ${investigationOrdinal}.${problemOrdinal}`;
-        const title = this.stores.unit
-          ?.getInvestigation(Number(investigationOrdinal))?.getProblem(Number(problemOrdinal))?.title;
-        if (title) titleByLabel.set(sectionLabel, title);
+        const investigation = this.stores.unit?.getInvestigation(Number(investigationOrdinal));
+        const title = investigation?.getProblem(Number(problemOrdinal))?.title;
+        if (title) labelMap.set(sectionLabel, title);
       } else if (problemOrdinal != null) {
         sectionLabel = `${problemTerm} ${problemOrdinal}`;
       }
@@ -319,11 +323,6 @@ export class DocumentGroup {
 
     // Group/sort by the ordinal-based key, but display the resolved problem title (when available).
     const sortedSectionLabels = sortProblemSectionLabels(Array.from(docMap.keys()));
-    return sortedSectionLabels.map(label => new DocumentGroup({
-      label: titleByLabel.get(label) ?? label,
-      sortType: "Problem",
-      documents: docMap.get(label) ?? [],
-      stores: this.stores
-    }));
+    return this.buildDocumentCollection({ docMap, labelMap, sortedSectionLabels, sortType: "Problem" });
   }
 }

--- a/src/models/stores/document-group.ts
+++ b/src/models/stores/document-group.ts
@@ -52,9 +52,7 @@ interface IBuildDocumentCollectionProps {
   docMap: Map<string, IDocumentMetadataModel[]>;
   sortedSectionLabels: string[];
   sortType: SecondarySortType;
-  // Optional per-label display overrides, keyed by the ordinal-based grouping
-  // label. Problem sort uses this to show a problem's title in place of the
-  // generic "Problem 1.1" while still grouping/sorting by the ordinal key.
+  // Optional per-label display overrides, keyed by the ordinal-based grouping label.
   labelMap?: Map<string, string>;
 }
 

--- a/src/models/stores/sorted-documents.ts
+++ b/src/models/stores/sorted-documents.ts
@@ -18,6 +18,7 @@ import { DocumentsModelType } from "./documents";
 import { GroupsModelType } from "./groups";
 import { PrimarySortType } from "./ui-types";
 import { UserModelType } from "./user";
+import { UnitModelType } from "../curriculum/unit";
 
 export type SortedDocumentsMap = Record<string, DocumentGroup[]>;
 
@@ -30,6 +31,7 @@ export interface ISortedDocumentsStores {
   bookmarks: Bookmarks;
   user: UserModelType;
   curriculumConfig: CurriculumConfigType;
+  unit?: UnitModelType;
 }
 
 export const MetadataDocMapModel = types.map(DocumentMetadataModel);

--- a/src/utilities/sort-utils.test.ts
+++ b/src/utilities/sort-utils.test.ts
@@ -1,9 +1,10 @@
 import { SortTypeIds } from "../authoring/types";
 import { OverrideableDocFilterTypeIds } from "../models/stores/ui-types";
 import {
-  escapeKeyForForm, FILTER_TYPE_TO_TRANSLATION_KEY, getFilterTypeTranslationKey,
+  escapeKeyForForm, FILTER_TYPE_TO_TRANSLATION_KEY, getFilterTypeDisplayLabel, getFilterTypeTranslationKey,
   getSortTypeTranslationKey, isValidSortTypeId, SORT_TYPE_TO_TRANSLATION_KEY
 } from "./sort-utils";
+import { clearTermOverrides, setTermOverrides } from "./translation/translate";
 
 describe("sort-utils", () => {
   describe("FILTER_TYPE_TO_TRANSLATION_KEY", () => {
@@ -29,6 +30,26 @@ describe("sort-utils", () => {
 
     it("should return the filter type itself for non-overrideable types", () => {
       expect(getFilterTypeTranslationKey("All")).toBe("All");
+    });
+  });
+
+  describe("getFilterTypeDisplayLabel", () => {
+    afterEach(() => clearTermOverrides());
+
+    it("returns the upper-worded default label when there is no term override", () => {
+      clearTermOverrides();
+      expect(getFilterTypeDisplayLabel("Problem")).toBe("Problem");
+    });
+
+    // CLUE-563: the label must reflect the unit's term override for the problem scope.
+    it("applies the unit term override for the problem scope", () => {
+      setTermOverrides({ "contentLevel.problem": "Model" });
+      expect(getFilterTypeDisplayLabel("Problem")).toBe("Model");
+    });
+
+    it("returns non-overrideable scopes (e.g. All) unchanged", () => {
+      setTermOverrides({ "contentLevel.problem": "Model" });
+      expect(getFilterTypeDisplayLabel("All")).toBe("All");
     });
   });
 

--- a/src/utilities/sort-utils.test.ts
+++ b/src/utilities/sort-utils.test.ts
@@ -41,7 +41,6 @@ describe("sort-utils", () => {
       expect(getFilterTypeDisplayLabel("Problem")).toBe("Problem");
     });
 
-    // CLUE-563: the label must reflect the unit's term override for the problem scope.
     it("applies the unit term override for the problem scope", () => {
       setTermOverrides({ "contentLevel.problem": "Model" });
       expect(getFilterTypeDisplayLabel("Problem")).toBe("Model");

--- a/src/utilities/sort-utils.ts
+++ b/src/utilities/sort-utils.ts
@@ -1,7 +1,8 @@
 import {
   DocFilterType, isOverrideableDocFilterTypeId, OverrideableDocFilterTypeId, SortTypeId, SortTypeIds
 } from "../models/stores/ui-types";
-import { TranslationKeyType } from "./translation/translate";
+import { isTranslationKey, translate, TranslationKeyType } from "./translation/translate";
+import { upperWords } from "./string-utils";
 
 /**
  * Maps sort type IDs (used in PrimarySortType) to translation keys.
@@ -35,6 +36,15 @@ export function getFilterTypeTranslationKey(filterType: DocFilterType): Translat
   return isOverrideableDocFilterTypeId(filterType)
     ? FILTER_TYPE_TO_TRANSLATION_KEY[filterType]
     : filterType as TranslationKeyType;
+}
+
+/**
+ * Get the display label for a doc-filter scope, applying any unit term override
+ * (e.g. "Problem" -> "Model"). Non-overrideable scopes like "All" are returned as-is.
+ */
+export function getFilterTypeDisplayLabel(filterType: DocFilterType): string {
+  const key = getFilterTypeTranslationKey(filterType);
+  return isTranslationKey(key) ? upperWords(translate(key)) : filterType;
 }
 
 export function isValidSortTypeId(value: string): value is SortTypeId {


### PR DESCRIPTION
The sort-work "Show for" dropdown and the scroller "Shown for" label showed the raw filter id ("Problem"), same for "Investigation" and so on instead of the unit's term override, and selecting the Problem sort force-set the scope to "Investigation" (often not a valid option). Sort-by-Problem groups were also labeled "Problem 1.1" rather than by title.

- Drop the hard-coded title on the "Show for" CustomSelect so it shows the selected option's (term-overridden) label, like the sibling sort dropdowns.
- Add getFilterTypeDisplayLabel() and use it for both the dropdown options and the scroller "Shown for" label so they apply the term override consistently.
- Stop auto-setting the doc filter to "Investigation" when sorting by Problem.
- Label sort-by-Problem groups with the problem title (resolved from the unit), falling back to "Problem X.Y" when no title is available; ordinal grouping and sort order are unchanged. Thread unit (optional) onto the sorting stores types.
- Add tests for the display-label helper, the header, and title-based grouping.