### PR TITLE
CLUE-588: reconcile firestore.indexes.json with deployed production indexes

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -15,6 +15,20 @@
       ]
     },
     {
+      "collectionGroup": "documents",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "unit",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "type",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
       "collectionGroup": "messages",
       "queryScope": "COLLECTION",
       "fields": [
@@ -27,6 +41,43 @@
           "order": "ASCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "summaries",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "context_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "investigation",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "problem",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "unit",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "key",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "numAiAgreements",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "summaryEmbedding",
+          "vectorConfig": {
+            "dimension": 1536,
+            "flat": {}
+          }
+        }
+      ]
     }
   ],
   "fieldOverrides": [
@@ -36,6 +87,7 @@
       "indexes": [
         { "order": "ASCENDING", "queryScope": "COLLECTION" },
         { "order": "DESCENDING", "queryScope": "COLLECTION" },
+        { "arrayConfig": "CONTAINS", "queryScope": "COLLECTION" },
         { "order": "ASCENDING", "queryScope": "COLLECTION_GROUP" }
       ]
     }


### PR DESCRIPTION
## Summary

The repo's `firestore.indexes.json` had drifted from what is actually deployed to the **production** Firestore project (`collaborative-learning-ec215`). Several indexes/field-overrides existed in production but were missing from the file, so deploying the file as-is would have attempted to **delete** live production indexes (including the `summaries` vector index).

This makes the file a **superset of production**: everything production has, plus the `messages` index that was added to `firestore.indexes.json` as part of an earlier PR. We needed to deploy this `messages` index to production, so we made this superset to do so. 

This `firestore.indexes.json` has already been deployed to production as part of 7.3.0 release.

## Changes

Adds back the three production-only entries that were missing from the file:

- `documents` index (unit, type): I added this so I could track down which types have units and which types don't.
- `summaries` index (context_id, investigation, problem, unit, key, numAiAgreements + `summaryEmbedding` vector 1536) : I'm pretty sure these are for the AI summary support.
- the `arrayConfig: CONTAINS` entry on the `comments/uid` field override : I think this might have been added to support the comment tags report. I think this allows finding all comments by list of authors.

The existing `docs` and `messages` indexes are unchanged.

## Deploy process

```
firebase deploy --only firestore:indexes --project production
```

## Notes

There are more indexes on staging. We did not include them here. They seem to be experimental. There are a `summaries` vector-only (1536 / 2048) indexes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)