### PR TITLE
Fix Local Timezone Test

### DIFF
--- a/src/models/document/document-utils.test.ts
+++ b/src/models/document/document-utils.test.ts
@@ -92,7 +92,8 @@ describe("document utils", () => {
         });
         const appConfig = AppConfigModel.create({config: unitConfigDefaults});
         const title = getDocumentDisplayTitle(unit, metadata, appConfig);
-        expect(title).toMatch(/Test Title \(23FEB76-..:..:..\)/);
+        // The specified timestamp can be interpreted as on the 22nd or 23rd, depending on the local time zone.
+        expect(title).toMatch(/Test Title \(2[2|3]FEB76-..:..:..\)/);
       });
     });
 

--- a/src/models/document/document-utils.test.ts
+++ b/src/models/document/document-utils.test.ts
@@ -93,7 +93,7 @@ describe("document utils", () => {
         const appConfig = AppConfigModel.create({config: unitConfigDefaults});
         const title = getDocumentDisplayTitle(unit, metadata, appConfig);
         // The specified timestamp can be interpreted as on the 22nd or 23rd, depending on the local time zone.
-        expect(title).toMatch(/Test Title \(2[2|3]FEB76-..:..:..\)/);
+        expect(title).toMatch(/Test Title \(2[23]FEB76-..:..:..\)/);
       });
     });
 


### PR DESCRIPTION
This PR fixes a test that relies on local interpretation of a date. Previously, this test would fail when run in timezones west of Eastern, because the date was interpreted as the 22nd instead of the 23rd.