### PR TITLE
docs: add lean-comments guideline to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,8 @@ See [tiles.md](tiles.md) for detailed tile documentation.
 
 **className construction**: When a JSX element has any conditional or computed class, use the `classnames` helper (`import classNames from "classnames"`) rather than template literals or string concatenation. Pass static classes as bare strings, conditional classes via the object form, and any precomputed class variable as another argument. Example: `classNames("history-entry-item", sourceClass, { expanded, "not-undoable": !undoable })`. A plain string literal is fine only when there are no conditions or interpolations at all.
 
+**Comments**: Write a comment only when it adds information the code doesn't already convey. Don't restate the code, a function/variable name, or a test's `it(...)` description. Reserve comments for non-obvious *why* — rationale, gotchas, invariants — not *what*. Prefer a short note, or none, over a verbose multi-line explanation. AI-generated code tends to over-comment; err toward fewer, higher-value comments.
+
 ### URL Parameters for Testing
 
 | Parameter | Values | Purpose |


### PR DESCRIPTION
Adds a **Comments** entry to `CLAUDE.md` → Key Patterns, codifying review feedback that AI-authored PRs tend to over-comment:

> Write a comment only when it adds information the code doesn't already convey. Don't restate the code, a function/variable name, or a test's `it(...)` description. Reserve comments for non-obvious *why* — rationale, gotchas, invariants — not *what*. Prefer a short note, or none, over a verbose multi-line explanation.

Since `CLAUDE.md` is always loaded by Claude Code in this repo, this steers future AI-assisted editing to produce leaner comments up front, reducing the review cleanup Teale has been doing (e.g. on #2907).

🤖 Generated with [Claude Code](https://claude.com/claude-code)