### PR TITLE
CLUE-589: enable custom comment tags on QA unit

### DIFF
--- a/src/public/demo/units/qa/content.json
+++ b/src/public/demo/units/qa/content.json
@@ -119,6 +119,7 @@
     "tools": ["Simulator", "Timeline"],
     "enableCommentRoles": ["student", "teacher", "researcher"],
     "showCommentTag": true,
+    "allowCustomCommentTags": true,
     "termOverrides": {
       "strategy": "Select QA Strategy"
     },


### PR DESCRIPTION
Enables the teacher-created custom comment tags feature on the QA demo unit so it can be exercised in testing.

## What changed

Added `"allowCustomCommentTags": true` to `src/public/demo/units/qa/content.json`. The QA unit already sets `showCommentTag: true` and defines `commentTags`, so this is the one flag needed to turn on teacher-added custom tags.

## Why

Teachers can add their own comment tags only when a unit sets both `showCommentTag` and `allowCustomCommentTags` (the latter defaults to `false` so legacy units are unaffected). No bundled unit set `allowCustomCommentTags`, so the feature could not be tested from any unit.

Gating logic: `src/components/document/sort-work-add-tag.tsx` — `canAdd = showCommentTag && allowCustomCommentTags && user.isTeacher`.

## Testing

Log in as a teacher against the QA unit and confirm a custom tag can be added and that it merges with the config `commentTags`. Custom tags are stored per class + unit in Firestore at `commentTags/{classHash}/units/{unit}/tags`.

Jira: CLUE-589

🤖 Generated with [Claude Code](https://claude.com/claude-code)