### PR TITLE
CLUE-583: add wideContent layout setting

### DIFF
--- a/src/authoring/components/workspace/nav-tabs.tsx
+++ b/src/authoring/components/workspace/nav-tabs.tsx
@@ -67,7 +67,7 @@ const NavTabs: React.FC = () => {
     return unitConfig?.config?.defaultPanelLayout ?? "split";
   }, [unitConfig]);
   const currentContentLayout = useMemo(() => {
-    return unitConfig?.config?.contentLayout ?? "50-50";
+    return unitConfig?.config?.contentLayout ?? "evenLayout";
   }, [unitConfig]);
   const { handleSubmit, register, formState: { errors } } = useForm<INavTabsInputs>();
 
@@ -80,8 +80,8 @@ const NavTabs: React.FC = () => {
         } else {
           delete draft.config.defaultPanelLayout;
         }
-        // Save content layout (omit if "50-50" since that's the default)
-        if (data.contentLayout && data.contentLayout !== "50-50") {
+        // Save content layout (omit if "evenLayout" since that's the default)
+        if (data.contentLayout && data.contentLayout !== "evenLayout") {
           draft.config.contentLayout = data.contentLayout;
         } else {
           delete draft.config.contentLayout;
@@ -134,7 +134,7 @@ const NavTabs: React.FC = () => {
           {...register("contentLayout")}
           defaultValue={currentContentLayout}
         >
-          <option value="50-50">50 / 50 (even split)</option>
+          <option value="evenLayout">Even split (50 / 50)</option>
           <option value="wideContent">Wide content (narrow resources)</option>
         </select>
       </fieldset>

--- a/src/authoring/components/workspace/nav-tabs.tsx
+++ b/src/authoring/components/workspace/nav-tabs.tsx
@@ -15,6 +15,7 @@ interface FormTab {
 
 interface INavTabsInputs {
   defaultPanelLayout: IUnitConfig["defaultPanelLayout"];
+  contentLayout: IUnitConfig["contentLayout"];
   tabs: FormTab[];
 }
 
@@ -65,6 +66,9 @@ const NavTabs: React.FC = () => {
   const currentPanelLayout = useMemo(() => {
     return unitConfig?.config?.defaultPanelLayout ?? "split";
   }, [unitConfig]);
+  const currentContentLayout = useMemo(() => {
+    return unitConfig?.config?.contentLayout ?? "50-50";
+  }, [unitConfig]);
   const { handleSubmit, register, formState: { errors } } = useForm<INavTabsInputs>();
 
   const onSubmit: SubmitHandler<INavTabsInputs> = (data) => {
@@ -75,6 +79,12 @@ const NavTabs: React.FC = () => {
           draft.config.defaultPanelLayout = data.defaultPanelLayout;
         } else {
           delete draft.config.defaultPanelLayout;
+        }
+        // Save content layout (omit if "50-50" since that's the default)
+        if (data.contentLayout && data.contentLayout !== "50-50") {
+          draft.config.contentLayout = data.contentLayout;
+        } else {
+          delete draft.config.contentLayout;
         }
         formTabs.forEach((tab, index) => {
           const formTab = data.tabs[index];
@@ -114,6 +124,18 @@ const NavTabs: React.FC = () => {
           <option value="split">Split (resources and workspace)</option>
           <option value="workspace-only">Workspace only</option>
           <option value="resources-only">Resources only</option>
+        </select>
+        <p className="muted">
+          Content layout controls how the split view divides its width. &ldquo;Wide content&rdquo; keeps the
+          resources pane at its comments-open width (~1/3) so the workspace stays wide until comments are
+          opened.
+        </p>
+        <select
+          {...register("contentLayout")}
+          defaultValue={currentContentLayout}
+        >
+          <option value="50-50">50 / 50 (even split)</option>
+          <option value="wideContent">Wide content (narrow resources)</option>
         </select>
       </fieldset>
       <table>

--- a/src/authoring/types.ts
+++ b/src/authoring/types.ts
@@ -57,6 +57,9 @@ export interface IUnitConfig extends IItemTemplateConfig {
   sortWorkConfig?: ISortWorkConfig;
   termOverrides?: Record<string, string>;
   defaultPanelLayout?: "split" | "workspace-only" | "resources-only";
+  // "50-50" (default) splits the panes evenly; "wideContent" narrows the resources pane to its
+  // comments-open width so the workspace gets ~2/3 until comments are opened.
+  contentLayout?: "50-50" | "wideContent";
   defaultSharedDocuments?: boolean;
 }
 

--- a/src/authoring/types.ts
+++ b/src/authoring/types.ts
@@ -57,9 +57,9 @@ export interface IUnitConfig extends IItemTemplateConfig {
   sortWorkConfig?: ISortWorkConfig;
   termOverrides?: Record<string, string>;
   defaultPanelLayout?: "split" | "workspace-only" | "resources-only";
-  // "50-50" (default) splits the panes evenly; "wideContent" narrows the resources pane to its
+  // "evenLayout" (default) splits the panes evenly; "wideContent" narrows the resources pane to its
   // comments-open width so the workspace gets ~2/3 until comments are opened.
-  contentLayout?: "50-50" | "wideContent";
+  contentLayout?: "evenLayout" | "wideContent";
   defaultSharedDocuments?: boolean;
 }
 

--- a/src/components/navigation/sort-work-header.test.tsx
+++ b/src/components/navigation/sort-work-header.test.tsx
@@ -2,22 +2,50 @@ import React from "react";
 import { render, screen, within } from "@testing-library/react";
 import { SortWorkHeader } from "./sort-work-header";
 
+// Control the measured header width so we can test the responsive hide of the secondary sort.
+let mockWidth: number | undefined;
+jest.mock("react-resize-detector", () => ({
+  useResizeDetector: () => ({ width: mockWidth, ref: { current: null } }),
+}));
+
 function makeItems(texts: string[], selectedIndex = 0) {
   return texts.map((text, i) => ({ text, selected: i === selectedIndex, onClick: () => undefined }));
 }
 
+function renderHeader() {
+  return render(
+    <SortWorkHeader
+      docFilterItems={makeItems(["Model", "All"])}
+      primarySortItems={makeItems(["Date"])}
+      secondarySortItems={makeItems(["None"])}
+      showContextFilter={true}
+    />
+  );
+}
+
 describe("SortWorkHeader", () => {
+  beforeEach(() => {
+    mockWidth = undefined;
+  });
+
   it("shows the selected filter's (possibly overridden) label, not the raw filter id", () => {
-    render(
-      <SortWorkHeader
-        docFilterItems={makeItems(["Model", "All"])}
-        primarySortItems={makeItems(["Date"])}
-        secondarySortItems={makeItems(["None"])}
-        showContextFilter={true}
-      />
-    );
+    renderHeader();
     const filterTrigger = screen.getByTestId("filter-work-menu-header");
     expect(within(filterTrigger).getByText("Model")).toBeInTheDocument();
     expect(within(filterTrigger).queryByText("Problem")).not.toBeInTheDocument();
+  });
+
+  it("shows the secondary 'then' sort when the header is wide enough", () => {
+    mockWidth = 800;
+    renderHeader();
+    expect(screen.getByText("then")).toBeInTheDocument();
+  });
+
+  it("hides the secondary 'then' sort when the header is too narrow to fit all fields", () => {
+    mockWidth = 400;
+    renderHeader();
+    expect(screen.queryByText("then")).not.toBeInTheDocument();
+    // The filter menu (which was being clipped) is still present.
+    expect(screen.getByTestId("filter-work-menu-header")).toBeInTheDocument();
   });
 });

--- a/src/components/navigation/sort-work-header.tsx
+++ b/src/components/navigation/sort-work-header.tsx
@@ -19,7 +19,7 @@ interface ISortHeaderProps{
 
 export const SortWorkHeader:React.FC<ISortHeaderProps>= observer(function SortWorkView(props){
   const { docFilterItems, primarySortItems, secondarySortItems, showContextFilter = true } = props;
-  const { width, ref } = useResizeDetector();
+  const { width, ref } = useResizeDetector<HTMLDivElement>();
   // Show the secondary sort until we've measured a width that's too narrow to fit all fields.
   const showSecondarySort = width == null || width >= kMinWidthForSecondarySort;
   return (

--- a/src/components/navigation/sort-work-header.tsx
+++ b/src/components/navigation/sort-work-header.tsx
@@ -1,8 +1,14 @@
 import { observer } from "mobx-react";
 import React from "react";
+import { useResizeDetector } from "react-resize-detector";
 import { CustomSelect, ICustomDropdownItem } from "../../clue/components/custom-select";
 
 import "./sort-work-header.scss";
+
+// Below this width the "Sort by / then / Show for" row overflows a narrow resources pane (e.g. the
+// wideContent layout, or any layout with comments open) and clips the filter menu. When the header is
+// narrower than this we drop the secondary "then" sort so the remaining fields fit.
+const kMinWidthForSecondarySort = 620;
 
 interface ISortHeaderProps{
   docFilterItems: ICustomDropdownItem[];
@@ -13,8 +19,11 @@ interface ISortHeaderProps{
 
 export const SortWorkHeader:React.FC<ISortHeaderProps>= observer(function SortWorkView(props){
   const { docFilterItems, primarySortItems, secondarySortItems, showContextFilter = true } = props;
+  const { width, ref } = useResizeDetector();
+  // Show the secondary sort until we've measured a width that's too narrow to fit all fields.
+  const showSecondarySort = width == null || width >= kMinWidthForSecondarySort;
   return (
-    <div className="sort-filter-menu-container">
+    <div className="sort-filter-menu-container" ref={ref}>
       <div className="sort-work-header">
         <div className="header-text">Sort by</div>
         <div className="header-dropdown">
@@ -25,15 +34,19 @@ export const SortWorkHeader:React.FC<ISortHeaderProps>= observer(function SortWo
             showItemChecks={true}
           />
         </div>
-        <div className="header-text secondary">then</div>
-        <div className="header-dropdown">
-          <CustomSelect
-            className="sort-work-sort-menu secondary-sort-menu"
-            dataTest="sort-work-sort-menu"
-            items={secondarySortItems}
-            showItemChecks={true}
-          />
-        </div>
+        {showSecondarySort && (
+          <>
+            <div className="header-text secondary">then</div>
+            <div className="header-dropdown">
+              <CustomSelect
+                className="sort-work-sort-menu secondary-sort-menu"
+                dataTest="sort-work-sort-menu"
+                items={secondarySortItems}
+                showItemChecks={true}
+              />
+            </div>
+          </>
+        )}
       </div>
       {showContextFilter && (
         <div className="filter-work-header">

--- a/src/components/workspace/wide-content-layout.test.ts
+++ b/src/components/workspace/wide-content-layout.test.ts
@@ -15,8 +15,8 @@ describe("shouldNarrowResources", () => {
     expect(shouldNarrowResources(narrowState)).toBe(true);
   });
 
-  it("does not narrow in the default 50-50 layout", () => {
-    expect(shouldNarrowResources({ ...narrowState, contentLayout: "50-50" })).toBe(false);
+  it("does not narrow in the default even layout", () => {
+    expect(shouldNarrowResources({ ...narrowState, contentLayout: "evenLayout" })).toBe(false);
     expect(shouldNarrowResources({ ...narrowState, contentLayout: undefined })).toBe(false);
   });
 

--- a/src/components/workspace/wide-content-layout.test.ts
+++ b/src/components/workspace/wide-content-layout.test.ts
@@ -1,0 +1,36 @@
+import { kDividerHalf, kDividerMin, kDividerMax } from "../../models/stores/ui-types";
+import { IWideContentLayoutState, shouldNarrowResources } from "./wide-content-layout";
+
+// The state that narrows the resources pane: wideContent, both panes shown, divider centered, no comments.
+const narrowState: IWideContentLayoutState = {
+  contentLayout: "wideContent",
+  showLeftPanel: true,
+  showRightPanel: true,
+  dividerPosition: kDividerHalf,
+  showChatPanel: false,
+};
+
+describe("shouldNarrowResources", () => {
+  it("narrows the resources pane in the wideContent layout with both panes shown and comments closed", () => {
+    expect(shouldNarrowResources(narrowState)).toBe(true);
+  });
+
+  it("does not narrow in the default 50-50 layout", () => {
+    expect(shouldNarrowResources({ ...narrowState, contentLayout: "50-50" })).toBe(false);
+    expect(shouldNarrowResources({ ...narrowState, contentLayout: undefined })).toBe(false);
+  });
+
+  it("does not narrow when comments are open (the pane needs its full width for the chat)", () => {
+    expect(shouldNarrowResources({ ...narrowState, showChatPanel: true })).toBe(false);
+  });
+
+  it("does not narrow unless the divider is centered (both panes sharing the split)", () => {
+    expect(shouldNarrowResources({ ...narrowState, dividerPosition: kDividerMin })).toBe(false);
+    expect(shouldNarrowResources({ ...narrowState, dividerPosition: kDividerMax })).toBe(false);
+  });
+
+  it("does not narrow unless both panels are visible", () => {
+    expect(shouldNarrowResources({ ...narrowState, showLeftPanel: false })).toBe(false);
+    expect(shouldNarrowResources({ ...narrowState, showRightPanel: false })).toBe(false);
+  });
+});

--- a/src/components/workspace/wide-content-layout.ts
+++ b/src/components/workspace/wide-content-layout.ts
@@ -2,7 +2,7 @@ import { kDividerHalf } from "../../models/stores/ui-types";
 
 export interface IWideContentLayoutState {
   /** appConfig.contentLayout — "wideContent" opts into the narrow-resources behavior. */
-  contentLayout: "50-50" | "wideContent" | undefined;
+  contentLayout: "evenLayout" | "wideContent" | undefined;
   showLeftPanel: boolean;
   showRightPanel: boolean;
   /** persistentUI.dividerPosition (kDividerMin/Half/Max). */

--- a/src/components/workspace/wide-content-layout.ts
+++ b/src/components/workspace/wide-content-layout.ts
@@ -1,0 +1,26 @@
+import { kDividerHalf } from "../../models/stores/ui-types";
+
+export interface IWideContentLayoutState {
+  /** appConfig.contentLayout — "wideContent" opts into the narrow-resources behavior. */
+  contentLayout: "50-50" | "wideContent" | undefined;
+  showLeftPanel: boolean;
+  showRightPanel: boolean;
+  /** persistentUI.dividerPosition (kDividerMin/Half/Max). */
+  dividerPosition: number;
+  /** persistentUI.showChatPanel — the comments panel. */
+  showChatPanel: boolean;
+}
+
+/**
+ * Whether the resources pane should be narrowed to its comments-open width (giving the workspace ~2/3).
+ * This only applies in the "wideContent" layout while both panes actually share the split (divider
+ * centered) and comments are closed; opening comments — or collapsing either pane — restores the even
+ * 50/50 split so the comments panel has room.
+ */
+export function shouldNarrowResources(state: IWideContentLayoutState): boolean {
+  const { contentLayout, showLeftPanel, showRightPanel, dividerPosition, showChatPanel } = state;
+  return contentLayout === "wideContent"
+    && showLeftPanel && showRightPanel
+    && dividerPosition === kDividerHalf
+    && !showChatPanel;
+}

--- a/src/components/workspace/workspace.scss
+++ b/src/components/workspace/workspace.scss
@@ -23,7 +23,8 @@
   // its comments-open content width (~1/3 — the nav tabs get 64% of the 50% panel once the 36%-wide chat
   // opens) so the workspace gets ~2/3. The class is removed when comments open, restoring the 50/50 split;
   // the panel's existing 0.5s transition animates the change. #resources-panel overrides its flex: 1.
-  &.wide-content-narrow #resources-panel:not(.collapsed) {
+  // (shouldNarrowResources already excludes collapsed states, so no :not(.collapsed) guard is needed.)
+  &.wide-content-narrow #resources-panel {
     flex: 0 0 32%;
   }
 }

--- a/src/components/workspace/workspace.scss
+++ b/src/components/workspace/workspace.scss
@@ -18,4 +18,12 @@
     right: 0;
     bottom: 0;
   }
+
+  // "wideContent" layout: while both panes are shown and comments are closed, hold the resources pane at
+  // its comments-open content width (~1/3 — the nav tabs get 64% of the 50% panel once the 36%-wide chat
+  // opens) so the workspace gets ~2/3. The class is removed when comments open, restoring the 50/50 split;
+  // the panel's existing 0.5s transition animates the change. #resources-panel overrides its flex: 1.
+  &.wide-content-narrow #resources-panel:not(.collapsed) {
+    flex: 0 0 32%;
+  }
 }

--- a/src/components/workspace/workspace.tsx
+++ b/src/components/workspace/workspace.tsx
@@ -1,8 +1,10 @@
 import { observer } from "mobx-react";
+import classNames from "classnames";
 import React, { useCallback, useEffect, useRef } from "react";
 import { IBaseProps } from "../base";
 import { useStores } from "../../hooks/use-stores";
 import { usePanelVisibility } from "../../hooks/use-panel-visibility";
+import { shouldNarrowResources } from "./wide-content-layout";
 import { DocumentWorkspaceComponent } from "../document/document-workspace";
 import { ImageDragDrop } from "../utilities/image-drag-drop";
 import { NavTabPanel } from "../navigation/nav-tab-panel";
@@ -20,7 +22,8 @@ interface IProps extends IBaseProps {
 
 export const WorkspaceComponent: React.FC<IProps> = observer((props) => {
   const stores = useStores();
-  const { persistentUI: { navTabContentShown, workspaceShown },
+  const { persistentUI: { navTabContentShown, workspaceShown, dividerPosition, showChatPanel },
+          appConfig,
           exemplarController,
           problem,
           ui: { standalone }
@@ -28,6 +31,13 @@ export const WorkspaceComponent: React.FC<IProps> = observer((props) => {
   const hotKeys = useRef(new HotKeys());
   const saveIndicatorPortalRef = useRef<HTMLDivElement>(null);
   const { showLeftPanel, showRightPanel } = usePanelVisibility();
+  const wideContentActive = shouldNarrowResources({
+    contentLayout: appConfig.contentLayout,
+    showLeftPanel,
+    showRightPanel,
+    dividerPosition,
+    showChatPanel,
+  });
   const ariaLabels = getAriaLabels();
   const problemTitle = stores.isProblemLoaded
     ? problem.title + (problem.subtitle ? `: ${problem.subtitle}` : "")
@@ -53,7 +63,7 @@ export const WorkspaceComponent: React.FC<IProps> = observer((props) => {
 
   return (
     <main
-      className="workspace"
+      className={classNames("workspace", { "wide-content-narrow": wideContentActive })}
       onKeyDown={(e) => hotKeys.current.dispatch(e)}>
       {problemTitle && <h1 className="visually-hidden">{problemTitle}</h1>}
       <div

--- a/src/models/stores/app-config-model.test.ts
+++ b/src/models/stores/app-config-model.test.ts
@@ -179,6 +179,26 @@ describe("ConfigurationManager", () => {
     });
   });
 
+  describe("contentLayout", () => {
+    it("should return undefined when not configured", () => {
+      const appConfig = AppConfigModel.create({ config: unitConfigDefaults });
+      expect(appConfig.contentLayout).toBeUndefined();
+    });
+
+    it("should return the configured value", () => {
+      const appConfig = AppConfigModel.create({
+        config: { ...unitConfigDefaults, contentLayout: "wideContent" }
+      });
+      expect(appConfig.contentLayout).toBe("wideContent");
+    });
+
+    it("should cascade from override configs", () => {
+      const appConfig = AppConfigModel.create({ config: unitConfigDefaults });
+      appConfig.setConfigs([{ contentLayout: "wideContent" }]);
+      expect(appConfig.contentLayout).toBe("wideContent");
+    });
+  });
+
   describe("chatTutorPrompts", () => {
     it("should return undefined when not configured", () => {
       const appConfig = AppConfigModel.create({ config: unitConfigDefaults });

--- a/src/models/stores/app-config-model.ts
+++ b/src/models/stores/app-config-model.ts
@@ -110,6 +110,7 @@ export const AppConfigModel = types
     get sortWorkConfig() { return self.configMgr.sortWorkConfig; },
     get termOverrides() { return self.configMgr.termOverrides; },
     get defaultPanelLayout() { return self.configMgr.defaultPanelLayout; },
+    get contentLayout() { return self.configMgr.contentLayout; },
     get defaultSharedDocuments() { return self.configMgr.defaultSharedDocuments; },
     get authorToolbar() {
       return ToolbarModel.create([

--- a/src/models/stores/configuration-manager.ts
+++ b/src/models/stores/configuration-manager.ts
@@ -243,6 +243,10 @@ export class ConfigurationManager implements UnitConfiguration {
     return this.getProp<UC["defaultPanelLayout"]>("defaultPanelLayout");
   }
 
+  get contentLayout() {
+    return this.getProp<UC["contentLayout"]>("contentLayout");
+  }
+
   get defaultSharedDocuments() {
     return this.getProp<UC["defaultSharedDocuments"]>("defaultSharedDocuments");
   }

--- a/src/models/stores/problem-configuration.ts
+++ b/src/models/stores/problem-configuration.ts
@@ -35,8 +35,8 @@ export interface ProblemConfiguration {
   // default panel layout when user first visits a problem
   // "split" (default) shows both panels; "workspace-only" collapses resources; "resources-only" collapses workspace
   defaultPanelLayout?: "split" | "workspace-only" | "resources-only";
-  // how the resources and workspace panes divide the split view. "50-50" (default) splits evenly.
+  // how the resources and workspace panes divide the split view. "evenLayout" (default) splits evenly.
   // "wideContent" narrows the resources pane to its comments-open width (~1/3) when both panes are shown
   // and comments are closed, giving the workspace ~2/3; opening comments expands it back to the even split.
-  contentLayout?: "50-50" | "wideContent";
+  contentLayout?: "evenLayout" | "wideContent";
 }

--- a/src/models/stores/problem-configuration.ts
+++ b/src/models/stores/problem-configuration.ts
@@ -35,4 +35,8 @@ export interface ProblemConfiguration {
   // default panel layout when user first visits a problem
   // "split" (default) shows both panels; "workspace-only" collapses resources; "resources-only" collapses workspace
   defaultPanelLayout?: "split" | "workspace-only" | "resources-only";
+  // how the resources and workspace panes divide the split view. "50-50" (default) splits evenly.
+  // "wideContent" narrows the resources pane to its comments-open width (~1/3) when both panes are shown
+  // and comments are closed, giving the workspace ~2/3; opening comments expands it back to the even split.
+  contentLayout?: "50-50" | "wideContent";
 }


### PR DESCRIPTION
Add an optional per-unit "content layout" that widens the workspace for content-heavy units (e.g. Hurricane Explorer).

- New config `contentLayout: "50-50" | "wideContent"` (default "50-50"), authored in the nav-tabs Panel Layout fieldset and plumbed through problem-configuration, configuration-manager, and app-config-model (mirrors defaultPanelLayout).
- In "wideContent", while both panes share the split and comments are closed, the resources pane is held at its comments-open width (~1/3, flex: 0 0 32%) so the workspace gets ~2/3; opening comments (or collapsing a pane) restores the even 50/50 split. The narrowing predicate is extracted to shouldNarrowResources and unit-tested.
- Sort Work header: hide the secondary "then" sort when the header is too narrow to fit all fields (any layout), so the filter menu no longer clips in the narrow resources pane. Measured with useResizeDetector; hides the control but preserves the stored sort selection.