### PR TITLE
fix: skip hidden nav tabs when routing report links [CLUE-539]

### DIFF
--- a/src/models/stores/persistent-ui/persistent-ui.test.ts
+++ b/src/models/stores/persistent-ui/persistent-ui.test.ts
@@ -492,6 +492,28 @@ describe("PersistentUI", () => {
 
         expect(persistentUI.activeNavTab).toBe(ENavTab.kMyWork);
       });
+
+      it("substitutes Sort Work on the doc-based path when the natural tab is hidden", () => {
+        // No fromUrlStudentDocument flag: a teacher/researcher opening another
+        // student's problem doc (e.g. from a comment) resolves to student-work via
+        // getNavTabOfDocument. When that tab is hidden (mods), route to the visible
+        // Sort Work tab instead of the hidden one.
+        mockUser = { id: "teacher1", isTeacherOrResearcher: true };
+        mockAppConfig = {
+          aiEvaluation: undefined,
+          navTabs: {
+            tabSpecs: [
+              { tab: "sort-work", label: "Class Work" },
+              { tab: "my-work", label: "My Work" },
+              { tab: "student-work", label: "Student Work", hidden: true }
+            ]
+          }
+        };
+
+        persistentUI.openResourceDocument(mockDoc, mockAppConfig, mockUser, mockSortedDocuments);
+
+        expect(persistentUI.activeNavTab).toBe(ENavTab.kSortWork);
+      });
     });
   });
 

--- a/src/models/stores/persistent-ui/persistent-ui.test.ts
+++ b/src/models/stores/persistent-ui/persistent-ui.test.ts
@@ -445,6 +445,32 @@ describe("PersistentUI", () => {
         expect(persistentUI.activeNavTab).toBe(ENavTab.kStudentWork);
       });
 
+      it("does not route to student-work when that tab is hidden, even with the group available", () => {
+        // The mods unit hides its student-work tab and exposes sort-work as the
+        // visible "Class Work" tab. Routing to the hidden student-work tab leaves
+        // displayedActiveNavTab falling back to the first tab, so the doc never shows.
+        mockAppConfig = {
+          aiEvaluation: undefined,
+          navTabs: {
+            tabSpecs: [
+              { tab: "sort-work", label: "Class Work" },
+              { tab: "my-work", label: "My Work" },
+              { tab: "student-work", label: "Student Work", hidden: true }
+            ]
+          }
+        };
+
+        persistentUI.openResourceDocument(
+          mockDoc,
+          mockAppConfig,
+          mockUser,
+          mockSortedDocuments,
+          { fromUrlStudentDocument: true, hasStudentWorkGroup: true }
+        );
+
+        expect(persistentUI.activeNavTab).toBe(ENavTab.kSortWork);
+      });
+
       it("does not force student-work when Sort Work is unavailable (uses the doc's natural tab)", () => {
         mockAppConfig = {
           aiEvaluation: undefined,

--- a/src/models/stores/persistent-ui/persistent-ui.ts
+++ b/src/models/stores/persistent-ui/persistent-ui.ts
@@ -266,7 +266,11 @@ export const PersistentUIModelV2 = types
       opts?: { fromUrlStudentDocument?: boolean, hasStudentWorkGroup?: boolean }
     ) {
       const { aiEvaluation, navTabs } = appConfig || {};
-      const availableTabs = navTabs?.tabSpecs.map(tab => tab.tab) ?? [];
+      // Only route to tabs that are actually displayed. A unit can hide a tab it
+      // defines (e.g. mods hides student-work and exposes sort-work as "Class Work");
+      // routing the active tab to a hidden tab leaves displayedActiveNavTab falling
+      // back to the first tab, so the document never appears.
+      const availableTabs = navTabs?.tabSpecs.filter(tab => !tab.hidden).map(tab => tab.tab) ?? [];
       let navTab = "";
 
       if (opts?.fromUrlStudentDocument) {

--- a/src/models/stores/persistent-ui/persistent-ui.ts
+++ b/src/models/stores/persistent-ui/persistent-ui.ts
@@ -295,6 +295,14 @@ export const PersistentUIModelV2 = types
         navTab = getNavTabOfDocument(doc, user) || "";
       }
 
+      // getNavTabOfDocument can pick a tab the unit hides (e.g. a teacher/researcher
+      // opening another student's problem doc resolves to student-work, which mods
+      // hides). Routing there leaves displayedActiveNavTab falling back to the first
+      // tab, so substitute the always-visible Sort Work tab when it's available.
+      if (navTab && !availableTabs.includes(navTab as ENavTab) && availableTabs.includes(ENavTab.kSortWork)) {
+        navTab = ENavTab.kSortWork;
+      }
+
       let docGroupId = "";
       if (navTab === ENavTab.kClassWork) {
         if (doc.type === LearningLogPublication) {


### PR DESCRIPTION
openResourceDocument built its candidate tab list from every tab the unit defines, including hidden ones. On the mods unit — which hides student-work and exposes sort-work as the visible "Class Work" tab — a researcher or teacher report link has the doc's group, so routing chose the hidden student-work tab. displayedActiveNavTab can't find a hidden tab among the displayed tabs, so it fell back to the first tab (Lesson) and the document never appeared.

Exclude hidden tabs when computing availableTabs so routing only targets tabs that are actually displayed, falling through to the next visible candidate (Sort Work / "Class Work") instead.