### PR TITLE
Download Raw Seismic Data Without Availability Confirmation

### DIFF
--- a/shared/seismic/earthscope-client.test.ts
+++ b/shared/seismic/earthscope-client.test.ts
@@ -141,6 +141,39 @@ AK K204 -- HNZ M 100.0 2026-02-03T00:00:00.000000Z 2026-02-04T00:00:00.000000Z`;
     ]);
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+  it("falls back to the full requested range when the proxy endpoint fails (e.g. 410 Gone)", async () => {
+    setUrl("http://localhost/?seismicProxy");
+    fetchMock.mockResponseOnce("Gone", { status: 410, statusText: "Gone" });
+
+    const ranges = await fetchAvailability({ ...stationTimeRange, endTime: "2026-02-05T00:00:00.000Z" });
+
+    expect(ranges).toEqual([
+      { start: utcDay(2026, 1, 30), end: utcDay(2026, 2, 5) },
+    ]);
+  });
+
+  it("falls back to the full requested range when the proxy request throws (network error)", async () => {
+    setUrl("http://localhost/?seismicProxy");
+    fetchMock.mockRejectOnce(new Error("network down"));
+
+    const ranges = await fetchAvailability({ ...stationTimeRange, endTime: "2026-02-05T00:00:00.000Z" });
+
+    expect(ranges).toEqual([
+      { start: utcDay(2026, 1, 30), end: utcDay(2026, 2, 5) },
+    ]);
+  });
+
+  it("propagates aborts instead of falling back", async () => {
+    setUrl("http://localhost/?seismicProxy");
+    const controller = new AbortController();
+    controller.abort();
+    fetchMock.mockRejectOnce(new DOMException("aborted", "AbortError"));
+
+    await expect(
+      fetchAvailability(stationTimeRange, { signal: controller.signal })
+    ).rejects.toThrow();
+  });
 });
 
 describe("fetch config override", () => {

--- a/shared/seismic/earthscope-client.ts
+++ b/shared/seismic/earthscope-client.ts
@@ -220,42 +220,54 @@ const AVAILABILITY_PATH = "/earthscope/cached/availability/1/query";
  * Mock/local mode: the availability service is not mocked, so we assume the
  * entire requested range is available (one range). Callers then attempt every
  * day; the mock dataselect returns "no data" for days it doesn't cover.
+ *
+ * Availability is only an optimization to skip empty days, so a failed lookup
+ * (network error, or a retired endpoint returning e.g. 410 Gone) must not abort
+ * the whole download: it degrades to the same full-range assumption as mock mode.
+ * Aborts still propagate — a cancelled download should stop, not press on.
  */
 export async function fetchAvailability(
   query: StationQuery,
   options?: EarthscopeOptions
 ): Promise<TimeRange[]> {
   const { network, station, location, channel, startTime, endTime } = query;
+  const fullRange = (): TimeRange[] => [{
+    start: new Date(startTime).getTime() / 1000,
+    end: new Date(endTime).getTime() / 1000,
+  }];
   const proxy = options?.proxy ?? isProxyEnabled();
   if (!proxy) {
-    return [{
-      start: new Date(startTime).getTime() / 1000,
-      end: new Date(endTime).getTime() / 1000,
-    }];
+    return fullRange();
   }
   const base = options?.baseUrl ?? CLOUDFRONT_PROXY_URL;
   const params = new URLSearchParams({
     net: network, sta: station, cha: channel, loc: location || "--",
     start: startTime, end: endTime, format: "text",
   });
-  const response = await fetch(`${base}${AVAILABILITY_PATH}?${params}`, { signal: options?.signal });
-  if (!response.ok) {
-    throw new Error(`availability ${response.status}: ${response.statusText}`);
-  }
-
-  // Parse the whitespace-delimited FDSN availability text into [start, end) ranges.
-  // Columns: Network Station Location Channel Quality SampleRate Earliest Latest
-  const text = await response.text();
-  const ranges: TimeRange[] = [];
-  for (const line of text.trim().split("\n")) {
-    if (!line || line.startsWith("#")) continue;
-    const fields = line.trim().split(/\s+/);
-    if (fields.length < 8) continue;
-    const start = new Date(fields[6]).getTime() / 1000;
-    const end = new Date(fields[7]).getTime() / 1000;
-    if (Number.isFinite(start) && Number.isFinite(end) && end > start) {
-      ranges.push({ start, end });
+  try {
+    const response = await fetch(`${base}${AVAILABILITY_PATH}?${params}`, { signal: options?.signal });
+    if (!response.ok) {
+      throw new Error(`availability ${response.status}: ${response.statusText}`);
     }
+
+    // Parse the whitespace-delimited FDSN availability text into [start, end) ranges.
+    // Columns: Network Station Location Channel Quality SampleRate Earliest Latest
+    const text = await response.text();
+    const ranges: TimeRange[] = [];
+    for (const line of text.trim().split("\n")) {
+      if (!line || line.startsWith("#")) continue;
+      const fields = line.trim().split(/\s+/);
+      if (fields.length < 8) continue;
+      const start = new Date(fields[6]).getTime() / 1000;
+      const end = new Date(fields[7]).getTime() / 1000;
+      if (Number.isFinite(start) && Number.isFinite(end) && end > start) {
+        ranges.push({ start, end });
+      }
+    }
+    return ranges;
+  } catch (err) {
+    if (options?.signal?.aborted) throw err;
+    console.warn("Availability lookup failed; assuming the full requested range is available.", err);
+    return fullRange();
   }
-  return ranges;
 }

--- a/shared/seismic/seismic-downloader.test.ts
+++ b/shared/seismic/seismic-downloader.test.ts
@@ -94,6 +94,28 @@ describe("downloadRange", () => {
     expect(fetchRaw).toHaveBeenCalledTimes(3); // not the 31st
   });
 
+  it("emits dayEmpty and does not cache a day whose fetch returns no data (0 bytes)", async () => {
+    const d31 = dayIndex(utcDay(2026, 1, 31));
+    // The 31st has no waveform data: dataselect answers 204, so fetchRaw yields 0 bytes.
+    const fetchRaw = jest.fn(async (q: any) =>
+      new Date(q.startTime).getTime() / 1000 === utcDay(2026, 1, 31)
+        ? new ArrayBuffer(0)
+        : new ArrayBuffer(1));
+    const writeDayChunk = jest.fn(async () => {});
+    const deps = makeDeps({
+      fetchRaw,
+      cache: { scanCachedDays: async () => new Set<number>(), writeDayChunk },
+    });
+    const { events, onEvent } = collect();
+    await downloadRange(deps, RANGE, onEvent);
+
+    // Reported empty, never written, and never counted as a written day.
+    expect(events.some(e => e.type === "dayEmpty" && (e as any).day === d31)).toBe(true);
+    expect(events.some(e => e.type === "dayWritten" && (e as any).day === d31)).toBe(false);
+    expect(writeDayChunk).not.toHaveBeenCalledWith(expect.anything(), d31, expect.anything());
+    expect(events.at(-1)).toEqual({ type: "done" });
+  });
+
   it("fetches the final day when the range ends on it (availability window must cover the whole day)", async () => {
     // Mimic the real endpoint: it only reports availability within the requested window.
     const dataStart = utcDay(2026, 1, 30), dataEnd = utcDay(2026, 2, 3); // station has data through Feb 2

--- a/shared/seismic/seismic-downloader.ts
+++ b/shared/seismic/seismic-downloader.ts
@@ -117,6 +117,12 @@ export async function downloadRange(
           const data = await deps.fetchRaw(
             { ...stationData, startTime: dStart, endTime: dEnd }, params.signal
           );
+          // A 204/empty response means the station has no data for this day. Don't cache a
+          // 0-byte chunk — it would masquerade as a present day and break models that read it.
+          if (data.byteLength === 0) {
+            onEvent({ type: "dayEmpty", day });
+            return;
+          }
           await deps.cache.writeDayChunk(stationData, day, data);
           completed++;
           onEvent({ type: "dayWritten", day, bytes: data.byteLength });

--- a/shared/seismic/seismic-downloader.ts
+++ b/shared/seismic/seismic-downloader.ts
@@ -120,7 +120,9 @@ export async function downloadRange(
           // A 204/empty response means the station has no data for this day. Don't cache a
           // 0-byte chunk — it would masquerade as a present day and break models that read it.
           if (data.byteLength === 0) {
+            completed++;
             onEvent({ type: "dayEmpty", day });
+            emitProgress();
             return;
           }
           await deps.cache.writeDayChunk(stationData, day, data);


### PR DESCRIPTION
CLUE-605

This PR is a quick fix to accommodate the earthscope availability service being pulled without warning.
- When the availability check returns 410, we just assume all of the time range is available.
- We now report days with 0 bytes as empty days. Previously, the availability service would have told us a day like that was not available and we wouldn't have even tried downloading it.