### PR TITLE
Fix master build break and studentDocument tab routing regression

### DIFF
--- a/src/components/navigation/nav-tab-panel.tsx
+++ b/src/components/navigation/nav-tab-panel.tsx
@@ -55,7 +55,7 @@ export class NavTabPanel extends BaseComponent<IProps> {
     const selectedNavTab = this.stores.displayedActiveNavTab;
     const selectedTabIndex = tabs?.findIndex(t => t.tab === selectedNavTab);
     const isChatEnabled = appConfig.showCommentPanelFor(user.type) &&
-      !shouldHideChat(activeNavTab, user.type);
+      !shouldHideChat(selectedNavTab, user.type);
     const openChatPanel = isChatEnabled && showChatPanel;
     const focusTileId = selectedTileIds?.length === 1 ? selectedTileIds[0] : undefined;
     const ariaLabels = getAriaLabels();

--- a/src/models/stores/persistent-ui/persistent-ui.test.ts
+++ b/src/models/stores/persistent-ui/persistent-ui.test.ts
@@ -392,7 +392,7 @@ describe("PersistentUI", () => {
     });
 
     describe("URL student document handling", () => {
-      it("routes a report link to Sort Work (not student-work) when available, sorted by Name", () => {
+      it("routes a report link to Sort Work when the doc's group is unavailable, sorted by Name", () => {
         // aiEvaluation is intentionally undefined to prove the Sort Work routing and
         // the Name sort come from the report-link path itself, not from aiEvaluation.
         mockAppConfig = {
@@ -406,6 +406,8 @@ describe("PersistentUI", () => {
           }
         };
 
+        // Without hasStudentWorkGroup, student-work would render blank (its group
+        // content loads async), so the report link falls back to Sort Work.
         persistentUI.openResourceDocument(
           mockDoc,
           mockAppConfig,
@@ -414,10 +416,33 @@ describe("PersistentUI", () => {
           { fromUrlStudentDocument: true }
         );
 
-        // Previously this activated "student-work", which can be hidden/absent from
-        // tabsToDisplay and leave the content panel blank.
         expect(persistentUI.activeNavTab).toBe(ENavTab.kSortWork);
         expect(persistentUI.primarySortBy).toBe("Name");
+      });
+
+      it("routes to Student Work when the doc's group is available to the viewer", () => {
+        mockAppConfig = {
+          aiEvaluation: undefined,
+          navTabs: {
+            tabSpecs: [
+              { tab: "sort-work", label: "Sort Work" },
+              { tab: "my-work", label: "My Work" },
+              { tab: "student-work", label: "Student Work" }
+            ]
+          }
+        };
+
+        // With the doc's group available, Student Work can render, so a teacher
+        // report link opens there rather than falling back to Sort Work.
+        persistentUI.openResourceDocument(
+          mockDoc,
+          mockAppConfig,
+          mockUser,
+          mockSortedDocuments,
+          { fromUrlStudentDocument: true, hasStudentWorkGroup: true }
+        );
+
+        expect(persistentUI.activeNavTab).toBe(ENavTab.kStudentWork);
       });
 
       it("does not force student-work when Sort Work is unavailable (uses the doc's natural tab)", () => {

--- a/src/models/stores/persistent-ui/persistent-ui.ts
+++ b/src/models/stores/persistent-ui/persistent-ui.ts
@@ -263,16 +263,20 @@ export const PersistentUIModelV2 = types
       appConfig: AppConfigModelType,
       user?: UserModelType,
       sortedDocuments?: SortedDocuments,
-      opts?: { fromUrlStudentDocument?: boolean }
+      opts?: { fromUrlStudentDocument?: boolean, hasStudentWorkGroup?: boolean }
     ) {
       const { aiEvaluation, navTabs } = appConfig || {};
       const availableTabs = navTabs?.tabSpecs.map(tab => tab.tab) ?? [];
       let navTab = "";
 
       if (opts?.fromUrlStudentDocument) {
-        // Report links land on Sort Work (ensured by setRequireSortWorkTab);
-        // activating kStudentWork can select a tab absent from tabsToDisplay -> blank panel.
-        if (availableTabs.includes(ENavTab.kSortWork)) {
+        // Student Work is group-keyed and loads its group's documents asynchronously,
+        // so activating it without the doc's group available leaves a blank panel.
+        // Use it only when the viewer's group is available; otherwise fall back to
+        // Sort Work, which needs no group.
+        if (opts.hasStudentWorkGroup && availableTabs.includes(ENavTab.kStudentWork)) {
+          navTab = ENavTab.kStudentWork;
+        } else if (availableTabs.includes(ENavTab.kSortWork)) {
           navTab = ENavTab.kSortWork;
         }
       } else if (aiEvaluation) {

--- a/src/models/stores/stores.ts
+++ b/src/models/stores/stores.ts
@@ -191,9 +191,12 @@ class Stores implements IStores{
       const docPromise = this.sortedDocuments.fetchFullDocument(docToDisplay);
       docPromise.then((doc) => {
         if (doc) {
+          // Student Work can only display the doc when the viewer has its group
+          // loaded; otherwise openResourceDocument falls back to Sort Work.
+          const hasStudentWorkGroup = !!doc.groupId && !!this.groups.getGroupById(doc.groupId);
           this.persistentUI.openResourceDocument(
             doc, this.appConfig, this.user, this.sortedDocuments,
-            { fromUrlStudentDocument: true }
+            { fromUrlStudentDocument: true, hasStudentWorkGroup }
           );
         } else {
           console.warn("Display document not found: ", params.documentToDisplay);

--- a/src/models/stores/stores.ts
+++ b/src/models/stores/stores.ts
@@ -191,12 +191,20 @@ class Stores implements IStores{
       const docPromise = this.sortedDocuments.fetchFullDocument(docToDisplay);
       docPromise.then((doc) => {
         if (doc) {
-          // Student Work can only display the doc when the viewer has its group
-          // loaded; otherwise openResourceDocument falls back to Sort Work.
-          const hasStudentWorkGroup = !!doc.groupId && !!this.groups.getGroupById(doc.groupId);
-          this.persistentUI.openResourceDocument(
-            doc, this.appConfig, this.user, this.sortedDocuments,
-            { fromUrlStudentDocument: true, hasStudentWorkGroup }
+          // Student Work is group-keyed and its group content loads asynchronously.
+          // Wait until either the doc's group is available or the DB listeners have
+          // finished their initial load (so we know it isn't coming — e.g. a researcher
+          // reaching the doc by key, who doesn't have its class/offering groups), then
+          // route: Student Work when the group is present, otherwise Sort Work.
+          when(
+            () => !!this.groups.getGroupById(doc.groupId) || this.db.listeners.isListening,
+            () => {
+              const hasStudentWorkGroup = !!doc.groupId && !!this.groups.getGroupById(doc.groupId);
+              this.persistentUI.openResourceDocument(
+                doc, this.appConfig, this.user, this.sortedDocuments,
+                { fromUrlStudentDocument: true, hasStudentWorkGroup }
+              );
+            }
           );
         } else {
           console.warn("Display document not found: ", params.documentToDisplay);


### PR DESCRIPTION
## Problem

Master's build broke from a **semantic merge conflict between two separately-valid PRs** — neither was wrong on its own.

- **#2899 (CLUE-562)** merged first. It refactored the chat-visibility check from a tab-*index* method `this.shouldHideChat(selectedTabIndex, …)` into a free function `shouldHideChat(activeNavTab, …)` that keys off tab *identity*. This relied on `activeNavTab` being destructured from `persistentUI` in `render()`.
- **#2896 (CLUE-539)**, branched before #2899 landed, **removed** `activeNavTab` from that destructuring, replacing it with `selectedNavTab` (resolved via `stores.displayedActiveNavTab`). On its own branch, line 58 was still the old `this.shouldHideChat(selectedTabIndex, …)`, so it built cleanly.
- Merging #2896 into master (which already had #2899) combined #2899's `shouldHideChat(activeNavTab, …)` call with #2896's removal of the `activeNavTab` variable. No textual conflict, but the result references a variable that no longer exists:

```
TS2304: Cannot find name 'activeNavTab'.
```

which failed **Build Main App**. The 3 Cypress failures (`Expected to find element: '.version', but never found it`) were downstream — the app never rendered because the bundle failed to build — not independent failures.

## Fix

Pass `selectedNavTab` to `shouldHideChat`. It's the resolved displayed-tab identity (`stores.displayedActiveNavTab`), which is exactly what CLUE-562's identity-based check wants, and it matches the `ChatPanel activeNavTab={selectedNavTab}` usage a few lines below.

```diff
-      !shouldHideChat(activeNavTab, user.type);
+      !shouldHideChat(selectedNavTab, user.type);
```

Type check passes clean; no other stale references remain.

## Follow-on commit: gate studentDocument routing on group availability

Running the full regression on this branch surfaced a pre-existing failure in `teacher_student_work_spec` ("Teacher can use studentDocument URL parameter"). It was never caught before because the full regression suite was skipped on the original CLUE-539 PR (#2896) — only smoke tests ran there.

**Root cause (from #2896, not the build fix):** the `studentDocument` report-link path in `persistent-ui.ts` routed to Sort Work whenever Sort Work was available — and since `setRequireSortWorkTab(true)` always force-adds it in that path, it *always* routed to Sort Work, never Student Work. That fixed the researcher blank-panel bug but also redirected the teacher `studentDocument` case, which expects Student Work.

Student Work is group-keyed and loads its group's documents asynchronously, so activating it without the doc's group available renders a blank panel. Groups are scoped to the viewer's own class/offering (`classes/{classHash}/offerings/{offeringId}/groups`), so a teacher-of-the-class has the doc's group loaded but a researcher reaching the doc by key does not.

**Fix:** route to Student Work only when the doc's group is available to the viewer (`groups.getGroupById(doc.groupId)`), otherwise fall back to Sort Work. This restores the teacher case (`teacher_student_work_spec` passes unchanged) while preserving the researcher blank-panel fix.

- `persistent-ui.ts` — added `hasStudentWorkGroup` opt; select Student Work when it and the tab are available, else Sort Work.
- `stores.ts` — at the call site (where `groups` is in scope), wait via a MobX `when` until the doc's group is available or the DB listeners have finished their initial load, then compute `hasStudentWorkGroup` and route.
- `persistent-ui.test.ts` — reframed the no-group case and added a group-available case.

Note: routing waits for the viewer's groups to settle before deciding. The `when` fires as soon as the doc's group is present (the common teacher case, usually immediate) or, failing that, once `db.listeners.isListening` flips true — so a researcher whose group never loads still falls back cleanly to Sort Work without hanging. This removes the timing race where a teacher whose groups hadn't loaded yet could be misrouted to Sort Work.

The other regression failure (`drawing_tool_spec` "Group") is an unrelated flake — it passed in the daily regression and touches no code in this PR; it clears on re-run.

