### PR TITLE
CLUE-610: fix Sort Work row scrolling, and pin its regression tests to the sections they test

### DIFF
--- a/cypress/e2e/functional/teacher_tests/teacher_sort_work_view_1_spec.js
+++ b/cypress/e2e/functional/teacher_tests/teacher_sort_work_view_1_spec.js
@@ -44,7 +44,7 @@ describe('SortWorkView Tests', () => {
 
     cy.log('verify opening and closing a document from the sort work view');
     cy.get('.section-header-arrow').click({multiple: true}); // Open the sections
-    sortWork.getSortWorkItem().eq(1).click(); // Open the first document in the list
+    sortWork.getSortWorkGroupItem('No Group').eq(1).click();
     resourcesPanel.getEditableDocumentContent().should('be.visible');
 
     cy.log('verify can switch sort groups using arrows');

--- a/cypress/e2e/functional/teacher_tests/teacher_sort_work_view_3_spec.js
+++ b/cypress/e2e/functional/teacher_tests/teacher_sort_work_view_3_spec.js
@@ -1,5 +1,6 @@
 import TeacherDashboard from "../../../support/elements/common/TeacherDashboard";
 import SortedWork from "../../../support/elements/common/SortedWork";
+import { getSettledProp } from "../../../support/helpers/settled";
 
 let sortWork = new SortedWork;
 let dashboard = new TeacherDashboard;
@@ -41,19 +42,24 @@ describe('SortWorkView Tests', () => {
       cy.wrap($el).find("[data-testid=doc-group]").should("have.length", 1);
       cy.wrap($el).find("[data-testid=doc-group-label]").should("not.exist");
     });
-    // The Investigation layout renders one set of scroll buttons per
-    // section-document-list, so scope the scroll-behavior assertions to a
-    // single section to avoid multi-element subjects on `.click()`.
-    cy.get("[data-testid=section-document-list]").first().within(() => {
-      cy.get("[data-testid=doc-group-list]").invoke("prop", "scrollLeft").should("be.eq", 0);
+    // The Investigation layout renders one set of scroll buttons per section-document-list, and only
+    // for a section whose documents overflow the row, so scope the scroll-behavior assertions to the
+    // "No Group" section — the one large enough to scroll — to avoid multi-element subjects on `.click()`.
+    sortWork.getSortWorkGroup("No Group").find("[data-testid=section-document-list]").within(() => {
+      // The row scrolls smoothly, and narrows once the scroll buttons take their place beside it —
+      // which is also what sets how far one click scrolls. Read both only once they hold still, or a
+      // click lands part-way through a scroll, or on a row about to be a different width.
+      const docRow = "[data-testid=doc-group-list]";
+      getSettledProp(docRow, "clientWidth").should("be.gt", 0);
+      getSettledProp(docRow, "scrollLeft").should("be.eq", 0);
       cy.get("[data-testid=scroll-button-left]").should("exist").and("be.disabled");
       cy.get("[data-testid=scroll-button-right]").should("exist").and("not.be.disabled");
       cy.get("[data-testid=scroll-button-right]").click();
+      getSettledProp(docRow, "scrollLeft").should("be.gt", 0);
       cy.get("[data-testid=scroll-button-left]").should("exist").and("not.be.disabled");
-      cy.get("[data-testid=doc-group-list]").invoke("prop", "scrollLeft").should("be.gt", 0);
       cy.get("[data-testid=scroll-button-left]").click();
+      getSettledProp(docRow, "scrollLeft").should("be.eq", 0);
       cy.get("[data-testid=scroll-button-left]").should("exist").and("be.disabled");
-      cy.get("[data-testid=doc-group-list]").invoke("prop", "scrollLeft").should("be.eq", 0);
     });
 
     // Apply secondary sort
@@ -80,7 +86,9 @@ describe('SortWorkView Tests', () => {
     });
 
     cy.log('verify can switch groups sorted by two means using arrows');
-    sortWork.getSimpleDocumentItem().eq(1).click();
+    // Open a document in the "No Group" section, the only one holding enough documents to be split
+    // across more than one name sub-group for the arrows to move between.
+    sortWork.getSimpleDocumentGroupItem("No Group").eq(1).click();
     cy.get('.header-text').should('not.contain.text', '1, Teacher');
     cy.get('.header-text').should('contain.text', '10, Student');
     cy.get('.switch-sort-group-button.left').click();

--- a/cypress/e2e/functional/teacher_tests/teacher_sort_work_view_6_spec.js
+++ b/cypress/e2e/functional/teacher_tests/teacher_sort_work_view_6_spec.js
@@ -35,10 +35,11 @@ describe('SortWorkView Tests', () => {
     sortWork.getSecondarySortByNoneOption().click();
     sortWork.getSecondarySortByNoneOption().should("have.class", "selected");
     cy.get('.section-header-arrow').eq(1).should("have.class", "up");
-    let prevFocusDocTitle = "";
-    sortWork.getSortWorkItem().first().find('div').invoke('text').then((docText) => {
-      prevFocusDocTitle = docText.trim();
-    });
+    let prevFocusDocKey = "";
+    cy.get(".sort-work-view .sorted-sections .list-item").first()
+      .invoke('attr', 'data-document-key').then((docKey) => {
+        prevFocusDocKey = docKey;
+      });
     sortWork.getSortWorkItem().first().click();
     cy.get('.close-doc-button').click();
     cy.get('.section-header-arrow').eq(1).should("have.class", "up");
@@ -49,9 +50,9 @@ describe('SortWorkView Tests', () => {
     sortWork.getSecondarySortByNameOption().click();
     cy.get(".sort-work-view .sorted-sections .simple-document-item.selected")
       .should("exist")
-      .invoke("attr", "title")
-      .then((docTitle2) => {
-        expect(docTitle2).to.equal(prevFocusDocTitle);
+      .invoke("attr", "data-document-key")
+      .then((docKey2) => {
+        expect(docKey2).to.equal(prevFocusDocKey);
       });
 
     cy.log("when primary sort is switched, there should be no expanded sections, and no highlighted documents");

--- a/cypress/e2e/functional/teacher_tests/teacher_sort_work_view_6_spec.js
+++ b/cypress/e2e/functional/teacher_tests/teacher_sort_work_view_6_spec.js
@@ -36,19 +36,19 @@ describe('SortWorkView Tests', () => {
     sortWork.getSecondarySortByNoneOption().should("have.class", "selected");
     cy.get('.section-header-arrow').eq(1).should("have.class", "up");
     let prevFocusDocKey = "";
-    cy.get(".sort-work-view .sorted-sections .list-item").first()
+    sortWork.getSortWorkListItem().first()
       .invoke('attr', 'data-document-key').then((docKey) => {
         prevFocusDocKey = docKey;
       });
     sortWork.getSortWorkItem().first().click();
     cy.get('.close-doc-button').click();
     cy.get('.section-header-arrow').eq(1).should("have.class", "up");
-    cy.get(".sort-work-view .sorted-sections .list-item").first().should("have.class", "selected");
+    sortWork.getSortWorkListItem().first().should("have.class", "selected");
 
     cy.log("change the secondary sort and verify that the section remains expanded and the document is highlighted");
     sortWork.getSecondarySortByMenu().click();
     sortWork.getSecondarySortByNameOption().click();
-    cy.get(".sort-work-view .sorted-sections .simple-document-item.selected")
+    sortWork.getSimpleDocumentItem().filter(".selected")
       .should("exist")
       .invoke("attr", "data-document-key")
       .then((docKey2) => {
@@ -62,6 +62,6 @@ describe('SortWorkView Tests', () => {
     sortWork.getSecondarySortByMenu().click();
     sortWork.getSecondarySortByNoneOption().click();
     cy.get('.section-header-arrow').click({multiple: true});
-    cy.get(".sort-work-view .sorted-sections .list-item").should("not.have.class", "selected");
+    sortWork.getSortWorkListItem().should("not.have.class", "selected");
   });
 });

--- a/cypress/support/elements/common/SortedWork.js
+++ b/cypress/support/elements/common/SortedWork.js
@@ -23,14 +23,20 @@ class SortedWork {
   getPrimarySortByProblemOption(){
     return cy.get('.custom-select.sort-work-sort-menu.primary-sort-menu [data-test="list-item-problem"]');
   }
+  getSortWorkListItem() {
+    return cy.get(".sort-work-view .sorted-sections .list-item");
+  }
   getSortWorkItem() {
-    return cy.get(".sort-work-view .sorted-sections .list-item .footer .info");
+    return this.getSortWorkListItem().find(".footer .info");
   }
   getSortWorkItemByTitle(title) {
     return this.getSortWorkItem().contains(title);
   }
   getSortWorkGroup(groupName) {
     return cy.get(".sort-work-view .sorted-sections .section-header-label").contains(groupName).parent().parent().parent();
+  }
+  getSortWorkGroupItem(groupName) {
+    return this.getSortWorkGroup(groupName).find(".list-item .footer .info");
   }
   getSortWorkSubgroup(groupName, subgroupName) {
     return this.getSortWorkGroup(groupName)
@@ -142,6 +148,9 @@ class SortedWork {
 
   getSimpleDocumentItem() {
     return cy.get('.sort-work-view .sorted-sections .simple-document-item');
+  }
+  getSimpleDocumentGroupItem(groupName) {
+    return this.getSortWorkGroup(groupName).find('.simple-document-item');
   }
 
   getPrimarySortLabelForItem(sortWorkItemIdx, isSimpleDocument = false) {

--- a/cypress/support/helpers/settled.js
+++ b/cypress/support/helpers/settled.js
@@ -1,0 +1,24 @@
+/**
+ * Yields a DOM property of an element only once it has stopped changing — that is, once two
+ * consecutive reads agree.
+ *
+ * Use it for anything the browser or the app keeps updating after the action that set it going: a
+ * smooth scroll still traveling towards its destination, a width that settles a render after the
+ * layout around it changes. A single read can catch such a value mid-flight, and an assertion that
+ * passes on a value still in motion leaves the step after it acting on a layout that has moved on.
+ *
+ * @param {string} selector - The element to read, as passed to `cy.get()`
+ * @param {string} prop - The DOM property to read, as passed to `.invoke("prop", ...)`
+ * @returns {Cypress.Chainable} The settled value of the property
+ * @example
+ * getSettledProp("[data-testid=doc-group-list]", "scrollLeft").should("be.eq", 0);
+ */
+export function getSettledProp(selector, prop) {
+  let previous;
+  return cy.get(selector).should($el => {
+    const current = $el.prop(prop);
+    const settled = current === previous;
+    previous = current;
+    expect(settled, `${prop} settled at ${current}`).to.be.true;
+  }).invoke("prop", prop);
+}

--- a/src/components/document/document-group.test.tsx
+++ b/src/components/document/document-group.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import React from "react";
 import { DocumentGroupComponent } from "./document-group";
 import { DocumentGroup } from "../../models/stores/document-group";
@@ -23,6 +23,13 @@ function createTestDocumentGroup(docCount: number) {
 }
 
 describe("DocumentGroupComponent", () => {
+  const originalScrollBy = HTMLElement.prototype.scrollBy;
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    HTMLElement.prototype.scrollBy = originalScrollBy;
+  });
+
   it("does not render scroll buttons before the container width is measured", () => {
     // In jsdom, offsetWidth is 0, so containerWidth stays 0 and visibleCount = 0.
     // If scroll buttons render in that state, clicking them computes
@@ -38,5 +45,37 @@ describe("DocumentGroupComponent", () => {
     );
     expect(queryByTestId("scroll-button-left")).not.toBeInTheDocument();
     expect(queryByTestId("scroll-button-right")).not.toBeInTheDocument();
+  });
+
+  it("scrolls by the row's current width, not the width it was last measured at", () => {
+    // The row is narrower once the scroll buttons take their place beside it, and the measurement
+    // that follows that change arrives a render later. A click in between must still scroll by a
+    // whole number of the document boxes that fit *now*, or the row lands on an offset the opposite
+    // button cannot undo: out by the old width and back by the new one leaves the difference behind,
+    // and with it a left arrow that stays enabled but never returns the row to its start.
+    const scrollUnit = 16 + 10;           // one document box plus the gap after it
+    const widthWhenMeasured = 24 * scrollUnit + 13;
+    const widthNow = 22 * scrollUnit + 13;
+    const widthSpy = jest.spyOn(HTMLElement.prototype, "offsetWidth", "get")
+      .mockReturnValue(widthWhenMeasured);
+    jest.spyOn(HTMLElement.prototype, "clientWidth", "get").mockReturnValue(widthNow);
+    // Enough content to scroll through, so the right arrow is not disabled for want of overflow.
+    jest.spyOn(HTMLElement.prototype, "scrollWidth", "get").mockReturnValue(50 * scrollUnit);
+    const scrollBy = jest.fn();
+    HTMLElement.prototype.scrollBy = scrollBy;
+
+    const documentGroup = createTestDocumentGroup(50);
+    const { getByTestId } = render(
+      <DocumentGroupComponent
+        documentGroup={documentGroup}
+        secondarySort="None"
+        onSelectDocument={() => undefined}
+      />
+    );
+    // The buttons are showing now, and the row has narrowed around them.
+    widthSpy.mockReturnValue(widthNow);
+
+    fireEvent.click(getByTestId("scroll-button-right"));
+    expect(scrollBy).toHaveBeenCalledWith({ left: 22 * scrollUnit, behavior: "smooth" });
   });
 });

--- a/src/components/document/document-group.test.tsx
+++ b/src/components/document/document-group.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render } from "@testing-library/react";
 import React from "react";
-import { DocumentGroupComponent } from "./document-group";
+import { DocumentGroupComponent, kScrollUnit } from "./document-group";
 import { DocumentGroup } from "../../models/stores/document-group";
 
 jest.mock("../thumbnail/simple-document-item", () => ({
@@ -31,10 +31,9 @@ describe("DocumentGroupComponent", () => {
   });
 
   it("does not render scroll buttons before the container width is measured", () => {
-    // In jsdom, offsetWidth is 0, so containerWidth stays 0 and visibleCount = 0.
-    // If scroll buttons render in that state, clicking them computes
-    // scrollAmount = visibleCount * scrollUnit = 0 — a silent no-op that
-    // leaves the arrow-disabled state out of sync with reality.
+    // In jsdom every element measures 0 wide, so containerWidth stays 0 and visibleCount = 0.
+    // If scroll buttons render in that state, clicking them rounds a zero width down to a zero
+    // scroll — a silent no-op that leaves the arrow-disabled state out of sync with reality.
     const documentGroup = createTestDocumentGroup(10);
     const { queryByTestId } = render(
       <DocumentGroupComponent
@@ -53,18 +52,23 @@ describe("DocumentGroupComponent", () => {
     // whole number of the document boxes that fit *now*, or the row lands on an offset the opposite
     // button cannot undo: out by the old width and back by the new one leaves the difference behind,
     // and with it a left arrow that stays enabled but never returns the row to its start.
-    const scrollUnit = 16 + 10;           // one document box plus the gap after it
-    const widthWhenMeasured = 24 * scrollUnit + 13;
-    const widthNow = 22 * scrollUnit + 13;
+    const docCount = 50;
+    const boxesWhenMeasured = 24;
+    const boxesThatFitNow = 22;
+    // A leftover strip one pixel short of another box, so neither width is an exact multiple of
+    // kScrollUnit and the component has to round down to a whole number of boxes.
+    const partialBoxWidth = kScrollUnit - 1;
+    const widthWhenMeasured = boxesWhenMeasured * kScrollUnit + partialBoxWidth;
+    const widthNow = boxesThatFitNow * kScrollUnit + partialBoxWidth;
     const widthSpy = jest.spyOn(HTMLElement.prototype, "offsetWidth", "get")
       .mockReturnValue(widthWhenMeasured);
     jest.spyOn(HTMLElement.prototype, "clientWidth", "get").mockReturnValue(widthNow);
-    // Enough content to scroll through, so the right arrow is not disabled for want of overflow.
-    jest.spyOn(HTMLElement.prototype, "scrollWidth", "get").mockReturnValue(50 * scrollUnit);
+    // More content than the row can show, so the right arrow is not disabled for want of overflow.
+    jest.spyOn(HTMLElement.prototype, "scrollWidth", "get").mockReturnValue(docCount * kScrollUnit);
     const scrollBy = jest.fn();
     HTMLElement.prototype.scrollBy = scrollBy;
 
-    const documentGroup = createTestDocumentGroup(50);
+    const documentGroup = createTestDocumentGroup(docCount);
     const { getByTestId } = render(
       <DocumentGroupComponent
         documentGroup={documentGroup}
@@ -76,6 +80,6 @@ describe("DocumentGroupComponent", () => {
     widthSpy.mockReturnValue(widthNow);
 
     fireEvent.click(getByTestId("scroll-button-right"));
-    expect(scrollBy).toHaveBeenCalledWith({ left: 22 * scrollUnit, behavior: "smooth" });
+    expect(scrollBy).toHaveBeenCalledWith({ left: boxesThatFitNow * kScrollUnit, behavior: "smooth" });
   });
 });

--- a/src/components/document/document-group.tsx
+++ b/src/components/document/document-group.tsx
@@ -15,11 +15,14 @@ interface IProps {
   onSelectDocument: (document: IDocumentMetadataModel) => void;
 }
 
+// A document box and the gap that follows it, matching the box size and `column-gap` of
+// `.doc-group-list.simple` in document-group.scss. The row scrolls in whole units of this.
+const kDocBoxWidth = 16;
+const kDocBoxGap = 10;
+export const kScrollUnit = kDocBoxWidth + kDocBoxGap;
+
 export const DocumentGroupComponent = observer(function DocumentGroupComponent(props: IProps) {
   const { documentGroup, secondarySort, onSelectDocument } = props;
-  const docBoxWidth = 16;
-  const docBoxGap = 10;
-  const scrollUnit = docBoxWidth + docBoxGap;
   const docCount = documentGroup.documents.length || 0;
   const isUnsorted = secondarySort === "None";
   const docListContainerRef = useRef<HTMLDivElement>(null);
@@ -42,7 +45,7 @@ export const DocumentGroupComponent = observer(function DocumentGroupComponent(p
       // The row's width changes as the scroll buttons take their place beside it, so both directions
       // measure at click time: they have to move by the same amount for the row to reach its start
       // again. Whole boxes only, so a click never leaves one half out of view.
-      const scrollAmount = Math.floor(docListContainer.clientWidth / scrollUnit) * scrollUnit;
+      const scrollAmount = Math.floor(docListContainer.clientWidth / kScrollUnit) * kScrollUnit;
       docListContainer.scrollBy({
         left: direction === "left" ? -scrollAmount : scrollAmount,
         behavior: "smooth"
@@ -80,10 +83,10 @@ export const DocumentGroupComponent = observer(function DocumentGroupComponent(p
   // Calculate the number of visible documents based on the current container width
   useEffect(() => {
     if (docListContainerRef.current) {
-      const count = Math.floor(containerWidth / scrollUnit);
+      const count = Math.floor(containerWidth / kScrollUnit);
       setVisibleCount(count);
     }
-  }, [containerWidth, scrollUnit]);
+  }, [containerWidth]);
 
   // Update arrow button states based on scroll position.
   useEffect(() => {
@@ -104,7 +107,7 @@ export const DocumentGroupComponent = observer(function DocumentGroupComponent(p
         docListContainer.removeEventListener("scroll", updateArrowStates);
       };
     }
-  }, [visibleCount, scrollUnit]);
+  }, [visibleCount]);
 
   const renderScrollButton = (direction: "left" | "right", disabled: boolean) => {
     return (

--- a/src/components/document/document-group.tsx
+++ b/src/components/document/document-group.tsx
@@ -28,18 +28,22 @@ export const DocumentGroupComponent = observer(function DocumentGroupComponent(p
   const [leftArrowDisabled, setLeftArrowDisabled] = useState(true);
   const [rightArrowDisabled, setRightArrowDisabled] = useState(false);
   const sortedGroupDocuments = sortDocumentsInGroup(documentGroup);
-  // Gate on visibleCount > 0: before the ResizeObserver fires, visibleCount is 0
-  // and handleScroll's scrollAmount would be 0 — a silent no-op click. Render the
-  // buttons only once we have a measurement, so a click always actually scrolls.
+  // Gate on visibleCount > 0: before the ResizeObserver fires, the row has no measured width, so
+  // there is nothing to scroll by — a silent no-op click. Render the buttons only once we have a
+  // measurement, so a click always actually scrolls.
   const showScrollButtons = visibleCount > 0 && visibleCount < docCount;
 
   // Each document in the group is represented by a square box. The group of document boxes is displayed in
   // a single row. If there are more boxes than can fit within the row's width, scroll buttons are added
   // to either side of the list so the user can scroll through it.
   const handleScroll = (direction: "left" | "right") => {
-    if (docListContainerRef.current) {
-      const scrollAmount = visibleCount * scrollUnit;
-      docListContainerRef.current.scrollBy({
+    const docListContainer = docListContainerRef.current;
+    if (docListContainer) {
+      // The row's width changes as the scroll buttons take their place beside it, so both directions
+      // measure at click time: they have to move by the same amount for the row to reach its start
+      // again. Whole boxes only, so a click never leaves one half out of view.
+      const scrollAmount = Math.floor(docListContainer.clientWidth / scrollUnit) * scrollUnit;
+      docListContainer.scrollBy({
         left: direction === "left" ? -scrollAmount : scrollAmount,
         behavior: "smooth"
       });

--- a/src/components/thumbnail/simple-document-item.test.tsx
+++ b/src/components/thumbnail/simple-document-item.test.tsx
@@ -50,6 +50,11 @@ describe("SimpleDocumentItem", () => {
     expect(item.getAttribute("aria-label")).toBe(item.getAttribute("title"));
   });
 
+  it("identifies which document it stands for, the same way a thumbnail does", () => {
+    const { item, document } = renderItem();
+    expect(item).toHaveAttribute("data-document-key", document.key);
+  });
+
   it("sets aria-current='true' when the document is selected", () => {
     const { item } = renderItem({ selected: true });
     expect(item).toHaveAttribute("aria-current", "true");

--- a/src/components/thumbnail/simple-document-item.tsx
+++ b/src/components/thumbnail/simple-document-item.tsx
@@ -34,6 +34,7 @@ export const SimpleDocumentItem = observer(function SimpleDocumentItem(
       aria-label={titleWithUser}
       className={classNames("simple-document-item", { selected, private: isPrivate })}
       data-test="simple-document-item"
+      data-document-key={document.key}
       title={titleWithUser}
       type="button"
       onClick={handleClick}


### PR DESCRIPTION
Three Sort Work regression tests decide what to assert from whichever document happens to sit at a
given index across *all* sections at once. That ties them to the order the sections come out in,
which is not what any of them is trying to check — and while investigating that, the scroll
assertions turned up a real bug in the row of document boxes.

Splitting this out ahead of the Sort Work work on CLUE-610, since none of it depends on that: every
change here either keeps the exact document the test was already picking, or removes a dependency on
timing.

### The scroll bug (`document-group.tsx`)

The row of small document boxes narrows when its scroll buttons take their place beside it, and the
`ResizeObserver` measurement that follows arrives a render later. A click in between scrolled by the
width the row *used to* have. Scroll out by the old width and back by the new one and the difference
stays behind — the left arrow remains enabled on a row that can never reach its start again.

Reproducible by hand: switch "Show for" to Investigation and click the right arrow of a long row the
instant it appears, then click left. The row does not return to the start.

The fix measures at click time instead of reusing the last measured `visibleCount`. The new unit test
pins the distance down exactly: with the row measured at 24 boxes wide but only 22 fitting now, it
must scroll 572px, not 624px.

### Identifying a document by key, not by caption (`simple-document-item.tsx`)

The selection-retention test read a document's caption off a thumbnail and compared it with the
`title` of the small item standing for the same document under a different sort. Those two strings
are built by different code — the caption falls back to a teacher name from Firestore, the small item
only looks in the class store — so the comparison holds for documents owned by a class member and
fails on a teacher's document without anything actually being wrong.

The thumbnail already carries `data-document-key`; this gives the small item the same attribute, and
the test compares keys.

### Scoping the tests to the section each one needs

Each of these tests does need a particular section: one reads the long document scroller of
"No Group", another needs a row wide enough to scroll and enough documents to split across name
sub-groups. Two new `SortedWork` helpers scope the existing item lookups to a named section, so the
tests say that rather than relying on an index.

The scroll assertions also read the row while it was still moving (it scrolls with
`behavior: "smooth"`), so a passing "has scrolled" assertion could catch a position the row was only
travelling through, and the following click landed mid-scroll. Those reads now wait until two
consecutive samples agree.

### Verification

Run locally against a dev server on this branch:

- `teacher_sort_work_view_1_spec.js`, `teacher_sort_work_view_3_spec.js`, `teacher_sort_work_view_6_spec.js` — all pass, first attempt, no retries. Spec 3 went from 1:57 to 0:26, the difference being retry churn the scroll fix removed.
- `document-group.test.tsx` and `simple-document-item.test.tsx` — 10 tests pass. The new scroll test fails on the old code with the expected 624 vs 572.
- ESLint clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)