### PR TITLE
CLUE-600: Unit setting to show or hide the share button

### DIFF
--- a/docs/unit-configuration.md
+++ b/docs/unit-configuration.md
@@ -111,6 +111,8 @@ which checks if the the aiEvaluation is set or if there are invisible exemplar d
 
 `hide4up`: (boolean | undefined) If true, the button that switches to 4up view is always hidden.
 
+`showShare`: (boolean | undefined) Whether the share/unshare toggle is shown on student documents (problem, personal, and learning log). Defaults to `true`. Set to `false` to hide sharing for the unit. Hiding the button does not unshare documents that are already shared.
+
 ## Unit- or Problem-level `config` properties
 
 These properties are configurable at the unit, investigation, or problem levels of the curriculum JSON.

--- a/src/authoring/components/workspace/document-settings.test.tsx
+++ b/src/authoring/components/workspace/document-settings.test.tsx
@@ -28,6 +28,9 @@ const applyLastUpdater = (seed: Record<string, any> = {}) => {
 const shareCheckbox = () =>
   screen.getByRole("checkbox", { name: "Show the share button on student documents" });
 
+const fourUpCheckbox = () =>
+  screen.getByRole("checkbox", { name: "Show the 4-up view button" });
+
 describe("DocumentSettings — Share Button", () => {
   beforeEach(() => {
     mockSetUnitConfig.mockClear();
@@ -70,5 +73,49 @@ describe("DocumentSettings — Share Button", () => {
     // Seed the draft with the existing false so the delete is observable.
     const mockDraft = applyLastUpdater({ showShare: false });
     expect(mockDraft.config.showShare).toBeUndefined();
+  });
+});
+
+describe("DocumentSettings — 4-up View", () => {
+  beforeEach(() => {
+    mockSetUnitConfig.mockClear();
+    for (const key of Object.keys(mockConfig)) delete mockConfig[key];
+    mockCurriculumValue.saveState = undefined;
+  });
+
+  it("defaults the 4-up checkbox to checked when the config is unset", () => {
+    render(<DocumentSettings />);
+    expect(fourUpCheckbox()).toBeChecked();
+  });
+
+  it("loads hide4up:true as unchecked", () => {
+    mockConfig.hide4up = true;
+    render(<DocumentSettings />);
+    expect(fourUpCheckbox()).not.toBeChecked();
+  });
+
+  it("stores hide4up:true when the box is unchecked", async () => {
+    const user = userEvent.setup();
+    render(<DocumentSettings />);
+
+    await user.click(fourUpCheckbox());
+    fireEvent.click(screen.getByRole("button", { name: /Save/i }));
+
+    await waitFor(() => expect(mockSetUnitConfig).toHaveBeenCalled());
+    const mockDraft = applyLastUpdater();
+    expect(mockDraft.config.hide4up).toBe(true);
+  });
+
+  it("removes hide4up when re-enabled (default shown is implicit)", async () => {
+    mockConfig.hide4up = true;
+    const user = userEvent.setup();
+    render(<DocumentSettings />);
+
+    await user.click(fourUpCheckbox()); // was unchecked; re-check it
+    fireEvent.click(screen.getByRole("button", { name: /Save/i }));
+
+    await waitFor(() => expect(mockSetUnitConfig).toHaveBeenCalled());
+    const mockDraft = applyLastUpdater({ hide4up: true });
+    expect(mockDraft.config.hide4up).toBeUndefined();
   });
 });

--- a/src/authoring/components/workspace/document-settings.test.tsx
+++ b/src/authoring/components/workspace/document-settings.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import DocumentSettings from "./document-settings";
+
+const mockSetUnitConfig = jest.fn();
+const mockConfig: Record<string, any> = {};
+const mockCurriculumValue = {
+  unitConfig: { config: mockConfig },
+  setUnitConfig: mockSetUnitConfig,
+  saveState: undefined as string | undefined
+};
+
+jest.mock("../../hooks/use-curriculum", () => ({
+  useCurriculum: () => mockCurriculumValue
+}));
+
+// Runs the updater passed to setUnitConfig against a mock draft seeded with the given pre-existing
+// config, and returns it.
+const applyLastUpdater = (seed: Record<string, any> = {}) => {
+  const updaterFn = mockSetUnitConfig.mock.calls[0][0];
+  const mockDraft = { config: { ...seed }, sections: {} };
+  updaterFn(mockDraft);
+  return mockDraft;
+};
+
+const shareCheckbox = () =>
+  screen.getByRole("checkbox", { name: "Show the share button on student documents" });
+
+describe("DocumentSettings — Share Button", () => {
+  beforeEach(() => {
+    mockSetUnitConfig.mockClear();
+    for (const key of Object.keys(mockConfig)) delete mockConfig[key];
+    mockCurriculumValue.saveState = undefined;
+  });
+
+  it("defaults the share-button checkbox to checked when the config is unset", () => {
+    render(<DocumentSettings />);
+    expect(shareCheckbox()).toBeChecked();
+  });
+
+  it("loads showShare:false as unchecked", () => {
+    mockConfig.showShare = false;
+    render(<DocumentSettings />);
+    expect(shareCheckbox()).not.toBeChecked();
+  });
+
+  it("stores showShare:false when the box is unchecked", async () => {
+    const user = userEvent.setup();
+    render(<DocumentSettings />);
+
+    await user.click(shareCheckbox());
+    fireEvent.click(screen.getByRole("button", { name: /Save/i }));
+
+    await waitFor(() => expect(mockSetUnitConfig).toHaveBeenCalled());
+    const mockDraft = applyLastUpdater();
+    expect(mockDraft.config.showShare).toBe(false);
+  });
+
+  it("removes showShare when re-enabled (default true is implicit)", async () => {
+    mockConfig.showShare = false;
+    const user = userEvent.setup();
+    render(<DocumentSettings />);
+
+    await user.click(shareCheckbox()); // was unchecked; re-check it
+    fireEvent.click(screen.getByRole("button", { name: /Save/i }));
+
+    await waitFor(() => expect(mockSetUnitConfig).toHaveBeenCalled());
+    // Seed the draft with the existing false so the delete is observable.
+    const mockDraft = applyLastUpdater({ showShare: false });
+    expect(mockDraft.config.showShare).toBeUndefined();
+  });
+});

--- a/src/authoring/components/workspace/document-settings.tsx
+++ b/src/authoring/components/workspace/document-settings.tsx
@@ -7,6 +7,7 @@ import { buildSectionDividerTemplate } from "../../utils/template-utils";
 interface DocumentSettingsFormInputs {
   defaultSharedDocuments: boolean;
   showShare: boolean;
+  show4up: boolean;
   showTextTitles: boolean;
   documentTemplateEnabled: boolean;
   planningTemplateEnabled: boolean;
@@ -23,6 +24,8 @@ const DocumentSettings: React.FC = () => {
     return {
       defaultSharedDocuments: config?.defaultSharedDocuments ?? false,
       showShare: config?.showShare ?? true,
+      // hide4up defaults false, so the 4-up button shows by default.
+      show4up: !config?.hide4up,
       // Titles are shown only when the unit explicitly opts in with text.hideTitle: false.
       showTextTitles: config?.settings?.text?.hideTitle === false,
       // Default to on when a legacy template already exists (flag undefined → applied at runtime).
@@ -52,6 +55,12 @@ const DocumentSettings: React.FC = () => {
         delete draft.config.showShare;
       } else {
         draft.config.showShare = false;
+      }
+      // Inverse of the showShare pattern: hide4up defaults false, so store true only to hide the button.
+      if (data.show4up) {
+        delete draft.config.hide4up;
+      } else {
+        draft.config.hide4up = true;
       }
       if (data.showTextTitles) {
         if (!draft.config.settings) draft.config.settings = {} as ISettings;
@@ -125,6 +134,21 @@ const DocumentSettings: React.FC = () => {
         <p className="muted small">
           When enabled (the default), students see the share/unshare toggle on their documents. Turn it
           off to hide sharing for this unit.
+        </p>
+      </fieldset>
+
+      <fieldset>
+        <legend>4-up View</legend>
+        <label className="horizontal middle">
+          <input
+            type="checkbox"
+            {...register("show4up")}
+          />
+          <span>Show the 4-up view button</span>
+        </label>
+        <p className="muted small">
+          When enabled (the default), students see the button to switch to the 4-up group view. Turn it
+          off to hide it for this unit.
         </p>
       </fieldset>
 

--- a/src/authoring/components/workspace/document-settings.tsx
+++ b/src/authoring/components/workspace/document-settings.tsx
@@ -6,6 +6,7 @@ import { buildSectionDividerTemplate } from "../../utils/template-utils";
 
 interface DocumentSettingsFormInputs {
   defaultSharedDocuments: boolean;
+  showShare: boolean;
   showTextTitles: boolean;
   documentTemplateEnabled: boolean;
   planningTemplateEnabled: boolean;
@@ -21,6 +22,7 @@ const DocumentSettings: React.FC = () => {
   const formDefaults: DocumentSettingsFormInputs = useMemo(() => {
     return {
       defaultSharedDocuments: config?.defaultSharedDocuments ?? false,
+      showShare: config?.showShare ?? true,
       // Titles are shown only when the unit explicitly opts in with text.hideTitle: false.
       showTextTitles: config?.settings?.text?.hideTitle === false,
       // Default to on when a legacy template already exists (flag undefined → applied at runtime).
@@ -44,6 +46,12 @@ const DocumentSettings: React.FC = () => {
         draft.config.defaultSharedDocuments = true;
       } else {
         delete draft.config.defaultSharedDocuments;
+      }
+      // Default is true (button shown); only persist the non-default (hidden) so config stays minimal.
+      if (data.showShare) {
+        delete draft.config.showShare;
+      } else {
+        draft.config.showShare = false;
       }
       if (data.showTextTitles) {
         if (!draft.config.settings) draft.config.settings = {} as ISettings;
@@ -102,6 +110,21 @@ const DocumentSettings: React.FC = () => {
         <p className="muted small">
           When enabled, new student documents (problem, personal, and learning log)
           will be shared with classmates by default instead of being private.
+        </p>
+      </fieldset>
+
+      <fieldset>
+        <legend>Share Button</legend>
+        <label className="horizontal middle">
+          <input
+            type="checkbox"
+            {...register("showShare")}
+          />
+          <span>Show the share button on student documents</span>
+        </label>
+        <p className="muted small">
+          When enabled (the default), students see the share/unshare toggle on their documents. Turn it
+          off to hide sharing for this unit.
         </p>
       </fieldset>
 

--- a/src/authoring/types.ts
+++ b/src/authoring/types.ts
@@ -61,6 +61,7 @@ export interface IUnitConfig extends IItemTemplateConfig {
   // comments-open width so the workspace gets ~2/3 until comments are opened.
   contentLayout?: "evenLayout" | "wideContent";
   defaultSharedDocuments?: boolean;
+  showShare?: boolean;
 }
 
 export interface IAuthorTool {

--- a/src/components/document/document.tsx
+++ b/src/components/document/document.tsx
@@ -14,7 +14,6 @@ import { logDocumentEvent, logDocumentViewEvent } from "../../models/document/lo
 import { IToolbarModel } from "../../models/stores/problem-configuration";
 import { SupportType, TeacherSupportModelType, AudienceEnum } from "../../models/stores/supports";
 import { WorkspaceModelType } from "../../models/stores/workspace";
-import { ENavTab } from "../../models/view/nav-tabs";
 import { upperWords } from "../../utilities/string-utils";
 import { translate } from "../../utilities/translation/translate";
 import { BaseComponent, IBaseProps } from "../base";
@@ -227,9 +226,11 @@ export class DocumentComponent extends BaseComponent<IProps, IState> {
     }
   }
 
-  private showPersonalShareToggle() {
-    const tabNames = this.stores.appConfig.navTabs.tabSpecs.map(tab => tab.tab);
-    return tabNames.includes(ENavTab.kSortWork);
+  // Whether the share/unshare toggle is shown, driven by the definitive `showShare` unit setting
+  // (default true). Previously this was implicitly coupled to the presence of the Sort Work tab, which
+  // both hid the button in units that wanted it and showed it in units that didn't.
+  private shareButtonEnabled() {
+    return this.stores.appConfig.showShare;
   }
 
   private renderTitleBar(type: string) {
@@ -308,7 +309,7 @@ export class DocumentComponent extends BaseComponent<IProps, IState> {
     return this.renderGenericTitleBar({
       title: problemTitle,
       hideButtons,
-      showShareButton: type !== "planning",
+      showShareButton: type !== "planning" && this.shareButtonEnabled(),
       docType: type,
       show4up
     });
@@ -463,7 +464,7 @@ export class DocumentComponent extends BaseComponent<IProps, IState> {
     const isPrimary = this.isPrimary();
     const displayId = document.getDisplayId(appConfig);
     const hasDisplayId = !!displayId;
-    const showPersonalShareToggle = this.showPersonalShareToggle();
+    const showShareToggle = this.shareButtonEnabled();
     return (
       <div className={`titlebar ${type}`}>
         <div className="actions">
@@ -502,7 +503,7 @@ export class DocumentComponent extends BaseComponent<IProps, IState> {
         <div className="actions">
           {(!hideButtons || supportStackedTwoUpView) &&
             <div className="actions">
-              {showPersonalShareToggle &&
+              {showShareToggle &&
                 <ShareButton isShared={document.visibility === "public"} onClick={this.handleToggleVisibility} />}
               {supportStackedTwoUpView && isPrimary &&
                 <OneUpButton onClick={this.handleHideTwoUp} selected={!workspace.comparisonVisible} />}

--- a/src/models/stores/app-config-model.test.ts
+++ b/src/models/stores/app-config-model.test.ts
@@ -269,4 +269,24 @@ describe("ConfigurationManager", () => {
     });
   });
 
+  describe("showShare", () => {
+    it("should default to true when not configured", () => {
+      const appConfig = AppConfigModel.create({ config: unitConfigDefaults });
+      expect(appConfig.showShare).toBe(true);
+    });
+
+    it("should return false when explicitly set to false", () => {
+      const appConfig = AppConfigModel.create({
+        config: { ...unitConfigDefaults, showShare: false }
+      });
+      expect(appConfig.showShare).toBe(false);
+    });
+
+    it("should let a false override win over the default", () => {
+      const appConfig = AppConfigModel.create({ config: unitConfigDefaults });
+      appConfig.setConfigs([{ showShare: false }]);
+      expect(appConfig.showShare).toBe(false);
+    });
+  });
+
 });

--- a/src/models/stores/app-config-model.ts
+++ b/src/models/stores/app-config-model.ts
@@ -112,6 +112,8 @@ export const AppConfigModel = types
     get defaultPanelLayout() { return self.configMgr.defaultPanelLayout; },
     get contentLayout() { return self.configMgr.contentLayout; },
     get defaultSharedDocuments() { return self.configMgr.defaultSharedDocuments; },
+    // Default true: the share toggle shows unless a unit explicitly hides it.
+    get showShare() { return self.configMgr.showShare ?? true; },
     get authorToolbar() {
       return ToolbarModel.create([
         ...self.toolbar.map(button => ToolbarButtonModel.create(getSnapshot(button))),

--- a/src/models/stores/configuration-manager.test.ts
+++ b/src/models/stores/configuration-manager.test.ts
@@ -219,6 +219,22 @@ describe("ConfigurationManager", () => {
     expect(configManager.defaultSharedDocuments).toBe(true);
   });
 
+  it("should return undefined for showShare when not configured", () => {
+    const configManager = new ConfigurationManager(defaults, []);
+    expect(configManager.showShare).toBeUndefined();
+  });
+
+  it("should return false for showShare when explicitly set to false", () => {
+    const configManager = new ConfigurationManager({ ...defaults, showShare: false }, []);
+    expect(configManager.showShare).toBe(false);
+  });
+
+  it("should let a false showShare override win over a true base (getProp tests != null)", () => {
+    const override: Partial<UnitConfiguration> = { showShare: false };
+    const configManager = new ConfigurationManager({ ...defaults, showShare: true }, [override]);
+    expect(configManager.showShare).toBe(false);
+  });
+
   it("should return false for allowCustomCommentTags when showCommentTag is not set", () => {
     const config = { ...defaults, allowCustomCommentTags: true };
     const configManager = new ConfigurationManager(config, []);

--- a/src/models/stores/configuration-manager.ts
+++ b/src/models/stores/configuration-manager.ts
@@ -251,6 +251,10 @@ export class ConfigurationManager implements UnitConfiguration {
     return this.getProp<UC["defaultSharedDocuments"]>("defaultSharedDocuments");
   }
 
+  get showShare() {
+    return this.getProp<UC["showShare"]>("showShare");
+  }
+
   get settings(): UC["settings"]  {
     // settings are merged rather than simply returning the closest non-empty value
     // merge is just two levels deep: eg merges items under settings.table, but not elements of settings.table.tools

--- a/src/models/stores/unit-configuration.ts
+++ b/src/models/stores/unit-configuration.ts
@@ -127,4 +127,7 @@ export interface UnitConfiguration extends ProblemConfiguration {
   termOverrides?: Record<string, string>;
   // whether student documents (problem, personal, learning log) are shared by default
   defaultSharedDocuments?: boolean;
+  // whether the share/unshare toggle is shown on student documents. Default true. This is a
+  // definitive per-unit switch — it replaces the old implicit coupling to the Sort Work tab's presence.
+  showShare?: boolean;
 }


### PR DESCRIPTION
## CLUE-600: Unit setting to show or hide the share button

### The problem
Whether the document **share/unshare toggle** appeared was implicitly coupled to the presence of the **Sort Work** tab in a unit's `navTabs`: `showPersonalShareToggle()` returned `tabSpecs.map(t => t.tab).includes("sort-work")`. Because it keyed off *presence in `tabSpecs`* (ignoring `hidden`), this both **hid** the button in units that wanted sharing but had no Sort Work tab, and **showed** it in units that didn't want it but happened to have a (even hidden) Sort Work entry.

### The fix — a definitive `showShare` setting (default `true`)
- New `showShare?: boolean` on `UnitConfiguration` + authoring `IUnitConfig`, with a `configuration-manager` getter and an `app-config-model` view that **defaults to `true`** (`?? true`).
- `document.tsx`: `showPersonalShareToggle()` (the sort-work check) becomes `shareButtonEnabled()` → `appConfig.showShare`, gating **both** share-button paths — the personal/other-doc toggle **and** the problem-doc button (`type !== "planning" && this.shareButtonEnabled()`). Removed the now-unused `ENavTab` import.
- **Authoring:** a "Show the share button on student documents" checkbox in a new **Share Button** fieldset on the Document Settings page (default checked; stores `false` only when hidden, deletes the key on re-enable so config stays minimal).

Default `true` preserves current behavior for problem-doc units; the previously-broken cases (personal-doc units without Sort Work) now show the button as expected.

### Also: authoring for the existing `hide4up` setting (2nd commit)
While here, the `hide4up` setting (hide the 4-up view button) was fully wired at runtime but had **no author-facing control** — authors had to hand-edit config JSON. Added a "Show the 4-up view button" checkbox to the same Document Settings page, mirroring the `showShare` pattern (inverted: default checked; stores `hide4up: true` only when hidden). No model changes — the config/getter/view already existed.

### Testing
- `npm run check:types` + lint clean.
- New `document-settings.test.tsx` covering both toggles: default-on, load the non-default, save the non-default, and delete-on-re-enable (8 tests).
- Manual QA on localhost: default units still show both buttons; unchecking each hides it on problem and personal docs; a personal-doc unit without Sort Work now shows the share button by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
