### PR TITLE
CLUE-594: Author unit switch to turn on AI chat

### DIFF
--- a/shared/chat-tutor-default-intro.ts
+++ b/shared/chat-tutor-default-intro.ts
@@ -1,0 +1,4 @@
+// Default intro message shown at the top of the AI chat tutor column. It is display-only — it is
+// never sent to the model as context. Units may override it via config.chatTutorIntro.
+export const CHAT_TUTOR_DEFAULT_INTRO =
+  "Hi. I'm Ada Idea. I can see the work in your workspace and help you think it through.";

--- a/shared/chat-tutor-generic-prompt.ts
+++ b/shared/chat-tutor-generic-prompt.ts
@@ -15,7 +15,7 @@
 export const CHAT_GENERIC_PROMPT = `You are a warm, patient science tutor built into CLUE, a collaborative document \
 environment where a student (usually middle- or high-school age) works through a science problem by building their \
 own document out of tiles. Help them reason about their work and think it through themselves — guide their thinking, \
-don't do it for them.
+don't do it for them. Your name is Ada Idea; if a student asks what to call you, tell them Ada Idea.
 
 ## What you can see
 - THE PROBLEM: the authored curriculum the student is working through (their assignment), given once below. It is \

--- a/specs/CLUE-566-ai-chat-tutor.md
+++ b/specs/CLUE-566-ai-chat-tutor.md
@@ -25,6 +25,9 @@ interface, testable with both uncommitted draft config (authoring preview) and c
 - App-header launcher button, shown only when the `chatTutor` URL param is on, the user is a
   student, and a workspace document is open **with its content loaded** (a restored
   `primaryDocumentKey` does not imply loaded content; `documentSummarizer(undefined)` throws).
+  *(Superseded by CLUE-594: the launcher is now a floating round "AIdeas" button at the workspace's
+  lower-right — not in the header — and is enabled per-unit via `config.chatTutorEnabled` in addition
+  to the `chatTutor` URL param; a configurable render-only intro was also added.)*
 - Right-edge drawer under a new `src/components/chat-tutor/` directory (distinct from CLUE's
   existing `src/components/chat/` comment panel), restyled to CLUE's design system with
   WCAG-AA-verified contrast. *(Post-implementation change: the drawer is inline, not overlaying —
@@ -237,6 +240,9 @@ conversation (reverting to a prior prompt resumes that version's old conversatio
 
 **Decision**: **B — the `chatTutor` URL param.** A spike gate; per-unit config is a production
 concern. (Renamed from AP's `?chat` to avoid the existing chat-panel collision.)
+*(Superseded by CLUE-594: option A was implemented — a `chatTutorEnabled` `UnitConfiguration` boolean
+surfaced through `AppConfigModel`, with an authoring checkbox. The `chatTutor` URL param is retained as
+an author-preview override, so the gate is now `chatTutorEnabled || urlParams.chatTutor`.)*
 
 ---
 

--- a/src/authoring/components/workspace/chat-tutor-settings.test.tsx
+++ b/src/authoring/components/workspace/chat-tutor-settings.test.tsx
@@ -5,11 +5,14 @@ import React from "react";
 import ChatTutorSettings from "./chat-tutor-settings";
 import { IChatTutorPrompts } from "../../types";
 import { CHAT_GENERIC_PROMPT } from "../../../../shared/chat-tutor-generic-prompt";
+import { CHAT_TUTOR_DEFAULT_INTRO } from "../../../../shared/chat-tutor-default-intro";
 
 const mockSetUnitConfig = jest.fn();
 
 const mockConfig = {
-  chatTutorPrompts: undefined as IChatTutorPrompts | undefined
+  chatTutorPrompts: undefined as IChatTutorPrompts | undefined,
+  chatTutorEnabled: undefined as boolean | undefined,
+  chatTutorIntro: undefined as string | undefined
 };
 
 const mockCurriculumValue = {
@@ -22,10 +25,13 @@ jest.mock("../../hooks/use-curriculum", () => ({
   useCurriculum: () => mockCurriculumValue
 }));
 
-// Runs the updater passed to setUnitConfig against a mock draft and returns it.
-const applyLastUpdater = (chatTutorPrompts?: IChatTutorPrompts) => {
+// Runs the updater passed to setUnitConfig against a mock draft (seeded with the given pre-existing
+// config) and returns it.
+const applyLastUpdater = (chatTutorPrompts?: IChatTutorPrompts, chatTutorEnabled?: boolean) => {
   const updaterFn = mockSetUnitConfig.mock.calls[0][0];
-  const mockDraft = { config: { chatTutorPrompts } };
+  const mockDraft: {
+    config: { chatTutorPrompts?: IChatTutorPrompts; chatTutorEnabled?: boolean; chatTutorIntro?: string };
+  } = { config: { chatTutorPrompts, chatTutorEnabled } };
   updaterFn(mockDraft);
   return mockDraft;
 };
@@ -34,6 +40,8 @@ describe("ChatTutorSettings", () => {
   beforeEach(() => {
     mockSetUnitConfig.mockClear();
     mockConfig.chatTutorPrompts = undefined;
+    mockConfig.chatTutorEnabled = undefined;
+    mockConfig.chatTutorIntro = undefined;
     mockCurriculumValue.saveState = undefined;
   });
 
@@ -100,5 +108,62 @@ describe("ChatTutorSettings", () => {
     await waitFor(() => expect(mockSetUnitConfig).toHaveBeenCalled());
     const mockDraft = applyLastUpdater({ replaceGenericPrompt: "old" });
     expect(mockDraft.config.chatTutorPrompts).toBeUndefined();
+  });
+
+  it("loads the enabled state into the checkbox", () => {
+    mockConfig.chatTutorEnabled = true;
+    render(<ChatTutorSettings />);
+    expect(screen.getByRole("checkbox")).toBeChecked();
+  });
+
+  it("enables the tutor on save, independent of the prompts", async () => {
+    const user = userEvent.setup();
+    render(<ChatTutorSettings />);
+
+    await user.click(screen.getByRole("checkbox"));
+    fireEvent.click(screen.getByRole("button", { name: /Save/i }));
+
+    await waitFor(() => expect(mockSetUnitConfig).toHaveBeenCalled());
+    const mockDraft = applyLastUpdater();
+    expect(mockDraft.config.chatTutorEnabled).toBe(true);
+  });
+
+  it("seeds the intro with the default and saves a customization", async () => {
+    const user = userEvent.setup();
+    render(<ChatTutorSettings />);
+
+    const intro = screen.getByLabelText("Chat intro message") as HTMLTextAreaElement;
+    expect(intro.value).toBe(CHAT_TUTOR_DEFAULT_INTRO);
+    await user.clear(intro);
+    await user.type(intro, "Hi. I'm Ada Idea. Let's plan your circuit.");
+    fireEvent.click(screen.getByRole("button", { name: /Save/i }));
+
+    await waitFor(() => expect(mockSetUnitConfig).toHaveBeenCalled());
+    const mockDraft = applyLastUpdater();
+    expect(mockDraft.config.chatTutorIntro).toBe("Hi. I'm Ada Idea. Let's plan your circuit.");
+  });
+
+  it("does not store the intro when left at the default", async () => {
+    render(<ChatTutorSettings />);
+    fireEvent.click(screen.getByRole("button", { name: /Save/i }));
+
+    await waitFor(() => expect(mockSetUnitConfig).toHaveBeenCalled());
+    const mockDraft = applyLastUpdater(undefined, undefined);
+    expect(mockDraft.config.chatTutorIntro).toBeUndefined();
+  });
+
+  it("disabling the tutor preserves existing prompts", async () => {
+    mockConfig.chatTutorEnabled = true;
+    mockConfig.chatTutorPrompts = { appendToGenericPrompt: "Focus on energy." };
+    const user = userEvent.setup();
+    render(<ChatTutorSettings />);
+
+    await user.click(screen.getByRole("checkbox")); // was checked; toggle off
+    fireEvent.click(screen.getByRole("button", { name: /Save/i }));
+
+    await waitFor(() => expect(mockSetUnitConfig).toHaveBeenCalled());
+    const mockDraft = applyLastUpdater({ appendToGenericPrompt: "Focus on energy." }, true);
+    expect(mockDraft.config.chatTutorEnabled).toBeUndefined();
+    expect(mockDraft.config.chatTutorPrompts).toEqual({ appendToGenericPrompt: "Focus on energy." });
   });
 });

--- a/src/authoring/components/workspace/chat-tutor-settings.test.tsx
+++ b/src/authoring/components/workspace/chat-tutor-settings.test.tsx
@@ -27,11 +27,13 @@ jest.mock("../../hooks/use-curriculum", () => ({
 
 // Runs the updater passed to setUnitConfig against a mock draft (seeded with the given pre-existing
 // config) and returns it.
-const applyLastUpdater = (chatTutorPrompts?: IChatTutorPrompts, chatTutorEnabled?: boolean) => {
+const applyLastUpdater = (
+  chatTutorPrompts?: IChatTutorPrompts, chatTutorEnabled?: boolean, chatTutorIntro?: string
+) => {
   const updaterFn = mockSetUnitConfig.mock.calls[0][0];
   const mockDraft: {
     config: { chatTutorPrompts?: IChatTutorPrompts; chatTutorEnabled?: boolean; chatTutorIntro?: string };
-  } = { config: { chatTutorPrompts, chatTutorEnabled } };
+  } = { config: { chatTutorPrompts, chatTutorEnabled, chatTutorIntro } };
   updaterFn(mockDraft);
   return mockDraft;
 };
@@ -143,16 +145,36 @@ describe("ChatTutorSettings", () => {
     expect(mockDraft.config.chatTutorIntro).toBe("Hi. I'm Ada Idea. Let's plan your circuit.");
   });
 
-  it("does not store the intro when left at the default", async () => {
+  it("loads a custom intro and removes the override when reset to the default", async () => {
+    mockConfig.chatTutorIntro = "Custom greeting.";
+    const user = userEvent.setup();
     render(<ChatTutorSettings />);
+
+    const intro = screen.getByLabelText("Chat intro message") as HTMLTextAreaElement;
+    expect(intro.value).toBe("Custom greeting."); // load path
+    await user.clear(intro);
+    await user.type(intro, CHAT_TUTOR_DEFAULT_INTRO);
     fireEvent.click(screen.getByRole("button", { name: /Save/i }));
 
     await waitFor(() => expect(mockSetUnitConfig).toHaveBeenCalled());
-    const mockDraft = applyLastUpdater(undefined, undefined);
+    // Seed the draft with the existing custom intro so the delete is observable.
+    const mockDraft = applyLastUpdater(undefined, undefined, "Custom greeting.");
     expect(mockDraft.config.chatTutorIntro).toBeUndefined();
   });
 
-  it("disabling the tutor preserves existing prompts", async () => {
+  it("stores an empty string when the intro is cleared (suppresses it)", async () => {
+    const user = userEvent.setup();
+    render(<ChatTutorSettings />);
+
+    await user.clear(screen.getByLabelText("Chat intro message"));
+    fireEvent.click(screen.getByRole("button", { name: /Save/i }));
+
+    await waitFor(() => expect(mockSetUnitConfig).toHaveBeenCalled());
+    const mockDraft = applyLastUpdater();
+    expect(mockDraft.config.chatTutorIntro).toBe("");
+  });
+
+  it("disabling the tutor writes false (so it overrides a higher-level true) and keeps prompts", async () => {
     mockConfig.chatTutorEnabled = true;
     mockConfig.chatTutorPrompts = { appendToGenericPrompt: "Focus on energy." };
     const user = userEvent.setup();
@@ -163,7 +185,7 @@ describe("ChatTutorSettings", () => {
 
     await waitFor(() => expect(mockSetUnitConfig).toHaveBeenCalled());
     const mockDraft = applyLastUpdater({ appendToGenericPrompt: "Focus on energy." }, true);
-    expect(mockDraft.config.chatTutorEnabled).toBeUndefined();
+    expect(mockDraft.config.chatTutorEnabled).toBe(false);
     expect(mockDraft.config.chatTutorPrompts).toEqual({ appendToGenericPrompt: "Focus on energy." });
   });
 });

--- a/src/authoring/components/workspace/chat-tutor-settings.tsx
+++ b/src/authoring/components/workspace/chat-tutor-settings.tsx
@@ -1,9 +1,12 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useForm, SubmitHandler } from "react-hook-form";
 import { CHAT_GENERIC_PROMPT } from "../../../../shared/chat-tutor-generic-prompt";
+import { CHAT_TUTOR_DEFAULT_INTRO } from "../../../../shared/chat-tutor-default-intro";
 import { useCurriculum } from "../../hooks/use-curriculum";
 
 interface ChatTutorSettingsFormInputs {
+  chatTutorEnabled: boolean;
+  chatTutorIntro: string;
   replaceGenericPrompt: string;
   appendToGenericPrompt: string;
 }
@@ -26,8 +29,11 @@ const ChatTutorSettings: React.FC = () => {
   };
 
   const formDefaults: ChatTutorSettingsFormInputs = useMemo(() => {
-    const chatTutorPrompts = unitConfig?.config?.chatTutorPrompts;
+    const config = unitConfig?.config;
+    const chatTutorPrompts = config?.chatTutorPrompts;
     return {
+      chatTutorEnabled: config?.chatTutorEnabled ?? false,
+      chatTutorIntro: config?.chatTutorIntro ?? CHAT_TUTOR_DEFAULT_INTRO,
       replaceGenericPrompt: chatTutorPrompts?.replaceGenericPrompt ?? "",
       appendToGenericPrompt: chatTutorPrompts?.appendToGenericPrompt ?? "",
     };
@@ -44,8 +50,18 @@ const ChatTutorSettings: React.FC = () => {
   const onSubmit: SubmitHandler<ChatTutorSettingsFormInputs> = (data) => {
     const replaceGenericPrompt = data.replaceGenericPrompt.trim();
     const appendToGenericPrompt = data.appendToGenericPrompt.trim();
+    const chatTutorIntro = data.chatTutorIntro.trim();
     setUnitConfig(draft => {
       if (!draft) return;
+      // The enable flag is independent of the prompt overrides — toggling it never discards prompts.
+      if (data.chatTutorEnabled) draft.config.chatTutorEnabled = true;
+      else delete draft.config.chatTutorEnabled;
+      // Store the intro only when it's a non-empty customization; otherwise fall back to the default.
+      if (chatTutorIntro && chatTutorIntro !== CHAT_TUTOR_DEFAULT_INTRO) {
+        draft.config.chatTutorIntro = chatTutorIntro;
+      } else {
+        delete draft.config.chatTutorIntro;
+      }
       if (!replaceGenericPrompt && !appendToGenericPrompt) {
         delete draft.config.chatTutorPrompts;
         return;
@@ -68,6 +84,26 @@ const ChatTutorSettings: React.FC = () => {
         the <code>chatTutor</code> parameter to this authoring page&apos;s URL before
         opening a student preview (preview links inherit it).
       </p>
+
+      <fieldset className="enableChatTutor">
+        <label>
+          <input type="checkbox" {...register("chatTutorEnabled")} />
+          Enable the AI chat tutor for students in this unit
+        </label>
+        <p className="muted small">
+          When off, the prompt overrides below are still kept, and the <code>chatTutor</code> URL
+          param can be used to preview the tutor.
+        </p>
+      </fieldset>
+
+      <fieldset className="chatTutorIntro">
+        <label htmlFor="chatTutorIntro">Chat intro message</label>
+        <textarea id="chatTutorIntro" rows={4} {...register("chatTutorIntro")} />
+        <p className="muted small">
+          Shown at the top of the chat column when a student opens the tutor. It is display-only —
+          never sent to the AI as context. Leave it as the default to use the built-in greeting.
+        </p>
+      </fieldset>
 
       <details className="builtInPrompt">
         <summary>View built-in tutor prompt</summary>

--- a/src/authoring/components/workspace/chat-tutor-settings.tsx
+++ b/src/authoring/components/workspace/chat-tutor-settings.tsx
@@ -53,14 +53,17 @@ const ChatTutorSettings: React.FC = () => {
     const chatTutorIntro = data.chatTutorIntro.trim();
     setUnitConfig(draft => {
       if (!draft) return;
-      // The enable flag is independent of the prompt overrides — toggling it never discards prompts.
-      if (data.chatTutorEnabled) draft.config.chatTutorEnabled = true;
-      else delete draft.config.chatTutorEnabled;
-      // Store the intro only when it's a non-empty customization; otherwise fall back to the default.
-      if (chatTutorIntro && chatTutorIntro !== CHAT_TUTOR_DEFAULT_INTRO) {
-        draft.config.chatTutorIntro = chatTutorIntro;
-      } else {
+      // Write the enable flag explicitly (rather than deleting on uncheck): config merges bottom-up
+      // and take the first non-null value (problem → investigation → unit → defaults), so a stored
+      // `false` correctly overrides a `true` set at a higher level, whereas a deleted key would let
+      // that higher-level `true` win. Independent of the prompt overrides — toggling never discards them.
+      draft.config.chatTutorEnabled = data.chatTutorEnabled;
+      // Intro: storing the built-in default as "unset" (delete) lets units inherit future default
+      // changes; any other value is stored — including an empty string, which suppresses the intro.
+      if (chatTutorIntro === CHAT_TUTOR_DEFAULT_INTRO) {
         delete draft.config.chatTutorIntro;
+      } else {
+        draft.config.chatTutorIntro = chatTutorIntro;
       }
       if (!replaceGenericPrompt && !appendToGenericPrompt) {
         delete draft.config.chatTutorPrompts;
@@ -101,7 +104,8 @@ const ChatTutorSettings: React.FC = () => {
         <textarea id="chatTutorIntro" rows={4} {...register("chatTutorIntro")} />
         <p className="muted small">
           Shown at the top of the chat column when a student opens the tutor. It is display-only —
-          never sent to the AI as context. Leave it as the default to use the built-in greeting.
+          never sent to the AI as context, so a name or claim you write here is not known to the tutor.
+          Leave it as the default to inherit the built-in greeting, or clear it to show no intro.
         </p>
       </fieldset>
 

--- a/src/authoring/types.ts
+++ b/src/authoring/types.ts
@@ -51,6 +51,8 @@ export interface IUnitConfig extends IItemTemplateConfig {
   aiEvaluation?: AIEvaluation;
   aiPrompt: IAiPrompt;
   chatTutorPrompts?: IChatTutorPrompts;
+  chatTutorEnabled?: boolean;
+  chatTutorIntro?: string;
   authorTools?: IAuthorTool[];
   showIdeasButton?: boolean;
   hide4up?: boolean;

--- a/src/clue/components/clue-app-header.scss
+++ b/src/clue/components/clue-app-header.scss
@@ -442,38 +442,51 @@ $member-size: 18px;
 // AA-checked against the header palette: text 8.5:1, border 4.1:1 on the
 // $workspace-teal-light-5 header background; open state white on
 // $workspace-teal-dark-1 = 4.5:1.
+// Floating round "AIdeas" launcher pinned at the lower-right of the workspace. Rendered from the
+// header for store access, but position:fixed takes it out of the header bar and floats it over the
+// workspace. Hidden (unmounted) while the chat drawer is open.
 .app-header .right .chat-tutor-launcher {
+  position: fixed;
+  right: 20px;
+  bottom: 20px;
+  z-index: 900;
   align-items: center;
   appearance: none;
-  background-color: $workspace-teal-light-5;
+  background-color: $problem-orange;
   border: solid 1.5px $charcoal;
-  border-radius: 5px;
+  border-radius: 50%;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
   box-sizing: border-box;
-  color: inherit;
+  color: $charcoal;
   cursor: pointer;
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
+  justify-content: center;
   font: inherit;
   font-weight: 600;
-  gap: 6px;
-  height: 40px;
-  padding: 0 10px;
+  gap: 1px;
+  width: 64px;
+  height: 64px;
+  padding: 0;
 
   @include focus-ring;
 
   &:hover {
-    background-color: $workspace-teal-light-3;
+    background-color: $problem-orange-light-1;
   }
 
-  &:active,
-  &[aria-expanded="true"] {
-    background-color: $workspace-teal-dark-1;
+  &:active {
+    background-color: $problem-orange-dark-1;
     border-color: white;
     color: white;
   }
 
   .chat-tutor-launcher-icon {
-    font-size: 16px;
+    display: block;
+  }
+
+  .chat-tutor-launcher-label {
+    font-size: 12px;
     line-height: 1;
   }
 }

--- a/src/clue/components/clue-app-header.scss
+++ b/src/clue/components/clue-app-header.scss
@@ -439,16 +439,18 @@ $member-size: 18px;
   }
 }
 
-// AA-checked against the header palette: text 8.5:1, border 4.1:1 on the
-// $workspace-teal-light-5 header background; open state white on
-// $workspace-teal-dark-1 = 4.5:1.
-// Floating round "AIdeas" launcher pinned at the lower-right of the workspace. Rendered from the
-// header for store access, but position:fixed takes it out of the header bar and floats it over the
-// workspace. Hidden (unmounted) while the chat drawer is open.
+// Floating round "AIdeas" launcher. Rendered from the header for store access, but position:fixed
+// floats it over the workspace — its containing block is the viewport, not the workspace panel. Kept
+// mounted but hidden while the chat drawer is open.
+// Contrast (measured): $charcoal-dark-3 text on $problem-orange is 8.17:1 (default), 8.85:1 (hover),
+// and 6.42:1 (active $problem-orange-dark-1) — all clear AA 4.5:1; the 1.5px $charcoal border on a
+// white workspace is 4.95:1 (>3:1 non-text). focus-ring(2px) places the ring outside the button.
 .app-header .right .chat-tutor-launcher {
   position: fixed;
   right: 20px;
   bottom: 20px;
+  // The header is its own stacking context (z-index: 20 above), so this only orders the launcher
+  // within it; modals/sidebars (z-index >= 100) still correctly paint over it.
   z-index: 900;
   align-items: center;
   appearance: none;
@@ -457,7 +459,7 @@ $member-size: 18px;
   border-radius: 50%;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
   box-sizing: border-box;
-  color: $charcoal;
+  color: $charcoal-dark-3;
   cursor: pointer;
   display: flex;
   flex-direction: column;
@@ -469,16 +471,20 @@ $member-size: 18px;
   height: 64px;
   padding: 0;
 
-  @include focus-ring;
+  // Higher specificity than the display:flex above, so `hidden` (drawer open) actually hides it.
+  &[hidden] {
+    display: none;
+  }
+
+  @include focus-ring(2px);
 
   &:hover {
     background-color: $problem-orange-light-1;
   }
 
+  // Keep the dark text on the darker active fill — white on $problem-orange-dark-1 can't reach 4.5:1.
   &:active {
     background-color: $problem-orange-dark-1;
-    border-color: white;
-    color: white;
   }
 
   .chat-tutor-launcher-icon {

--- a/src/clue/components/clue-app-header.tsx
+++ b/src/clue/components/clue-app-header.tsx
@@ -57,10 +57,23 @@ export const ClueAppHeaderComponent: React.FC<IProps> = observer(function ClueAp
     (appConfig.chatTutorEnabled || !!urlParams.chatTutor)
       && user.isStudent && !!chatTutorDocumentKey && !!chatTutorDocument?.content;
 
+  // Restore focus to the launcher after the drawer closes. The launcher stays mounted but is hidden
+  // while the drawer is open, so it can't be focused synchronously here — the show/hide re-render is
+  // batched and commits after this handler returns. Defer to the effect below, which runs post-commit
+  // once the launcher is visible again (the drawer trap's escape handler returns "handled" specifically
+  // so this launcher-restore stands).
+  const pendingLauncherFocusRef = useRef(false);
   const handleCloseChatTutor = useCallback(() => {
+    pendingLauncherFocusRef.current = true;
     ui.setShowChatTutor(false);
-    chatTutorLauncherRef.current?.focus();
   }, [ui]);
+
+  useEffect(() => {
+    if (!isChatTutorOpen && pendingLauncherFocusRef.current) {
+      pendingLauncherFocusRef.current = false;
+      chatTutorLauncherRef.current?.focus();
+    }
+  }, [isChatTutorOpen]);
 
   // Don't leave the drawer flagged open after its document goes away, or it would
   // pop back open unrequested when a document loads again.
@@ -74,7 +87,9 @@ export const ClueAppHeaderComponent: React.FC<IProps> = observer(function ClueAp
     type: "region",
     navigation: {
       containerRef: headerRef,
-      itemSelector: "button, .custom-select .header[role='button']",
+      // Exclude the floating launcher: it renders at the viewport corner, far from its DOM position
+      // in the header, so including it in horizontal header nav would teleport focus there.
+      itemSelector: "button:not(.chat-tutor-launcher), .custom-select .header[role='button']",
       orientation: "horizontal",
     },
   });
@@ -233,9 +248,10 @@ export const ClueAppHeaderComponent: React.FC<IProps> = observer(function ClueAp
   };
 
   const renderChatTutorLauncher = () => {
-    // Floating round "AIdeas" button pinned at the workspace's lower-right; hidden while the chat
-    // drawer is open and reappears when it closes.
-    if (!showChatTutorLauncher || isChatTutorOpen) return null;
+    // Floating round "AIdeas" button pinned at the viewport's lower-right. Kept mounted (so the ref
+    // stays valid for focus restore on close and aria-controls resolves to the live drawer) but
+    // hidden while the chat drawer is open; it reappears when the drawer closes.
+    if (!showChatTutorLauncher) return null;
     // Feather "message-circle" speech-bubble path.
     const chatIconPath = "M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8"
       + "-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48"
@@ -245,7 +261,9 @@ export const ClueAppHeaderComponent: React.FC<IProps> = observer(function ClueAp
         type="button"
         ref={chatTutorLauncherRef}
         className="chat-tutor-launcher"
+        hidden={isChatTutorOpen}
         aria-label="Open the AIdeas chat tutor"
+        aria-expanded={isChatTutorOpen}
         aria-controls="chat-tutor-sidebar"
         onClick={() => ui.setShowChatTutor(true)}
         data-testid="chat-tutor-launcher"

--- a/src/clue/components/clue-app-header.tsx
+++ b/src/clue/components/clue-app-header.tsx
@@ -52,8 +52,10 @@ export const ClueAppHeaderComponent: React.FC<IProps> = observer(function ClueAp
   // types.maybe and the workspace summarizer throws on undefined content.
   const chatTutorDocumentKey = persistentUI.problemWorkspace.primaryDocumentKey;
   const chatTutorDocument = chatTutorDocumentKey ? documents.getDocument(chatTutorDocumentKey) : undefined;
+  // Enabled per-unit via config, or via the chatTutor URL param (which lets authors preview it).
   const showChatTutorLauncher =
-    !!urlParams.chatTutor && user.isStudent && !!chatTutorDocumentKey && !!chatTutorDocument?.content;
+    (appConfig.chatTutorEnabled || !!urlParams.chatTutor)
+      && user.isStudent && !!chatTutorDocumentKey && !!chatTutorDocument?.content;
 
   const handleCloseChatTutor = useCallback(() => {
     ui.setShowChatTutor(false);
@@ -231,19 +233,31 @@ export const ClueAppHeaderComponent: React.FC<IProps> = observer(function ClueAp
   };
 
   const renderChatTutorLauncher = () => {
-    if (!showChatTutorLauncher) return null;
+    // Floating round "AIdeas" button pinned at the workspace's lower-right; hidden while the chat
+    // drawer is open and reappears when it closes.
+    if (!showChatTutorLauncher || isChatTutorOpen) return null;
+    // Feather "message-circle" speech-bubble path.
+    const chatIconPath = "M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8"
+      + "-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48"
+      + " 8.48 0 0 1 8 8v.5z";
     return (
       <button
         type="button"
         ref={chatTutorLauncherRef}
         className="chat-tutor-launcher"
-        aria-expanded={isChatTutorOpen}
+        aria-label="Open the AIdeas chat tutor"
         aria-controls="chat-tutor-sidebar"
-        onClick={() => ui.setShowChatTutor(!isChatTutorOpen)}
+        onClick={() => ui.setShowChatTutor(true)}
         data-testid="chat-tutor-launcher"
       >
-        <span className="chat-tutor-launcher-icon" aria-hidden="true">💬</span>
-        <span>Tutor</span>
+        <svg
+          className="chat-tutor-launcher-icon"
+          viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor"
+          strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"
+        >
+          <path d={chatIconPath} />
+        </svg>
+        <span className="chat-tutor-launcher-label">AIdeas</span>
       </button>
     );
   };

--- a/src/components/chat-tutor/chat-sidebar.scss
+++ b/src/components/chat-tutor/chat-sidebar.scss
@@ -1,6 +1,6 @@
 @import "../vars";
 
-// Right-edge drawer, below the app header so the header launcher stays visible. It sits
+// Right-edge drawer, offset below the app header so it aligns with the workspace/resources columns. It sits
 // at the right edge with a fixed width; the workspace reserves the same width when the
 // drawer is open (see clue-app-content.scss) so content is bumped over, not overlaid.
 // The teal frame lives on the chat body (see chat.scss) so the header sits above it,

--- a/src/components/chat-tutor/chat-sidebar.tsx
+++ b/src/components/chat-tutor/chat-sidebar.tsx
@@ -13,6 +13,7 @@ import { buildLeftContext, problemSectionsLoaded } from "./left-context";
 import { normalizeTutorPrompts, tutorPromptsKey } from "./tutor-prompts";
 import { useRightDirty } from "./use-right-dirty";
 import { useTutorDrawerTrap } from "./use-tutor-drawer-trap";
+import { CHAT_TUTOR_DEFAULT_INTRO } from "../../../shared/chat-tutor-default-intro";
 
 import "./chat-sidebar.scss";
 
@@ -67,6 +68,9 @@ export const ChatTutorSidebar: React.FC<IProps> = (props) => {
   const header = `${documentTitle} · ${problemPath}`;
   const chat = useChat({ transport, header });
 
+  // Display-only persona intro (never part of the AI context) — unit override or the built-in default.
+  const introText = appConfig.chatTutorIntro || CHAT_TUTOR_DEFAULT_INTRO;
+
   return (
     <div
       ref={containerRef}
@@ -78,7 +82,8 @@ export const ChatTutorSidebar: React.FC<IProps> = (props) => {
       data-testid="chat-tutor-sidebar"
     >
       <div ref={bodyRef} className="chat-tutor-sidebar-body">
-        <Chat chat={chat} onClose={onClose} closeLabel="Close tutor chat" transcriptTitle={header} />
+        <Chat chat={chat} onClose={onClose} closeLabel="Close tutor chat" transcriptTitle={header}
+              introText={introText} />
       </div>
     </div>
   );

--- a/src/components/chat-tutor/chat-sidebar.tsx
+++ b/src/components/chat-tutor/chat-sidebar.tsx
@@ -68,8 +68,9 @@ export const ChatTutorSidebar: React.FC<IProps> = (props) => {
   const header = `${documentTitle} · ${problemPath}`;
   const chat = useChat({ transport, header });
 
-  // Display-only persona intro (never part of the AI context) — unit override or the built-in default.
-  const introText = appConfig.chatTutorIntro || CHAT_TUTOR_DEFAULT_INTRO;
+  // Display-only persona intro (never part of the AI context). An unset value uses the built-in
+  // default; an authored empty string suppresses the intro entirely (?? keeps "" distinct from unset).
+  const introText = appConfig.chatTutorIntro ?? CHAT_TUTOR_DEFAULT_INTRO;
 
   return (
     <div

--- a/src/components/chat-tutor/chat.scss
+++ b/src/components/chat-tutor/chat.scss
@@ -138,9 +138,12 @@
       font-style: italic;
     }
 
-    // Persona greeting pinned at the top of the column. Visually distinct from real chat bubbles
-    // because it is not a conversation turn (never sent to the AI).
+    // Persona greeting pinned at the top of the column (sticky so it stays in view as messages scroll).
+    // Visually distinct from real chat bubbles because it is not a conversation turn (never sent to
+    // the AI). Its solid background keeps scrolling messages from showing through.
     .chat-intro {
+      position: sticky;
+      top: 0;
       flex: 0 0 auto;
       padding: 8px 12px;
       border-radius: 8px;

--- a/src/components/chat-tutor/chat.scss
+++ b/src/components/chat-tutor/chat.scss
@@ -137,6 +137,18 @@
       margin: auto 0;
       font-style: italic;
     }
+
+    // Persona greeting pinned at the top of the column. Visually distinct from real chat bubbles
+    // because it is not a conversation turn (never sent to the AI).
+    .chat-intro {
+      flex: 0 0 auto;
+      padding: 8px 12px;
+      border-radius: 8px;
+      background: $charcoal-light-7;
+      color: $charcoal-dark-2;
+      font-size: 13px;
+      line-height: 1.4;
+    }
   }
 
   .chat-row {

--- a/src/components/chat-tutor/chat.tsx
+++ b/src/components/chat-tutor/chat.tsx
@@ -213,7 +213,7 @@ export const Chat: React.FC<IProps> = ({ chat, onClose, closeLabel, transcriptTi
       <div className="chat-messages" ref={listRef} data-testid="chat-messages">
         {introText &&
           <div className="chat-intro" data-testid="chat-intro">{introText}</div>}
-        {turns.length === 0 &&
+        {turns.length === 0 && !introText &&
           <div className="chat-empty" data-testid="chat-empty">Ask the tutor about your work.</div>}
         {turns.map(turn => (
           turn.variant === "debug"

--- a/src/components/chat-tutor/chat.tsx
+++ b/src/components/chat-tutor/chat.tsx
@@ -14,6 +14,9 @@ interface IProps {
   // Optional scope line prepended as a heading to the copied transcript so a pasted
   // conversation is self-describing. Purely for the copy output.
   transcriptTitle?: string;
+  // Optional persona intro pinned at the top of the message column. Render-only: it is never a
+  // ChatTurn, so it never enters the AI context, the transport, or the copied transcript.
+  introText?: string;
 }
 
 // Build a plain-markdown transcript of the visible conversation for copy-to-clipboard.
@@ -96,7 +99,7 @@ const DebugTurn: React.FC<{ turn: ChatTurn }> = ({ turn }) => {
   );
 };
 
-export const Chat: React.FC<IProps> = ({ chat, onClose, closeLabel, transcriptTitle }) => {
+export const Chat: React.FC<IProps> = ({ chat, onClose, closeLabel, transcriptTitle, introText }) => {
   const { turns, error, pending, sendMessage, header } = chat;
   const [input, setInput] = useState("");
   const [sending, setSending] = useState(false);
@@ -208,6 +211,8 @@ export const Chat: React.FC<IProps> = ({ chat, onClose, closeLabel, transcriptTi
 
       <div className="chat-body">
       <div className="chat-messages" ref={listRef} data-testid="chat-messages">
+        {introText &&
+          <div className="chat-intro" data-testid="chat-intro">{introText}</div>}
         {turns.length === 0 &&
           <div className="chat-empty" data-testid="chat-empty">Ask the tutor about your work.</div>}
         {turns.map(turn => (

--- a/src/models/stores/app-config-model.ts
+++ b/src/models/stores/app-config-model.ts
@@ -87,6 +87,8 @@ export const AppConfigModel = types
     get aiEvaluation() { return self.configMgr.aiEvaluation; },
     get aiPrompt() { return self.configMgr.aiPrompt; },
     get chatTutorPrompts() { return self.configMgr.chatTutorPrompts; },
+    get chatTutorEnabled() { return self.configMgr.chatTutorEnabled; },
+    get chatTutorIntro() { return self.configMgr.chatTutorIntro; },
     get documentLabelProperties() { return self.configMgr.documentLabelProperties; },
     get documentLabels() { return self.configMgr.documentLabels; },
     get disablePublish() { return self.configMgr.disablePublish; },

--- a/src/models/stores/configuration-manager.ts
+++ b/src/models/stores/configuration-manager.ts
@@ -67,6 +67,14 @@ export class ConfigurationManager implements UnitConfiguration {
     return this.getProp<UC["chatTutorPrompts"]>("chatTutorPrompts");
   }
 
+  get chatTutorEnabled(){
+    return this.getProp<UC["chatTutorEnabled"]>("chatTutorEnabled");
+  }
+
+  get chatTutorIntro(){
+    return this.getProp<UC["chatTutorIntro"]>("chatTutorIntro");
+  }
+
   get autoAssignStudentsToIndividualGroups() {
     return this.getProp<UC["autoAssignStudentsToIndividualGroups"]>("autoAssignStudentsToIndividualGroups");
   }

--- a/src/models/stores/unit-configuration.ts
+++ b/src/models/stores/unit-configuration.ts
@@ -111,6 +111,12 @@ export interface UnitConfiguration extends ProblemConfiguration {
   // server's built-in generic tutor prompt; appendToGenericPrompt is added after the
   // (possibly replaced) generic prompt
   chatTutorPrompts?: { replaceGenericPrompt?: string; appendToGenericPrompt?: string };
+  // if true, the AI chat tutor is enabled for students in this unit. The chatTutor URL param also
+  // enables it (so authors can preview it). Disabling preserves any chatTutorPrompts overrides above.
+  chatTutorEnabled?: boolean;
+  // optional per-unit intro message shown at the top of the chat tutor column. Display-only — it is
+  // never sent to the AI as context. Falls back to the built-in default when unset.
+  chatTutorIntro?: string;
   // List of the types of annotations supported (eg "curved-sparrow") or "all" or "none"
   annotations?: "all" | "none" | string[];
   // if set it will be used to determine if the show ideas button is shown, otherwise

--- a/src/models/stores/unit-configuration.ts
+++ b/src/models/stores/unit-configuration.ts
@@ -112,10 +112,13 @@ export interface UnitConfiguration extends ProblemConfiguration {
   // (possibly replaced) generic prompt
   chatTutorPrompts?: { replaceGenericPrompt?: string; appendToGenericPrompt?: string };
   // if true, the AI chat tutor is enabled for students in this unit. The chatTutor URL param also
-  // enables it (so authors can preview it). Disabling preserves any chatTutorPrompts overrides above.
+  // enables it (so authors can preview it). Like other config this merges bottom-up (problem, then
+  // investigation, then unit), so a value set at a lower level overrides the unit's. Disabling
+  // preserves any chatTutorPrompts overrides above.
   chatTutorEnabled?: boolean;
   // optional per-unit intro message shown at the top of the chat tutor column. Display-only — it is
-  // never sent to the AI as context. Falls back to the built-in default when unset.
+  // never sent to the AI as context. Unset falls back to the built-in default; an empty string
+  // suppresses the intro entirely.
   chatTutorIntro?: string;
   // List of the types of annotations supported (eg "curved-sparrow") or "all" or "none"
   annotations?: "all" | "none" | string[];


### PR DESCRIPTION
## CLUE-594: Author unit switch to turn on AI chat

Previously the AI chat tutor could only be enabled via the `chatTutor` URL parameter. This adds a **unit-level setting** (with an authoring checkbox) to turn it on, plus the requested launcher/intro UI changes.

### Enablement
- New `chatTutorEnabled` unit config, wired the same way as `chatTutorPrompts` (`unit-configuration.ts` + authoring `types.ts`, a `configuration-manager` getter, and an `app-config-model` view).
- The launcher is gated on `appConfig.chatTutorEnabled || urlParams.chatTutor` — the URL param is kept as an **author-preview override**.
- **Authoring:** an "Enable the AI chat tutor for students in this unit" checkbox on the Chat Tutor page, saved **non-destructively** (toggling it never discards the prompt overrides).

### Launcher UI
- Moved the launcher out of the header into a **round floating "AIdeas" button** (chat icon), pinned lower-right of the workspace, **hidden while the chat drawer is open** and reappearing when it closes. Styled in the student/problem orange (`$problem-orange`).

### Intro message
- New `chatTutorIntro` config field + a shared `CHAT_TUTOR_DEFAULT_INTRO` default ("Hi. I'm Ada Idea. I can see the work in your workspace and help you think it through.").
- Rendered as a pinned element at the top of the chat column. It is **render-only** — never a `ChatTurn` — so it is excluded from the AI context, the transport, and the copy transcript **by construction**.
- **Authoring:** an editable intro textarea (seeded with the default; stored only when customized).

### Testing
- `npm run check:types` and lint clean.
- Unit tests added/updated for the authoring checkbox and intro (enable/disable non-destructive behavior, intro default seeding + save).
- Manual QA in the authoring student preview: enable → the orange AIdeas button appears lower-right; open → button hides, intro shows atop the column; close → button returns; disabling preserves prompts.

### Notes for review
- Existing docs load unchanged (the new fields are optional; MST ignores absent keys).
- Legacy `chatTutor` URL param still works for previews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
