### PR TITLE
feat: aggregate tags in export tags script (CLUE-549)

### DIFF
--- a/scripts/export-comment-tags.ts
+++ b/scripts/export-comment-tags.ts
@@ -543,7 +543,7 @@ if (!args.contextIds.length && !args.documentKeys.length) {
 
 const tileTags: Record<string, Set<string>> = {};
 const documentTags: Record<string, Set<string>> = {};
-const tileKeyOf = (row: IPendingRow) => `${row.documentGroupKey} ${row.tileId}`;
+const tileKeyOf = (row: IPendingRow) => `${row.documentGroupKey}\u0000${row.tileId}`;
 
 for (const row of pendingRows) {
   if (!row.tag) continue;  // --include-untagged placeholder

--- a/scripts/export-comment-tags.ts
+++ b/scripts/export-comment-tags.ts
@@ -59,6 +59,9 @@
 //   sorted, de-duplicated unions of the tags on that tile/document. The
 //   document-level union is the same value CLUE itself maintains as the
 //   document's `strategies` field (functions-v2/src/on-document-tagged.ts).
+//   `all_tile_tags` is blank for document-level comments (those with no
+//   tileId), which have no tile to aggregate; `all_document_tags` still counts
+//   their tags.
 //
 //   Those unions are computed from the rows in THIS export, so grouping the CSV
 //   by tile/document reproduces them exactly. When --start-date/--end-date/
@@ -547,7 +550,11 @@ const tileKeyOf = (row: IPendingRow) => `${row.documentGroupKey}\u0000${row.tile
 
 for (const row of pendingRows) {
   if (!row.tag) continue;  // --include-untagged placeholder
-  (tileTags[tileKeyOf(row)] ??= new Set()).add(row.tag);
+  // Only tile-attached comments contribute to a tile union. Document-level
+  // comments (empty tileId) would otherwise all collapse into one bucket per
+  // document, making all_tile_tags a union of unrelated comments; they are
+  // still covered by all_document_tags below.
+  if (row.tileId) (tileTags[tileKeyOf(row)] ??= new Set()).add(row.tag);
   (documentTags[row.documentGroupKey] ??= new Set()).add(row.tag);
 }
 
@@ -559,7 +566,7 @@ const rows = pendingRows.map(row => [
   ...row.baseRow,
   row.tag,
   tagLabels[row.tag] ?? "",
-  joinTags(tileTags[tileKeyOf(row)]),
+  row.tileId ? joinTags(tileTags[tileKeyOf(row)]) : "",
   joinTags(documentTags[row.documentGroupKey]),
   ...row.contentColumns
 ]);

--- a/scripts/export-comment-tags.ts
+++ b/scripts/export-comment-tags.ts
@@ -52,6 +52,19 @@
 //   `offering_id`/`document_link` are blank for personal documents and
 //   learning logs (no offering) and for --demo runs.
 //
+//   Each row reports a single tag (`tag_id`), because CLUE only ever stores one
+//   tag per comment -- the tagging UI is a single-select and the AI tagger
+//   writes a one-element array. To see every tag applied to a tile or document,
+//   use the `all_tile_tags` and `all_document_tags` columns: pipe-separated,
+//   sorted, de-duplicated unions of the tags on that tile/document. The
+//   document-level union is the same value CLUE itself maintains as the
+//   document's `strategies` field (functions-v2/src/on-document-tagged.ts).
+//
+//   Those unions are computed from the rows in THIS export, so grouping the CSV
+//   by tile/document reproduces them exactly. When --start-date/--end-date/
+//   --commenter-uids narrow the export, tags on excluded comments are not
+//   counted.
+//
 // Examples:
 //   npx tsx export-comment-tags.ts --context-ids abc123 \
 //     --start-date 2026-03-01 --end-date 2026-05-31
@@ -360,10 +373,21 @@ const header = [
   "document_firestore_id", "document_key", "document_type", "document_title", "document_owner_uid",
   "problem_label", "document_offering_id", "document_link",
   "comment_id", "comment_created_at", "comment_author_uid", "comment_author_name", "comment_network",
-  "tile_id", "tag_id", "tag_label", "all_comment_tags",
+  "tile_id", "tag_id", "tag_label", "all_tile_tags", "all_document_tags",
   ...(args.excludeContent ? [] : ["comment_content"])
 ];
-const rows: string[][] = [];
+
+// Rows are buffered rather than written as they are produced, because the
+// all_tile_tags/all_document_tags columns can only be filled in once every
+// comment has been scanned.
+interface IPendingRow {
+  baseRow: string[];
+  tag: string;
+  contentColumns: string[];
+  documentGroupKey: string;
+  tileId: string;
+}
+const pendingRows: IPendingRow[] = [];
 
 let documentsProcessed = 0;
 let commentsProcessed = 0;
@@ -425,9 +449,13 @@ async function processComment(
     comment.network ?? "", comment.tileId ?? ""
   ];
   const contentColumns = args.excludeContent ? [] : [comment.content ?? ""];
+  // Group by the CLUE document key so that the several Firestore records that
+  // can share one key (e.g. metadata docs) roll up together; fall back to the
+  // Firestore path for documents with no key.
+  const documentGroupKey = documentData.key || documentSnapshot.ref.path;
   const emitTags = tags.length ? tags : [""];
   for (const tag of emitTags) {
-    rows.push([...baseRow, tag, tagLabels[tag] ?? "", tags.join("|"), ...contentColumns]);
+    pendingRows.push({ baseRow, tag, contentColumns, documentGroupKey, tileId: comment.tileId ?? "" });
     tagRowsEmitted++;
   }
 }
@@ -510,6 +538,31 @@ if (args.documentKeys.length) {
 if (!args.contextIds.length && !args.documentKeys.length) {
   await exportByCommenterUids();
 }
+
+// --- Aggregate tag columns ---
+
+const tileTags: Record<string, Set<string>> = {};
+const documentTags: Record<string, Set<string>> = {};
+const tileKeyOf = (row: IPendingRow) => `${row.documentGroupKey} ${row.tileId}`;
+
+for (const row of pendingRows) {
+  if (!row.tag) continue;  // --include-untagged placeholder
+  (tileTags[tileKeyOf(row)] ??= new Set()).add(row.tag);
+  (documentTags[row.documentGroupKey] ??= new Set()).add(row.tag);
+}
+
+// Sorted rather than first-seen, since Firestore returns comments in no
+// meaningful order; this keeps the column stable across runs.
+const joinTags = (tags: Set<string> | undefined) => tags ? [...tags].sort().join("|") : "";
+
+const rows = pendingRows.map(row => [
+  ...row.baseRow,
+  row.tag,
+  tagLabels[row.tag] ?? "",
+  joinTags(tileTags[tileKeyOf(row)]),
+  joinTags(documentTags[row.documentGroupKey]),
+  ...row.contentColumns
+]);
 
 // --- Output ---
 


### PR DESCRIPTION
[CLUE-549](https://concord-consortium.atlassian.net/browse/CLUE-549)

Replaces the `all_comment_tags` column in the comment/tag export with two aggregate columns, `all_tile_tags` and `all_document_tags`.

The `all_comment_tags` only ever duplicated `tag_id`. That's because CLUE stores exactly one tag per comment — the tagging UI is single-select and the AI tagger writes a one-element array — so a per-comment "all tags" column can never hold more than one value. The useful unit of aggregation is the tile or document, where multiple singly-tagged comments accumulate.

## Changes

- **New columns** `all_tile_tags` and `all_document_tags`: pipe-separated, sorted, de-duplicated unions of the tags applied to each tile / document. The document-level union mirrors the `strategies` field CLUE maintains server-side in `functions-v2/src/on-document-tagged.ts`.
- Rows are now buffered and the aggregates computed in a second pass, since a row's tile/document unions aren't known until every comment has been scanned.
- Documents group by `document_key` (falling back to the Firestore path) so records sharing a key roll up together.
- Header comment expanded to explain the one-tag-per-comment rule and to note that unions cover only the comments included in the export — filtering by date or commenter excludes those comments' tags from the totals, keeping the columns exactly reproducible by grouping the CSV.


[CLUE-549]: https://concord-consortium.atlassian.net/browse/CLUE-549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ