### PR TITLE
Extract AI message builders into shared/ai-analysis-messages.ts

### DIFF
--- a/.github/workflows/functions-v2.yml
+++ b/.github/workflows/functions-v2.yml
@@ -17,13 +17,21 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
-          cache-dependency-path: functions-v2/package-lock.json
+          cache-dependency-path: |
+            functions-v2/package-lock.json
+            shared/package-lock.json
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'
       - name: Install Dependencies
         working-directory: ./functions-v2
+        run: npm ci
+      # ../shared has its own openai and zod so the evaluation harness can import
+      # shared/ai-analysis-messages.ts directly. tsc resolves those from shared/node_modules when it
+      # compiles ../shared into this package, so the build fails without them.
+      - name: Install Shared Dependencies
+        working-directory: ./shared
         run: npm ci
       - name: Lint
         working-directory: ./functions-v2

--- a/functions-v2/README.md
+++ b/functions-v2/README.md
@@ -25,6 +25,7 @@ Here are the basic development operations you can do after you cd into the `func
 $ cd functions-v2
 $ nvm use 20      # Recent version of node is required for these functions
 $ npm install     # install local dependencies
+$ npm --prefix ../shared ci   # ../shared has its own openai/zod; the build needs them
 $ npm run lint    # lint the functions code
 $ npm run test    # runs jest (unit) tests for the functions code (requires emulator, see below)
 $ npm run build   # build the functions code (transpile TypeScript)

--- a/functions-v2/jest.config.js
+++ b/functions-v2/jest.config.js
@@ -11,6 +11,13 @@ module.exports = {
     "^firebase-admin/firestore$": "<rootDir>/node_modules/firebase-admin/lib/firestore",
     "^firebase-admin/app$": "<rootDir>/node_modules/firebase-admin/lib/app",
     "^firebase-admin/database$": "<rootDir>/node_modules/firebase-admin/lib/database",
+    // Same reason, for ../shared/ai-analysis-messages: shared/ has its own openai and zod so the
+    // evaluation harness can import it directly, but the deployed function resolves both from
+    // functions-v2/node_modules. Without these, jest would load two copies of zod and `instanceof`
+    // checks on the built schema (expect.any(ZodEnum) and friends) would fail.
+    "^openai$": "<rootDir>/node_modules/openai",
+    "^openai/(.*)$": "<rootDir>/node_modules/openai/$1",
+    "^zod$": "<rootDir>/node_modules/zod",
   },
   // The tests can't be run in parallel because they are using a shared Firestore and
   // Realtime database.

--- a/functions-v2/lib/src/ai-categorize-document.ts
+++ b/functions-v2/lib/src/ai-categorize-document.ts
@@ -1,8 +1,4 @@
 import OpenAI from "openai";
-import {zodResponseFormat} from "openai/helpers/zod";
-import { AutoParseableResponseFormat } from "openai/lib/parser";
-import { ChatCompletionContentPart, ChatCompletionMessageParam } from "openai/resources/chat/completions";
-import {z} from "zod";
 import fs from "node:fs/promises";
 import * as logger from "firebase-functions/logger";
 import {
@@ -12,138 +8,33 @@ import {
 } from "@google-cloud/firestore";
 import { AiAgreement } from "../../src/on-document-summarized";
 import { AgreementValue } from "../../../shared/shared";
+import {
+  Agreements,
+  RelatedSummary,
+  buildImageMessages,
+  buildSummaryMessages,
+  buildZodResponseSchema,
+  categorizationResponseFormat,
+  defaultAiPrompt
+} from "../../../shared/ai-analysis-messages";
 
-interface IAiPrompt {
-  systemPrompt: string;
-  mainPrompt: string;
-  categorizationDescription?: string;
-  categories?: string[];
-  keyIndicatorsPrompt?: string;
-  discussionPrompt?: string;
-}
-
-interface AgreementInfo {
-  content: string,
-  tags: string[],
-}
-type Agreements = Record<AgreementValue, AgreementInfo[]>
-
-interface RelatedSummary {
-  summary: string;
-  agreements: Agreements;
-}
-
-const defaultAiPrompt: IAiPrompt = {
-  mainPrompt: `This is a picture of a student document.
-They are working on engineering task. Please tell me which of the following areas of their design they are focusing on:
-- user: who's it for?
-- environment: where's it used?
-- form: what's it look like?
-- function: what does it do?
-and why you chose that area.
-Or if the document doesn't include enough content to clearly identify a focus area let me know by setting "category" to "unknown".
-Your answer should be a JSON document in the given format.`,
-  categorizationDescription: "Categorize the document based on its content.",
-  categories: ["user", "environment", "form", "function"],
-  keyIndicatorsPrompt: "What are the key indicators that support this categorization?",
-  discussionPrompt: "Please provide any additional discussion or context regarding the categorization.",
-  systemPrompt: "You are a teaching assistant in an engineering design course."
+// The message and schema builders live in shared/ so this function and the local evaluation
+// harness (scripts/ai-harness) construct identical OpenAI requests. They are re-exported here
+// so existing importers of this module keep working.
+export {
+  buildImageMessages,
+  buildSummaryMessages,
+  buildZodResponseSchema,
+  categorizationResponseFormat,
+  defaultAiPrompt
 };
+export type { AgreementInfo, Agreements, IAiPrompt, RelatedSummary } from "../../../shared/ai-analysis-messages";
 
 export async function categorizeDocument(file: string, apiKey: string) {
   const imageLoading = fs.readFile(file).then((data) => data.toString("base64"));
   const image = await imageLoading;
   const url = `data:image/png;base64,${image}`;
   return categorizeUrl(url, apiKey);
-}
-
-// openai v6's zodResponseFormat infers the parsed type through a zod v3/v4
-// conditional that recurses infinitely (TS2589) on a dynamically-built schema,
-// so the inference is bypassed and the parsed shape stated directly.
-function categorizationResponseFormat(
-  responseSchema: Record<string, z.ZodType>
-): AutoParseableResponseFormat<Record<string, any>> {
-  return zodResponseFormat(z.object(responseSchema) as never, "categorization-response");
-}
-
-export function buildZodResponseSchema(aiPrompt: IAiPrompt) {
-  const schema: Record<string, z.ZodType> = {};
-  if (aiPrompt.categorizationDescription && aiPrompt.categories && aiPrompt.categories.length > 0) {
-    schema.category = z.enum(["unknown", ...aiPrompt.categories!],
-      {description: aiPrompt.categorizationDescription});
-  }
-  if (aiPrompt.keyIndicatorsPrompt) {
-    schema.keyIndicators = z.array(z.string(), {description: aiPrompt.keyIndicatorsPrompt});
-  }
-  if (aiPrompt.discussionPrompt) {
-    schema.discussion = z.string({description: aiPrompt.discussionPrompt});
-  }
-  return schema;
-}
-
-export function buildImageMessages(aiPrompt: IAiPrompt, url: string): ChatCompletionMessageParam[] {
-  return [
-    {
-      role: "system",
-      content: aiPrompt.systemPrompt,
-    },
-    {
-      role: "user",
-      content: [
-        {
-          type: "text",
-          text: aiPrompt.mainPrompt,
-        },
-        {
-          type: "image_url",
-          image_url: {
-            url,
-            detail: "auto", // auto, low, high
-          },
-        },
-      ],
-    },
-  ];
-}
-
-export function buildSummaryMessages(aiPrompt: IAiPrompt, summary: string, relatedSummaries: RelatedSummary[]): ChatCompletionMessageParam[] {
-  const userContent: ChatCompletionContentPart[] = [
-    {
-      type: "text",
-      text: aiPrompt.mainPrompt,
-    },
-    {
-      type: "text",
-      text: `This is the AI generated summary:\n${summary}`,
-    },
-  ];
-
-  if (relatedSummaries.length > 0) {
-    relatedSummaries.forEach((related) => {
-      let text = `This is AI generated summary of a similar document:\n${related.summary}`;
-      const agreementCounts = Object.entries(related.agreements)
-        .map(([value, info]) => `${value}: ${info.length}`)
-        .join(", ");
-      if (agreementCounts.length > 0) {
-        text += `\n\nOther users agreed with this summary as follows: ${agreementCounts}`;
-      }
-      userContent.push({
-        type: "text",
-        text,
-      });
-    });
-  }
-
-  return [
-    {
-      role: "system",
-      content: aiPrompt.systemPrompt,
-    },
-    {
-      role: "user",
-      content: userContent,
-    },
-  ];
 }
 
 export async function categorizeUrl(url: string, apiKey: string, aiPrompt = defaultAiPrompt) {

--- a/functions-v2/test/ai-analysis-messages-integration.test.ts
+++ b/functions-v2/test/ai-analysis-messages-integration.test.ts
@@ -1,0 +1,84 @@
+// This file stays in functions-v2 (rather than next to shared/ai-analysis-messages.ts, where the
+// builder-behavior tests live) because it checks the cross-package seam: that the shared module still
+// re-exports through ai-categorize-document.ts and still runs against functions-v2's own installed
+// openai and zod, which is what the deployed function resolves.
+import {ZodArray, ZodEnum, ZodString} from "zod";
+import {
+  IAiPrompt,
+  buildImageMessages,
+  buildSummaryMessages,
+  buildZodResponseSchema,
+  categorizationResponseFormat,
+  defaultAiPrompt,
+} from "../../shared/ai-analysis-messages";
+import * as categorizeDocumentModule from "../lib/src/ai-categorize-document";
+
+const fullPrompt: IAiPrompt = {
+  systemPrompt: "You are a master teacher.",
+  mainPrompt: "Evaluate and categorize this.",
+  categorizationDescription: "Categorize the document based on its content.",
+  categories: ["category1", "category2"],
+  keyIndicatorsPrompt: "Key indicators.",
+  discussionPrompt: "Discussion.",
+};
+
+const emptySchemaPrompt: IAiPrompt = {
+  systemPrompt: "You are a master teacher.",
+  mainPrompt: "Evaluate this.",
+};
+
+describe("shared/ai-analysis-messages in functions-v2", () => {
+  describe("running against functions-v2's installed openai and zod", () => {
+    test("the builders and categorizationResponseFormat produce a usable request", () => {
+      // zod types imported here come from functions-v2/node_modules; the builders use whichever copy
+      // resolves for shared/. These instanceof checks fail if the two ever drift apart.
+      const responseSchema = buildZodResponseSchema(fullPrompt);
+      expect(responseSchema).toEqual({
+        category: expect.any(ZodEnum),
+        discussion: expect.any(ZodString),
+        keyIndicators: expect.any(ZodArray),
+      });
+
+      const responseFormat = categorizationResponseFormat(responseSchema);
+      expect(responseFormat.type).toBe("json_schema");
+      expect(responseFormat.json_schema.name).toBe("categorization-response");
+      expect((responseFormat as any).$brand).toBe("auto-parseable-response-format");
+      expect(typeof responseFormat.$parseRaw).toBe("function");
+
+      const jsonSchema = responseFormat.json_schema.schema as any;
+      expect(Object.keys(jsonSchema.properties).sort())
+        .toEqual(["category", "discussion", "keyIndicators"]);
+      expect(jsonSchema.properties.category.enum)
+        .toEqual(["unknown", "category1", "category2"]);
+
+      expect(buildImageMessages(fullPrompt, "https://example.com/image.png")).toHaveLength(2);
+      expect(buildSummaryMessages(fullPrompt, "A summary.", [])).toHaveLength(2);
+    });
+  });
+
+  describe("re-exports from ai-categorize-document", () => {
+    test("exposes the same builder functions the shared module defines", () => {
+      expect(categorizeDocumentModule.buildZodResponseSchema).toBe(buildZodResponseSchema);
+      expect(categorizeDocumentModule.buildImageMessages).toBe(buildImageMessages);
+      expect(categorizeDocumentModule.buildSummaryMessages).toBe(buildSummaryMessages);
+      expect(categorizeDocumentModule.categorizationResponseFormat).toBe(categorizationResponseFormat);
+      expect(categorizeDocumentModule.defaultAiPrompt).toBe(defaultAiPrompt);
+    });
+  });
+
+  describe("caller behavior is preserved", () => {
+    // categorizeUrl throws when the prompt yields an empty schema, catches its own error,
+    // and resolves to undefined. Nothing is sent to OpenAI, so this needs no network.
+    test("categorizeUrl gives up on a prompt with no schema fields", async () => {
+      const consoleLog = jest.spyOn(console, "log").mockImplementation(() => undefined);
+      try {
+        const result = await categorizeDocumentModule.categorizeUrl(
+          "https://example.com/image.png", "not-a-real-key", emptySchemaPrompt);
+        expect(result).toBeUndefined();
+        expect(consoleLog).toHaveBeenCalledWith("OpenAI error", expect.any(Error));
+      } finally {
+        consoleLog.mockRestore();
+      }
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "lint:unused": "tsc --noUnusedLocals --project .",
     "migrate": "node ./migrations/migrate",
     "migrate:debug": "node --inspect-brk ./migrations/migrate",
-    "postinstall": "patch-package",
+    "postinstall": "patch-package && npm ci --prefix shared",
     "serve": "npx serve -c ../serve.json -l 8080 dist",
     "start": "webpack-dev-server --hot",
     "start:secure": "webpack-dev-server --server-type https --hot --server-options-cert ~/.localhost-ssl/localhost.pem --server-options-key ~/.localhost-ssl/localhost.key",

--- a/shared/ai-analysis-messages.test.ts
+++ b/shared/ai-analysis-messages.test.ts
@@ -1,0 +1,157 @@
+import { ZodArray, ZodEnum, ZodString } from "zod";
+import {
+  Agreements, IAiPrompt, RelatedSummary, buildImageMessages, buildSummaryMessages, buildZodResponseSchema,
+  defaultAiPrompt
+} from "./ai-analysis-messages";
+
+const fullPrompt: IAiPrompt = {
+  systemPrompt: "You are a master teacher.",
+  mainPrompt: "Evaluate and categorize this.",
+  categorizationDescription: "Categorize the document based on its content.",
+  categories: ["category1", "category2"],
+  keyIndicatorsPrompt: "Key indicators.",
+  discussionPrompt: "Discussion."
+};
+
+const discussionOnlyPrompt: IAiPrompt = {
+  systemPrompt: "You are a master teacher.",
+  mainPrompt: "Evaluate this.",
+  discussionPrompt: "Discussion."
+};
+
+const emptySchemaPrompt: IAiPrompt = {
+  systemPrompt: "You are a master teacher.",
+  mainPrompt: "Evaluate this."
+};
+
+function makeRelatedSummary(summary: string, agreements: Partial<Agreements>): RelatedSummary {
+  return { summary, agreements: agreements as Agreements };
+}
+
+describe("ai-analysis-messages", () => {
+  describe("buildZodResponseSchema", () => {
+    it("builds every field from a full prompt", () => {
+      expect(buildZodResponseSchema(fullPrompt)).toEqual({
+        category: expect.any(ZodEnum),
+        discussion: expect.any(ZodString),
+        keyIndicators: expect.any(ZodArray)
+      });
+    });
+
+    it("builds only the discussion field from a discussion-only prompt", () => {
+      expect(buildZodResponseSchema(discussionOnlyPrompt)).toEqual({
+        discussion: expect.any(ZodString)
+      });
+    });
+
+    it("builds an empty schema when the prompt has no schema fields", () => {
+      expect(buildZodResponseSchema(emptySchemaPrompt)).toEqual({});
+    });
+  });
+
+  describe("buildImageMessages", () => {
+    it("creates a system message and a user message with text and image parts", () => {
+      expect(buildImageMessages(fullPrompt, "https://example.com/image.png")).toEqual([
+        {
+          role: "system",
+          content: "You are a master teacher."
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: "Evaluate and categorize this."
+            },
+            {
+              type: "image_url",
+              image_url: {
+                url: "https://example.com/image.png",
+                detail: "auto"
+              }
+            }
+          ]
+        }
+      ]);
+    });
+  });
+
+  describe("buildSummaryMessages", () => {
+    it("creates prompt and summary parts when there are no related summaries", () => {
+      expect(buildSummaryMessages(fullPrompt, "The student drew a box.", [])).toEqual([
+        {
+          role: "system",
+          content: "You are a master teacher."
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: "Evaluate and categorize this."
+            },
+            {
+              type: "text",
+              text: "This is the AI generated summary:\nThe student drew a box."
+            }
+          ]
+        }
+      ]);
+    });
+
+    it("appends one part per related summary, with its agreement counts", () => {
+      const related = [
+        makeRelatedSummary("First related summary.", {
+          yes: [{ content: "Agreed.", tags: ["form"] }, { content: "Also agreed.", tags: [] }],
+          no: [{ content: "Disagreed.", tags: [] }]
+        })
+      ];
+
+      const messages = buildSummaryMessages(fullPrompt, "The student drew a box.", related);
+      const userContent = messages[1].content as any[];
+
+      expect(userContent).toHaveLength(3);
+      expect(userContent[2]).toEqual({
+        type: "text",
+        text: "This is AI generated summary of a similar document:\nFirst related summary." +
+          "\n\nOther users agreed with this summary as follows: yes: 2, no: 1"
+      });
+    });
+
+    it("appends a part for each of two related summaries", () => {
+      const related = [
+        makeRelatedSummary("First related summary.", { yes: [{ content: "Agreed.", tags: [] }] }),
+        makeRelatedSummary("Second related summary.", { notSure: [{ content: "Unsure.", tags: [] }] })
+      ];
+
+      const messages = buildSummaryMessages(fullPrompt, "The student drew a box.", related);
+      const userContent = messages[1].content as any[];
+
+      expect(userContent).toHaveLength(4);
+      expect(userContent[2].text).toContain("First related summary.");
+      expect(userContent[2].text).toContain("yes: 1");
+      expect(userContent[3].text).toContain("Second related summary.");
+      expect(userContent[3].text).toContain("notSure: 1");
+    });
+
+    it("omits the agreement sentence when a related summary has no agreements", () => {
+      const related = [makeRelatedSummary("First related summary.", {})];
+
+      const messages = buildSummaryMessages(fullPrompt, "The student drew a box.", related);
+      const userContent = messages[1].content as any[];
+
+      expect(userContent[2]).toEqual({
+        type: "text",
+        text: "This is AI generated summary of a similar document:\nFirst related summary."
+      });
+    });
+  });
+
+  describe("defaultAiPrompt", () => {
+    it("still asks for the four design categories", () => {
+      expect(defaultAiPrompt.categories).toEqual(["user", "environment", "form", "function"]);
+      expect(defaultAiPrompt.systemPrompt)
+        .toBe("You are a teaching assistant in an engineering design course.");
+    });
+  });
+});

--- a/shared/ai-analysis-messages.ts
+++ b/shared/ai-analysis-messages.ts
@@ -14,10 +14,10 @@ export interface IAiPrompt {
 }
 
 export interface AgreementInfo {
-  content: string,
-  tags: string[],
+  content: string;
+  tags: string[];
 }
-export type Agreements = Record<AgreementValue, AgreementInfo[]>
+export type Agreements = Record<AgreementValue, AgreementInfo[]>;
 
 export interface RelatedSummary {
   summary: string;

--- a/shared/ai-analysis-messages.ts
+++ b/shared/ai-analysis-messages.ts
@@ -1,0 +1,131 @@
+import {zodResponseFormat} from "openai/helpers/zod";
+import { AutoParseableResponseFormat } from "openai/lib/parser";
+import { ChatCompletionContentPart, ChatCompletionMessageParam } from "openai/resources/chat/completions";
+import {z} from "zod";
+import { AgreementValue } from "./shared";
+
+export interface IAiPrompt {
+  systemPrompt: string;
+  mainPrompt: string;
+  categorizationDescription?: string;
+  categories?: string[];
+  keyIndicatorsPrompt?: string;
+  discussionPrompt?: string;
+}
+
+export interface AgreementInfo {
+  content: string,
+  tags: string[],
+}
+export type Agreements = Record<AgreementValue, AgreementInfo[]>
+
+export interface RelatedSummary {
+  summary: string;
+  agreements: Agreements;
+}
+
+export const defaultAiPrompt: IAiPrompt = {
+  mainPrompt: `This is a picture of a student document.
+They are working on engineering task. Please tell me which of the following areas of their design they are focusing on:
+- user: who's it for?
+- environment: where's it used?
+- form: what's it look like?
+- function: what does it do?
+and why you chose that area.
+Or if the document doesn't include enough content to clearly identify a focus area let me know by setting "category" to "unknown".
+Your answer should be a JSON document in the given format.`,
+  categorizationDescription: "Categorize the document based on its content.",
+  categories: ["user", "environment", "form", "function"],
+  keyIndicatorsPrompt: "What are the key indicators that support this categorization?",
+  discussionPrompt: "Please provide any additional discussion or context regarding the categorization.",
+  systemPrompt: "You are a teaching assistant in an engineering design course."
+};
+
+// openai v6's zodResponseFormat infers the parsed type through a zod v3/v4
+// conditional that recurses infinitely (TS2589) on a dynamically-built schema,
+// so the inference is bypassed and the parsed shape stated directly.
+export function categorizationResponseFormat(
+  responseSchema: Record<string, z.ZodType>
+): AutoParseableResponseFormat<Record<string, any>> {
+  return zodResponseFormat(z.object(responseSchema) as never, "categorization-response");
+}
+
+export function buildZodResponseSchema(aiPrompt: IAiPrompt) {
+  const schema: Record<string, z.ZodType> = {};
+  if (aiPrompt.categorizationDescription && aiPrompt.categories && aiPrompt.categories.length > 0) {
+    schema.category = z.enum(["unknown", ...aiPrompt.categories!],
+      {description: aiPrompt.categorizationDescription});
+  }
+  if (aiPrompt.keyIndicatorsPrompt) {
+    schema.keyIndicators = z.array(z.string(), {description: aiPrompt.keyIndicatorsPrompt});
+  }
+  if (aiPrompt.discussionPrompt) {
+    schema.discussion = z.string({description: aiPrompt.discussionPrompt});
+  }
+  return schema;
+}
+
+export function buildImageMessages(aiPrompt: IAiPrompt, url: string): ChatCompletionMessageParam[] {
+  return [
+    {
+      role: "system",
+      content: aiPrompt.systemPrompt,
+    },
+    {
+      role: "user",
+      content: [
+        {
+          type: "text",
+          text: aiPrompt.mainPrompt,
+        },
+        {
+          type: "image_url",
+          image_url: {
+            url,
+            detail: "auto", // auto, low, high
+          },
+        },
+      ],
+    },
+  ];
+}
+
+export function buildSummaryMessages(aiPrompt: IAiPrompt, summary: string, relatedSummaries: RelatedSummary[]): ChatCompletionMessageParam[] {
+  const userContent: ChatCompletionContentPart[] = [
+    {
+      type: "text",
+      text: aiPrompt.mainPrompt,
+    },
+    {
+      type: "text",
+      text: `This is the AI generated summary:\n${summary}`,
+    },
+  ];
+
+  if (relatedSummaries.length > 0) {
+    relatedSummaries.forEach((related) => {
+      let text = `This is AI generated summary of a similar document:\n${related.summary}`;
+      const agreementCounts = Object.entries(related.agreements)
+        .map(([value, info]) => `${value}: ${info.length}`)
+        .join(", ");
+      if (agreementCounts.length > 0) {
+        text += `\n\nOther users agreed with this summary as follows: ${agreementCounts}`;
+      }
+      userContent.push({
+        type: "text",
+        text,
+      });
+    });
+  }
+
+  return [
+    {
+      role: "system",
+      content: aiPrompt.systemPrompt,
+    },
+    {
+      role: "user",
+      content: userContent,
+    },
+  ];
+}

--- a/shared/package-lock.json
+++ b/shared/package-lock.json
@@ -1,0 +1,53 @@
+{
+  "name": "clue-shared",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "clue-shared",
+      "dependencies": {
+        "openai": "6.45.0",
+        "zod": "3.25.76"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.45.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.45.0.tgz",
+      "integrity": "sha512-5DQVNErssk0afNpTTHUm/qZPU4iKR9OYdNid8Ib4puq4gHNNvGWZht2zY4h9a8JMF949Ik6m8gQutllVPbjdnw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-node": ">=3.972.0 <4",
+        "@smithy/hash-node": ">=4.3.0 <5",
+        "@smithy/signature-v4": ">=5.4.0 <6",
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-node": {
+          "optional": true
+        },
+        "@smithy/hash-node": {
+          "optional": true
+        },
+        "@smithy/signature-v4": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,1 +1,9 @@
-{"type": "module"}
+{
+  "type": "module",
+  "name": "clue-shared",
+  "private": true,
+  "dependencies": {
+    "openai": "6.45.0",
+    "zod": "3.25.76"
+  }
+}


### PR DESCRIPTION
[CLUE-371](https://concord-consortium.atlassian.net/browse/CLUE-371)

Production and the CLUE-371 evaluation harness need to build identical OpenAI requests, so the pure message/schema builders move out of `functions-v2/lib/src/ai-categorize-document.ts` (which also imports firebase-functions and Firestore) into `shared/`. (See [CLUE-371-harness-plan.md](https://github.com/concord-consortium/collaborative-learning/blob/6c4593d265e54e698e51be759a270391ef40c1ec/docs/plans/CLUE-371-harness-plan.md) for more context.)

The move is mechanical: `IAiPrompt`, `defaultAiPrompt` and `categorizationResponseFormat` gain export keywords, the `AgreementValue` import becomes relative, and `ai-categorize-document.ts` re-exports every moved symbol so existing importers are unchanged.

`shared/` gets its own pinned openai and zod so the harness can import the module in place; the root `node_modules` has neither. `functions-v2`'s jest config maps openai and zod to `functions-v2`'s copies, the same way it already maps firebase-admin. That matches deployment (`shared/node_modules` is not deployed) and keeps instanceof-based assertions such as `expect.any(ZodEnum)` working across the two installs.

The tests are split the way the repo splits tests. Builder behavior lives next to the builders in `shared/ai-analysis-messages.test.ts`, picked up by the root package's jest. `functions-v2/test/ai-analysis-messages-integration.test.ts` keeps only what is specific to that package: the re-exports, the caller behavior, and one case running the builders and `categorizationResponseFormat` against `functions-v2`'s own openai and zod.

[CLUE-371]: https://concord-consortium.atlassian.net/browse/CLUE-371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ