### PR TITLE
feat: AI evaluation harness milestone 1 (CLUE-371)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,8 @@ jobs:
           cache-dependency-path: |
             package-lock.json
             authoring-api/package-lock.json
+            shared/package-lock.json
+            scripts/ai-harness/package-lock.json
       - name: Install Dependencies
         run: npm ci --fetch-retries=5 --fetch-retry-maxtimeout=120000
       - name: Install Authoring API Dependencies
@@ -52,6 +54,17 @@ jobs:
       - name: Run Authoring API Tests
         working-directory: ./authoring-api
         run: npm test
+      # The harness is a dev-only tool, but several of its tests are tripwires on production code:
+      # they fail when a new tile type is registered without a capability record, when the committed
+      # copy of the default AI prompt drifts from shared/, when openai/zod versions fall out of
+      # lockstep, or when a tile summarizer stops carrying content. Nobody changing that code would
+      # think to run these by hand, so they run on every PR rather than behind a path filter.
+      - name: Install AI Harness Dependencies
+        working-directory: ./scripts/ai-harness
+        run: npm ci
+      - name: Run AI Harness Tests
+        working-directory: ./scripts/ai-harness
+        run: npm run typecheck && npm test
       - name: Cache Jest cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       # (`npm ci --prefix shared`) during "Install Dependencies" above.
       - name: Install AI Harness Dependencies
         working-directory: ./scripts/ai-harness
-        run: npm ci
+        run: npm ci --fetch-retries=5 --fetch-retry-maxtimeout=120000
       - name: Run AI Harness Tests
         working-directory: ./scripts/ai-harness
         run: npm run typecheck && npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,9 @@ jobs:
       # copy of the default AI prompt drifts from shared/, when openai/zod versions fall out of
       # lockstep, or when a tile summarizer stops carrying content. Nobody changing that code would
       # think to run these by hand, so they run on every PR rather than behind a path filter.
+      # ../../shared's own openai and zod, which the harness imports through
+      # shared/ai-analysis-messages.ts, are installed by the root package's postinstall
+      # (`npm ci --prefix shared`) during "Install Dependencies" above.
       - name: Install AI Harness Dependencies
         working-directory: ./scripts/ai-harness
         run: npm ci

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ docs/drafts
 src/public/ai/dataset*
 src/public/ai/screenshotDataset*
 
+# Everything the AI evaluation harness derives from documents
+scripts/ai-harness/data/
+
 # VSCode project settings
 .vscode/*
 !.vscode/launch.json

--- a/docs/plans/CLUE-371-harness-implementation-1.md
+++ b/docs/plans/CLUE-371-harness-implementation-1.md
@@ -1,0 +1,292 @@
+# CLUE-371 Harness — Milestone 1 Implementation
+
+Status: implementation spec for milestone 1 of [CLUE-371-harness-plan.md](./CLUE-371-harness-plan.md). Written to be handed to a coding agent or developer as a self-contained work order. Revision 4 — revision 2 addressed an external (Codex) review (see "Review disposition" at the end); revision 3 is an editorial consistency pass; revision 4 splits A4's tests across two files.
+Scope: shared message-builder extraction, harness skeleton, synthetic corpus, text-only runs, cache, spend ceiling, reports as data (no HTML). Nothing else — see "Out of scope" at the end.
+Branching: this is spike work — milestone branches PR into the long-running `CLUE-371` integration branch, not `master`. See "Branch and review strategy" in the harness plan.
+
+## Why this shape (one paragraph of context)
+
+The harness compares text vs. image vs. text+image representations of student documents by running them through the same AI call production makes. Milestone 1 builds the frame: the pieces that assemble AI requests get moved to `shared/` so production and the harness use identical code, and the harness gets a working end-to-end path for text-only runs against a small committed corpus of synthetic documents. Images, mixed mode, and production data come in later milestones.
+
+## Canonical serialization (used everywhere; define once)
+
+Several features hash JSON values (cache keys, prompt provenance, experiment hashes, resume identity). Define one function in `src/schemas.ts` — `canonicalJson(value)`: recursively sort object keys, no whitespace, UTF-8 — and one `sha256Canonical(value)` helper. Every hash in this document means `sha256Canonical` unless it says "file bytes."
+
+## Part A — extract the shared message builders (a production refactor)
+
+**A1. Dependency layout — resolve this first, it gates everything.** `shared/ai-analysis-messages.ts` imports `zod` and `openai` (the `zodResponseFormat` helper is a runtime import; the message-param types are type-only). Node resolves bare imports upward from the *imported file's* directory — `shared/` → repo root — and the root `node_modules` contains neither `openai` nor `zod`. So the harness, importing the shared file in place via `tsx`, would fail to resolve them; it works from `functions-v2` today only because that package compiles shared source into its own tree. The fix: **give `shared/` its own dependencies.** Extend `shared/package.json` (currently just `{"type": "module"}`):
+
+```json
+{
+  "type": "module",
+  "name": "clue-shared",
+  "private": true,
+  "dependencies": {
+    "openai": "<exact version from functions-v2/package-lock.json>",
+    "zod": "<exact version from functions-v2/package-lock.json>"
+  }
+}
+```
+
+Run `npm install` in `shared/` and commit the lockfile. Exact versions, not ranges: `shared/node_modules` is what the harness resolves at runtime, while deployed functions resolve `functions-v2/node_modules` — behavior parity requires the versions to be identical. A lockstep test (implemented in the harness test suite; acceptance criterion 3) reads all three lockfiles — `shared/`, `functions-v2/`, `scripts/ai-harness/` — and asserts the resolved `openai` and `zod` versions match, so they can't drift silently. `functions-v2`'s compile picks up `shared/node_modules` types (nearest-first resolution) — same versions, so no conflict; if `tsc` surfaces duplicate-type issues, resolve with the same alias approach its tsconfig already uses for `firebase-admin`, not by restructuring.
+
+**A2. The move.** New file `shared/ai-analysis-messages.ts` containing, from `functions-v2/lib/src/ai-categorize-document.ts`:
+
+- Types: `IAiPrompt`, `AgreementInfo`, `Agreements`, `RelatedSummary`
+- Data: `defaultAiPrompt`
+- Functions: `buildZodResponseSchema`, `categorizationResponseFormat`, `buildImageMessages`, `buildSummaryMessages`
+
+Note: `IAiPrompt`, `defaultAiPrompt`, and `categorizationResponseFormat` are **not currently exported** — the move adds `export` to them; that is the only intended change beyond relocation (the `AgreementValue` import becomes `./shared`). No `firebase-functions`, no Firestore, no logging in this file — that's the point of it. (`buildMixedMessages` joins in milestone 3.)
+
+**A3. The caller.** `ai-categorize-document.ts` imports the moved symbols from `../../../shared/ai-analysis-messages` and re-exports them, so existing imports (e.g. `functions-v2/test/on-analysis-document-imaged.test.ts`) keep working unedited. The diff to this file is deletions plus import/re-export lines only.
+
+**A4. Tests — two files, split by what each one is actually testing.** The repo colocates tests with the code they test, so the builder tests belong next to the builders. What cannot move is the check that the module still works through `functions-v2`'s *own* dependency installs, because those are what the deployed function resolves.
+
+New `shared/ai-analysis-messages.test.ts` (colocated; run by the **root** package's jest, whose `testRegex` already picks up `shared/*.test.ts` the same way it picks up the `ai-summarizer` tests) — pure builder behavior:
+
+- Schema from a full `aiPrompt`, vs. one with only `discussionPrompt`, vs. one with no schema fields at all.
+- `buildImageMessages` message shape (system + user with a text part and an `image_url` part).
+- `buildSummaryMessages` with zero, one and two related summaries, including the agreement-count sentence and its absence when a related summary has no agreements.
+- `defaultAiPrompt` still asks for the four design categories.
+
+New `functions-v2/test/ai-analysis-messages-integration.test.ts` — only what is specific to `functions-v2`, with a comment at the top of the file saying why it lives there so nobody relocates it later:
+
+- One case proving the builders and `categorizationResponseFormat` execute correctly against `functions-v2`'s installed `openai` and `zod` copies — the ones the deployed function resolves. (Note that its `instanceof` assertions cannot detect a version drift between `shared/node_modules` and `functions-v2/node_modules`: the jest `moduleNameMapper` deliberately gives every importer one copy of zod. Drift is the lockstep test's job, A1.)
+- Re-export check: the symbols are importable from `ai-categorize-document.ts` exactly as before.
+- Caller behavior preserved: a prompt with no schema fields still makes the categorize call give up (it throws internally, logs, and resolves to `undefined`).
+
+**A5. Cross-package load test (harness side, part of Part B's suite):** import `shared/ai-analysis-messages.ts` from a harness test, call each builder, and assert the module graph contains no `firebase-functions` or `@google-cloud/firestore` module afterward. (The version-lockstep test from A1 also lives in the harness suite.)
+
+**Acceptance for Part A:** `npm run build` and `npm test` in `functions-v2` pass with no changes to existing test expectations, and the root `npm test` passes the new colocated `shared/` test. The root jest must resolve `openai` and `zod` from `shared/node_modules` unaided — neither the root jest config nor `src/test/jest-resolver.js` may be changed to force it.
+
+**Explicit non-goal:** do not touch `findRelatedSummaries` in this PR. The one-word bug fix (spike finding 6a) plus its unit test is a separate, small PR.
+
+## Part B — the harness skeleton
+
+### Directory layout
+
+```
+scripts/ai-harness/
+  package.json / package-lock.json
+  tsconfig.json
+  jest.config.js
+  README.md
+  harness.ts                    # CLI entry: parses argv, dispatches to commands
+  src/
+    schemas.ts                  # types + runtime validators + canonicalJson/sha256Canonical
+    corpus.ts                   # import command, manifest read/write
+    capability.ts               # tile capability registry + document classification
+    represent-text.ts           # text representation variants (wraps shared/ai-summarizer)
+    messages.ts                 # builds requests via shared/ai-analysis-messages
+    cache.ts                    # response cache
+    cost.ts                     # pricing config, estimation, reservation ledger
+    execute.ts                  # OpenAI calls, concurrency, retries, JSONL writer
+    report.ts                   # summary tables from result JSONL
+    pricing.json
+  prompts/
+    categorize-design-default.json
+  experiments/
+    text-baselines.json
+  examples/
+    synthetic-corpus/
+      expectations.json         # per-fixture expected behavior (see Fixtures)
+      documents/<one per tile type>.json
+      # note: no manifest.json here — manifests are generated by `import`; tests
+      # and the smoke test import these documents into data/corpus/ first
+  test/
+  data/                         # created at runtime; NEVER committed
+```
+
+Add to the **root** `.gitignore`: `scripts/ai-harness/data/`.
+
+Also new in `shared/`: `shared/tile-types.ts` (see Capability registry).
+
+### Dependencies and toolchain — exact, locked, verified
+
+Own `package.json`, `"type": "module"`:
+
+- dependencies: `openai` and `zod` at the **exact same versions as `shared/`** (the lockstep test covers all three packages), `dotenv`.
+- devDependencies: `tsx`, `typescript` `~5.9.2` (matching `functions-v2`), `jest` 29, `ts-jest` 29, `@types/jest`, `@types/node`.
+- scripts: `"test"`, `"typecheck": "tsc --noEmit"`.
+- Commit `package-lock.json`; acceptance uses `npm ci`, never bare `npm install`.
+
+**ESM + Jest configuration, spelled out** (this combination is a known time sink; do it this way):
+
+- `tsconfig.json`: `module: "nodenext"`, `moduleResolution: "nodenext"`, `strict: true`, `target: "es2022"`; include `harness.ts`, `src`, and `test`. The `../../shared/*.ts` imports pull shared sources into the compilation automatically; if tsc objects to files outside the project directory, mirror how `functions-v2/tsconfig.json` already handles compiling `../shared` (it's the same situation) rather than inventing a new arrangement. `npm run typecheck` must cover the shared files the harness imports.
+- Relative imports in harness source use **`.js` suffixes** (NodeNext requirement), e.g. `import { classify } from "./capability.js"`.
+- `jest.config.js`: `preset: "ts-jest/presets/default-esm"`, `extensionsToTreatAsEsm: [".ts"]`, `moduleNameMapper: { "^(\\.{1,2}/.*)\\.js$": "$1" }`, transform configured with `useESM: true`; test script runs with `NODE_OPTIONS=--experimental-vm-modules`.
+- CLI runs via `npx tsx harness.ts …` (tsx handles ESM + TS + the `.js`-suffix convention natively).
+- Acceptance requires `npm run typecheck` to pass, not only jest — jest's transform can mask type errors that would break the CLI at runtime.
+
+The OpenAI key is read from `scripts/.env` (`OPENAI_API_KEY=…`) or the environment. `firebase-admin` is *not* a milestone-1 dependency.
+
+CLI parsing: plain `process.argv`; flags are `--name value` pairs; unknown flags are errors.
+
+### Capability registry and document classification (`capability.ts` + `shared/tile-types.ts`)
+
+**The authoritative tile-type list** is a new, import-safe module — `shared/tile-types.ts` — exporting a readonly string array of every tile type CLUE registers. It must include the full set from `src/register-tile-types.ts` **plus** the statically-registered `"Placeholder"` and `"Unknown"`: Question, AI, BarGraph, DataCard, Dataflow, Diagram, Drawing, ErrorTest, Expression, Geometry, Graph, Image, IframeInteractive, Numberline, Simulator, Starter, Table, Text, Timeline, WaveRunner, Placeholder, Unknown. (Verify against the file when implementing; this list is from an audit, the file is the truth.) Do **not** import `src/register-tile-types.ts` from the harness — it drags in client-side loading utilities and its registry object isn't exported.
+
+**The sync tripwire:** a harness test reads `src/register-tile-types.ts` *as text*, extracts the quoted keys of the registration object with a regex, and asserts the extracted set plus `{Placeholder, Unknown}` equals the `shared/tile-types.ts` list. New tile registrations then fail this test until both the list and the capability registry are updated. (Migrating `register-tile-types.ts` to consume the shared list is a nice later refactor; out of scope here.)
+
+**Per-tile capability record** — three properties, because they answer different questions:
+
+```ts
+interface TileRepresentationCapability {
+  containsStudentText: boolean;            // can students author text content in this tile type?
+  summaryFidelity: "full" | "partial" | "stub" | "fallback";  // how well the CURRENT text summarizer carries it
+  requiresVisualRepresentation: boolean;   // does an image add information text can't carry?
+}
+```
+
+Seed values (verify judgment calls in review):
+
+| Tile types | containsStudentText | summaryFidelity | requiresVisualRepresentation |
+|---|---|---|---|
+| Text | true | full | false |
+| Table | true | full | false |
+| Dataflow | true | full | true |
+| Graph | false | full | true |
+| Simulator | false | partial | true |
+| Question | false — children classify individually (see traversal below) | partial | false — children decide |
+| Drawing | true (text labels) | stub | true |
+| Image | false | stub | true |
+| Geometry, Diagram, BarGraph, DataCard, Numberline, Expression, Timeline, WaveRunner | false (known simplification — several of these can hold typed text, e.g. DataCard fields; instance-level checks may upgrade them in M3, and any deviation found while authoring fixtures gets recorded in `expectations.json`) | fallback | true |
+| AI, ErrorTest, Starter, IframeInteractive | false | fallback | true |
+| Placeholder | false | full (empty) | false |
+| **Unknown / unlisted** | **false** | **fallback** | **true** |
+
+Unknown types are conservatively visual so nothing silently drops.
+
+**Instance-level refinement:** type-level flags say what a tile *can* contain; classification of a real document also checks what it *does* contain. Milestone 1 implements two instance checks: a Text tile counts as text only if its content is non-empty after trimming, and a Drawing tile counts as containing student text only if it has text objects with content. Other instance checks can come later.
+
+**Question traversal:** Question tiles hold their children in a nested `rowOrder`/`rowMap` inside their content, with tile ids resolving through the *document's* top-level `tileMap` — iterate them the way `handleQuestionTile()` in `shared/ai-summarizer/ai-tile-summarizer.ts` does (first row = authored prompt, remaining rows = student response). Rules: the authored prompt does **not** count as student text; response tiles classify individually by their own types; missing tile references are skipped with a recorded warning; a tile referenced twice counts once; nested Questions recurse with a depth cap (8) against cycles. Unit-test each rule.
+
+**Document classification** (`computedModality`): `"text-only" | "visual-only" | "mixed" | "empty"`. Any tile with (instance-level) student text and any tile requiring visual representation → `mixed`; only text → `text-only`; only visual → `visual-only`; neither → `empty`.
+
+Tests must iterate the `shared/tile-types.ts` list and fail if any type lacks a capability record.
+
+### File formats (schemas.ts implements these as types + validators)
+
+Every format has `schemaVersion: 1`. Validators run on every read; a bad file fails with a message naming the file and field.
+
+**Corpus manifest** (`manifest.json`):
+
+```json
+{
+  "schemaVersion": 1,
+  "name": "synthetic-corpus",
+  "createdAt": "2026-08-12T00:00:00Z",
+  "documents": [
+    {
+      "id": "drawing-only",
+      "file": "documents/drawing-only.json",
+      "source": "synthetic",
+      "contentSha256": "…",
+      "retrievedAt": null,
+      "unit": null, "investigation": null, "problem": null, "contextId": null,
+      "computedModality": "visual-only",
+      "modalityOverride": null,
+      "labels": {},
+      "relatedSummaries": [],
+      "historical": null
+    }
+  ]
+}
+```
+
+- `source`: `"synthetic" | "demo" | "qa" | "production"`.
+- `computedModality` is always refreshed by `import` from current content; `modalityOverride` is only ever set by a human and never touched by tooling. Reports use the override when present and show both. (Same pattern for any future derived-vs-manual metadata.)
+- `historical`: `null`, or (production, later) `{ summarizer, promptTokens, completionTokens, response, analyzedAt }`. Never compared pairwise against new runs unless `contentSha256` matches — enforced in `report.ts`.
+
+**Import command rules:** document id = source filename without extension, validated as `[a-z0-9-]+`; id collision within a corpus is an error; resolved paths must stay inside the corpus directory (reject `..`); source files that disappear leave their manifest entries in place with a warning (explicit `--prune` removes them); `--source demo|qa|synthetic` sets the source field (default `synthetic`).
+
+**Prompt file** (`prompts/categorize-design-default.json`): the `aiPrompt` object plus `provenance { source, retrievedAt, aiPromptSha256 }` where the hash is `sha256Canonical(aiPrompt)`. **Anti-drift test:** a harness test computes `sha256Canonical(defaultAiPrompt)` from the shared module and asserts it equals both the file's `aiPromptSha256` and the hash of the file's own `aiPrompt` — the committed copy can't drift from production's default without a failing test.
+
+**Experiment file** (`experiments/text-baselines.json`) — milestone 1 supports an explicit run list only:
+
+```json
+{
+  "schemaVersion": 1,
+  "name": "text-baselines",
+  "runs": [
+    { "id": "text-default", "message": "text-only", "textVariant": "default", "prompt": "categorize-design-default" },
+    { "id": "text-minimal", "message": "text-only", "textVariant": "minimal", "prompt": "categorize-design-default" }
+  ]
+}
+```
+
+Validation: `message` must be `"text-only"`; `textVariant` known; `prompt` names an existing file; run ids unique.
+
+**Result rows** — a **discriminated union on `status`**; report code handles every status exhaustively:
+
+Common fields (all statuses): `schemaVersion`, `experiment`, `experimentSha256`, `runId`, `corpus`, `docId`, `modality` (effective: override ?? computed), `message`, `textVariant`, `prompt {name, sha256}`, `requestKey` (the cache key — this is also resume identity; `null` on `skipped` rows, which never build a request), `runMeta { date, openaiSdkVersion, gitCommit, gitDirty }`.
+
+- `status: "success"` → `response {parsed, raw}`, `usage {promptTokens, completionTokens, source: "api" | "cache"}`, `cost {modeledUsd, incurredThisRunUsd}`, `responseOriginMeta {date, modelReturned, systemFingerprint}` (equals this run for API calls; the originating call's for cache hits — `incurredThisRunUsd` is 0 for cache hits).
+- `status: "refusal"` → refusal text, usage, cost, responseOriginMeta (refusals are real API responses: they cost money, and they are **cached** like successes so reruns don't re-spend on deterministic refusals).
+- `status: "error"` → structured `error {type, message, attempts}`; never cached.
+- `status: "skipped"` → `skipReasons: string[]` (reserved for milestone 3's skip-empty; the shape ships now).
+
+**Pricing config** (`src/pricing.json`): `{ schemaVersion, effectiveDate, models: { "gpt-4o-mini": { inputPerMTokUsd, outputPerMTokUsd, maxOutputTokens } } }`. Verify current prices when implementing.
+
+### Cost control (`cost.ts`) — a real upper bound, not an accounting fiction
+
+- **Every OpenAI request sets `max_completion_tokens` to the pricing config's `maxOutputTokens`** (1024 to start). This is a deliberate, documented deviation from production (which sets no cap): without it the reservation is not a bound. Record the cap in the request config; note in the README that production should likely adopt the same cap later. Feedback comments are short; 1024 is generous.
+- Input-token estimate: `messages` text length ÷ 3 (conservative chars-per-token) + canonical response-schema length ÷ 3, rounded up.
+- Worst-case reservation per call = (input estimate + `maxOutputTokens`) priced, × (1 + retries) — **the same formula in `plan` and `run`**, so `plan`'s projected maximum is never lower than what `run` can reserve.
+- Reservation ledger: before dispatch, atomically reserve; if the reservation would exceed `--max-cost`, don't dispatch (finish in-flight work, then stop with a clear message). Cache hits reserve nothing. On completion, replace the reservation with actual cost. Final report: reserved vs. actual.
+
+### Cache (`cache.ts`)
+
+Key = `sha256Canonical({ model, messages, responseFormat, generationSettings })` — `generationSettings` includes `max_completion_tokens`. Store under `data/cache/<first-2>/<key>.json` with the full response and its `responseOriginMeta`. Successes **and refusals** are cached; errors never. Flags: `--no-cache` disables reads *and* writes; `--refresh-cache` bypasses reads but writes fresh results.
+
+### Execution and resume (`execute.ts`)
+
+- `run` takes `--output <file>` (default `data/results/<experiment>.jsonl` — a stable, deterministic path; no timestamp in the name). Rerunning with the same output file resumes it: a (docId × runId) pair is skipped only if an existing row has the **same `requestKey`** — so a changed document, prompt, representation, experiment definition, or generation setting re-runs automatically (the key embeds all of them via the messages), while true duplicates skip. Error rows never block a retry-rerun.
+- All completions flow through a single JSONL writer queue; one line per write, flushed per line — concurrent tasks can't interleave, and a crash leaves whole rows or nothing.
+- Concurrency cap 4; retry twice on transient errors (429/5xx/network) with backoff.
+
+### Commands
+
+- `npx tsx harness.ts import --from <dir> --corpus <name> [--source synthetic|demo|qa] [--prune]` — rules under "Import command rules" above; `production` is deliberately not an option here (the `pull` command sets it, milestone 6).
+- `npx tsx harness.ts represent --corpus <name> --variants default,minimal` — writes each representation as a JSON envelope `{ schemaVersion, docId, variantId, variantVersion, sourceContentSha256, generatedAt, markdown }` under `data/corpus/<name>/representations/` — the envelope, not the file's existence, is how staleness is detected (regenerate when `sourceContentSha256` or `variantVersion` differ). Each variant implementation in `represent-text.ts` exports a `variantVersion` integer constant, bumped whenever its output would change for the same input. Variants: `default`, `minimal`; `svg-drawings` (via `documentSummarizerWithDrawings`) is a stretch goal — include only if the React import works under tsx without build gymnastics; otherwise note it in the README and move on.
+- `npx tsx harness.ts plan --corpus <name> --experiment <file>` — validate everything; print the expanded run list (runs × documents) with its total call count, and the worst-case cost using the same reservation formula as `run`. No network.
+- `npx tsx harness.ts run --corpus <name> --experiment <file> --max-cost <usd> [--output <file>] [--no-cache | --refresh-cache]` — `--max-cost` required; no unlimited mode.
+- `npx tsx harness.ts report --results <file>.jsonl` — stdout table + `summary.json`: per run-config × modality (and overall): docs, cache hits, statuses, token mean/median/total, modeled and incurred cost, category distribution, refusal count.
+
+### Synthetic corpus and fixtures
+
+The committed example corpus is `documents/` plus `expectations.json` — no committed manifest; tests (and the smoke test) run `import` on it first, which generates the manifest under `data/corpus/` and exercises the import path for free.
+
+One minimal document per type in `shared/tile-types.ts`, plus one `mixed` document (Text + Drawing) and one `empty` document. Two special cases: the `Unknown` fixture is a document containing a tile with a made-up type string (that is what "unknown" means in practice), and the `Placeholder` fixture is a document whose section is empty. Author as CLUE document-content JSON (`rowOrder`/`rowMap`/`tileMap`; copy structure from `shared/ai-summarizer/ai-summarizer.test.ts` fixtures). Tiles needing shared models (Table/Graph datasets, Diagram variables) must include them — a fixture that exercises only the degenerate empty case doesn't test the handler.
+
+`expectations.json` records, per fixture: expected `computedModality`; expected capability classification; handler tier (`full|partial|stub|fallback`); a distinctive string (the fixture id embedded in its content) that must appear in the `default` summary **when the tier is full or partial**; whether `default` and `minimal` summarization must succeed. A test walks the corpus against these expectations. Weak summaries from stub/fallback tiles are expected and *visible* — that's data, not failure.
+
+## Acceptance criteria (milestone 1 is done when…)
+
+1. `functions-v2`: `npm run build` + `npm test` pass; existing test expectations unchanged; builders come from `shared/ai-analysis-messages.ts`.
+2. `scripts/ai-harness`: `npm ci`, `npm run typecheck`, and `npm test` all pass.
+3. Lockstep test: `shared/`, `functions-v2/`, and `scripts/ai-harness/` lockfiles resolve identical `openai` and `zod` versions.
+4. Cross-package load test: the shared module imports and runs from both `functions-v2` tests and harness tests; the harness import loads no Firebase modules.
+5. Capability registry covers every type in `shared/tile-types.ts`; the text-parse tripwire against `src/register-tile-types.ts` passes; Question traversal rules each have a test.
+6. Every OpenAI request sets `max_completion_tokens`; `plan` and `run` share one reservation formula; a concurrency test proves the ledger can't overshoot `--max-cost`.
+7. Success, refusal, error, and skipped rows validate against distinct schemas; `report` handles all four.
+8. A cache-hit test verifies `usage.source`, zero `incurredThisRunUsd`, current `runMeta`, and preserved `responseOriginMeta`; a refusal-caching test verifies refusals don't re-spend.
+9. An interrupted run resumed via `--output` skips completed pairs; a changed document/prompt/experiment/representation is *not* skipped (requestKey mismatch test).
+10. Concurrent completions produce valid, non-interleaved JSONL (writer-queue test).
+11. The committed default prompt's hash mechanically matches `sha256Canonical(defaultAiPrompt)`.
+12. The mocked-OpenAI smoke test runs `import` → `represent` → `plan` → `run` → `report` end-to-end with no network; message arrays match snapshots built with the shared builders; modality breakdowns appear in the summary.
+13. One real run of `text-baselines` on the synthetic corpus completes under $0.50 with a readable report (human-verified; needs `OPENAI_API_KEY`).
+14. `git status` after a full real run shows nothing untracked outside `scripts/ai-harness/data/`.
+15. `README.md` documents setup, per-command prerequisites (network/key/none), file formats (pointing at `schemas.ts`), cache flags, resume, and the data-safety rules from the harness plan.
+
+## Out of scope for milestone 1 (do not build, even if tempting)
+
+Image representations and backends (M2); `buildMixedMessages`, mixed/image-only execution, extras variants, skip-empty *execution* (M3 — the registry and the `skipped` row shape ship now, unused); HTML review report and `--shareable` (M4); rubric scoring (M5); production `pull`, `firebase-admin`, anything touching real student data (M6); the `findRelatedSummaries` bug fix (separate small PR); matrix-style experiment expansion (M3); migrating `register-tile-types.ts` to consume `shared/tile-types.ts` (nice refactor, not now).
+
+## Review disposition (revision 2)
+
+An external (Codex) review of revision 1 raised 15 findings plus 12 acceptance-criteria additions; all were verified against the code where checkable and essentially all adopted. The three blockers were real: the root `node_modules` lacks `openai`/`zod`, so the shared module couldn't have resolved its imports from the harness (fixed by giving `shared/` its own pinned dependencies + a lockstep test); the tile-registry test as specified was impossible (`gTileRegistration` is unexported and the module drags in client code) and the capability table was missing `ErrorTest`, `IframeInteractive`, `Starter`, and `Unknown` (fixed with `shared/tile-types.ts` as the authoritative import-safe list plus a text-parse tripwire); and the spend ceiling wasn't a true bound without `max_completion_tokens` on the request (fixed, recorded as a deliberate parity deviation). Also adopted: the three-property capability model replacing the conflated two flags, Question-traversal rules, exact version pinning with committed lockfiles and `npm ci`, the spelled-out ESM/jest configuration with a required typecheck, discriminated result rows, cache-hit cost/provenance fields, refusal caching, `--no-cache` vs `--refresh-cache` semantics, deterministic `--output` resume keyed on `requestKey`, the single JSONL writer, the prompt anti-drift hash test, `computedModality`/`modalityOverride` separation with import edge-case rules, representation envelopes, expectation-driven fixtures, and the explicit note that three moved symbols gain `export` keywords. One correction of fact from the review: TypeScript is pinned to `~5.9.2` (matching `functions-v2`), not 5.5 as revision 1 said.
+
+Revision 3 (editorial pass, no design changes): fixed cross-references between A1/A4/A5 (the lockstep test lives in the harness suite and is described once, in A1); replaced the capability table's "varies — audit each" with an explicit default (`false`, documented as a known simplification) so no judgment call is delegated to the implementer; resolved a contradiction where the committed example corpus contained a `manifest.json` that the `import` command is supposed to generate (the example corpus is now documents + expectations only); defined where `variantVersion` comes from; clarified that `requestKey` is `null` on skipped rows; and specified the `Unknown` and `Placeholder` fixtures.
+
+Revision 4 (A4 only): the Part A tests are split into two files instead of one. `shared/ai-analysis-messages.test.ts` sits next to the code it tests, following the repo's colocation convention, and runs under the root package's jest. `functions-v2/test/ai-analysis-messages-integration.test.ts` keeps only the cross-package checks — the re-exports, the caller behavior, and one case executing the builders against `functions-v2`'s own `openai`/`zod` installs — since those are the parts that would be meaningless anywhere else. Acceptance for Part A now also requires the root `npm test` to pass, without altering the root jest config or `src/test/jest-resolver.js` to make `shared/node_modules` resolve.

--- a/functions-v2/test/ai-analysis-messages-integration.test.ts
+++ b/functions-v2/test/ai-analysis-messages-integration.test.ts
@@ -30,11 +30,9 @@ const emptySchemaPrompt: IAiPrompt = {
 describe("shared/ai-analysis-messages in functions-v2", () => {
   describe("running against functions-v2's installed openai and zod", () => {
     test("the builders and categorizationResponseFormat produce a usable request", () => {
-      // jest.config.js maps openai and zod to functions-v2's copies for every importer, including
-      // ../shared, so this proves the builders run correctly against the copies the deployed function
-      // resolves — one zod, so these instanceof checks cannot detect a version drift between
-      // shared/node_modules and functions-v2/node_modules. That is the lockfile-lockstep test's job
-      // (scripts/ai-harness/test/versions.test.ts).
+      // jest.config.js gives every importer, ../shared included, one copy of zod, so this proves the
+      // builders run against the copies the deployed function resolves. It cannot detect version
+      // drift; that is the lockstep test's job (scripts/ai-harness/test/versions.test.ts).
       const responseSchema = buildZodResponseSchema(fullPrompt);
       expect(responseSchema).toEqual({
         category: expect.any(ZodEnum),

--- a/functions-v2/test/ai-analysis-messages-integration.test.ts
+++ b/functions-v2/test/ai-analysis-messages-integration.test.ts
@@ -30,8 +30,11 @@ const emptySchemaPrompt: IAiPrompt = {
 describe("shared/ai-analysis-messages in functions-v2", () => {
   describe("running against functions-v2's installed openai and zod", () => {
     test("the builders and categorizationResponseFormat produce a usable request", () => {
-      // zod types imported here come from functions-v2/node_modules; the builders use whichever copy
-      // resolves for shared/. These instanceof checks fail if the two ever drift apart.
+      // jest.config.js maps openai and zod to functions-v2's copies for every importer, including
+      // ../shared, so this proves the builders run correctly against the copies the deployed function
+      // resolves — one zod, so these instanceof checks cannot detect a version drift between
+      // shared/node_modules and functions-v2/node_modules. That is the lockfile-lockstep test's job
+      // (scripts/ai-harness/test/versions.test.ts).
       const responseSchema = buildZodResponseSchema(fullPrompt);
       expect(responseSchema).toEqual({
         category: expect.any(ZodEnum),

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
       "/functions-v1/",
       "/functions-v2/",
       "/authoring-api/",
+      "/scripts/ai-harness/",
       "/.yalc/"
     ],
     "transform": {

--- a/scripts/ai-harness/README.md
+++ b/scripts/ai-harness/README.md
@@ -27,7 +27,11 @@ npm test
 
 This package has its own jest, and the root package's jest is told to skip it
 (`testPathIgnorePatterns` in the root `package.json`) — these tests are ESM with NodeNext-style `.js`
-specifiers and cannot run under the root CommonJS runner.
+specifiers and cannot run under the root CommonJS runner. CI runs them anyway, as two steps in the
+`jest` job of `.github/workflows/ci.yml`: several of these tests are tripwires on production code
+(a new tile type without a capability record, a drifted prompt copy, an openai/zod version that has
+fallen out of lockstep, a tile summarizer that stopped carrying content), and nobody changing that
+code would think to run them by hand.
 
 For `run` you also need an OpenAI key, either in the environment or in `scripts/.env`:
 

--- a/scripts/ai-harness/README.md
+++ b/scripts/ai-harness/README.md
@@ -1,0 +1,312 @@
+# CLUE AI evaluation harness
+
+A checked-in tool that runs (representation × prompt × message-shape) experiments against a corpus of
+CLUE documents and reports quality inputs plus token and cost numbers — so text-only vs. image-only
+vs. mixed-mode claims are backed by measurements instead of intuition.
+
+This is **milestone 1** of [CLUE-371](../../docs/plans/CLUE-371-harness-plan.md): the shared message
+builders, the harness skeleton, a synthetic corpus, text-only runs, the response cache, the spend
+ceiling, and reports as data. Images (milestone 2), mixed mode (milestone 3), the HTML review report
+(milestone 4), rubric scoring (milestone 5) and the production corpus pull (milestone 6) are not here
+yet.
+
+All runs target `gpt-4o-mini`. That is deliberately the rolling alias, not a pinned snapshot:
+production calls the alias, and a harness that pinned a snapshot would stop measuring what production
+actually does. Reproducibility is handled instead by recording the returned model id and
+`system_fingerprint` in every result row's `responseOriginMeta`, so runs months apart can be told
+apart after the fact.
+
+## Setup
+
+```bash
+cd scripts/ai-harness
+npm ci                 # not `npm install` — the lockfile is the contract (see "Version lockstep")
+npm run typecheck
+npm test
+```
+
+This package has its own jest, and the root package's jest is told to skip it
+(`testPathIgnorePatterns` in the root `package.json`) — these tests are ESM with NodeNext-style `.js`
+specifiers and cannot run under the root CommonJS runner.
+
+For `run` you also need an OpenAI key, either in the environment or in `scripts/.env`:
+
+```
+OPENAI_API_KEY=sk-…
+```
+
+## Commands and what each one needs
+
+| Command | Network | OpenAI key | Notes |
+|---|---|---|---|
+| `import` | no | no | Copies documents into `data/corpus/<name>/` and (re)generates the manifest. |
+| `represent` | no | no | Renders text representations. Pure local computation. |
+| `plan` | no | no | Validates everything and prints the expanded run list and worst-case cost. |
+| `run` | **yes** | **yes** | The only command that calls OpenAI. `--max-cost` is required. |
+| `report` | no | no | Reads a results JSONL file and writes `summary.json` beside it. |
+
+```bash
+npx tsx harness.ts import    --from examples/synthetic-corpus --corpus synthetic-corpus \
+                             [--source synthetic|demo|qa] [--prune]
+npx tsx harness.ts represent --corpus synthetic-corpus --variants default,minimal
+npx tsx harness.ts plan      --corpus synthetic-corpus --experiment experiments/text-baselines.json
+npx tsx harness.ts run       --corpus synthetic-corpus --experiment experiments/text-baselines.json \
+                             --max-cost 0.50 [--output <file>] [--no-cache | --refresh-cache]
+npx tsx harness.ts report    --results data/results/text-baselines.jsonl
+```
+
+Flags are plain `--name value` pairs. An unknown flag is an error, not a warning.
+
+`plan` on the committed synthetic corpus projects a worst case of about **$0.11** for both text
+baselines across all 24 documents.
+
+## Data safety
+
+- **One artifact root.** Everything derived from a document — corpora, representations, the response
+  cache, results, reports — is written under `scripts/ai-harness/data/`, and nothing derived from a
+  document is written anywhere else. That whole tree is gitignored (see the root `.gitignore`).
+- Committed example corpora live in `examples/`, *outside* the ignored tree, so there are no
+  allowlist exceptions inside an ignored directory.
+- `import` will not set the `production` source; only the (not yet built, and gated) `pull` command
+  may, and it will require an explicit sign-off flag.
+- **Production student work is sensitive everywhere it flows**, not just at import. When production
+  corpora arrive: delete them when the experiment concludes, keep document ids and Firestore paths
+  out of anything that leaves the team, and remember that injected related-summaries data contains
+  *other* students' work.
+- Milestone 1 touches no production data, no credentials, and no `firebase-admin`.
+
+## Concepts
+
+### Corpus
+
+A corpus is a directory under `data/corpus/<name>/` with a `manifest.json` and a `documents/`
+directory. `import` generates the manifest; it is never committed. Manifest rules worth knowing:
+
+- The document id is the source filename without its extension and must match `[a-z0-9-]+`.
+- `computedModality` (`text-only` / `visual-only` / `mixed` / `empty`) is recomputed from the current
+  content on every import. `modalityOverride` is only ever set by a human and tooling never touches
+  it. Reports use the override when present.
+- A source file that disappears leaves its manifest entry in place with a warning. `--prune` removes
+  the entry **and deletes the document's copied content and every representation envelope generated
+  from it** — it is destructive by design, so that once production corpora exist no unreachable copy
+  of a student's document lingers in `data/`.
+- `historical` holds a production `done`-queue record (milestone 6). It describes an analysis of
+  whatever the document looked like *then*, so it is never lined up against a fresh run unless the
+  content hash proves the input is identical — see `historicalIsComparable` in `src/report.ts`.
+
+### Representations
+
+`represent` writes an envelope per (document, variant):
+
+```json
+{ "schemaVersion": 1, "docId": "…", "variantId": "default", "variantVersion": 1,
+  "sourceContentSha256": "…", "generatedAt": "…", "markdown": "…" }
+```
+
+Staleness is decided by the envelope, not by the file existing: a representation is reused only when
+`sourceContentSha256` and `variantVersion` both still match. Each variant in `src/represent-text.ts`
+exports a `variantVersion` that is bumped whenever its output would change for the same input.
+
+Variants: `default` and `minimal`. The `svg-drawings` variant
+(`documentSummarizerWithDrawings`) is **not** included — it imports `src/plugins/drawing`, which
+imports `.svg` assets that only a bundler can load, so it does not run under `tsx` without build
+gymnastics. It is a candidate for a later milestone.
+
+### Capability registry
+
+`src/capability.ts` records, per tile type, three separate things: whether students can author text
+in it, how well the current text summarizer carries it (`full` / `partial` / `stub` / `fallback`),
+and whether an image adds information text cannot. Unlisted tile types are treated conservatively as
+needing an image, so nothing silently drops.
+
+The authoritative tile-type list is `shared/tile-types.ts`. `test/tile-types.test.ts` parses
+`src/register-tile-types.ts` as text and fails if the two drift apart, so registering a new tile type
+also forces a capability record for it.
+
+Classification of a real document adds instance-level checks: a Text tile counts as text only when
+its content is non-empty after trimming, and a Drawing tile counts as containing student text only
+when it has text objects with content. Question tiles are traversed into: the authored prompt is not
+student work, response tiles classify by their own types, missing references are skipped with a
+warning, a tile referenced twice counts once, and nesting is capped at 8 levels.
+
+### Prompts
+
+`prompts/<name>.json` holds an `aiPrompt` plus provenance, including `aiPromptSha256`. Reports
+identify a prompt by hash, not only by name. `test/prompt.test.ts` asserts the committed
+`categorize-design-default` still hashes identically to `defaultAiPrompt` in
+`shared/ai-analysis-messages.ts`, so the copy cannot drift from production unnoticed.
+
+### Experiments
+
+Milestone 1 supports an explicit run list only (no matrix expansion). `message` must be `text-only`,
+`textVariant` must be a variant this build knows, `prompt` must name an existing prompt file, and run
+ids must be unique.
+
+### Cache
+
+Key = `sha256Canonical({ model, messages, responseFormat, generationSettings })`, stored at
+`data/cache/<first-2>/<key>.json`.
+
+- Successes **and refusals** are cached. A refusal is a real API response that cost real money;
+  re-running it would just spend the money again.
+- Errors are never cached. That includes a response carrying neither a parsed object nor a refusal
+  (usually a truncated completion): it becomes an `error` row with `type: "unparsed"` and the
+  response's `finish_reason` in the message, matching how production treats a missing `parsed`. The
+  call still cost money, so it is still charged against the ceiling, but a rerun re-requests it.
+- `--no-cache` disables reads *and* writes. `--refresh-cache` bypasses reads but still writes fresh
+  results. The two cannot be combined.
+
+On a cache hit the row records `usage.source: "cache"`, `cost.incurredThisRunUsd: 0`, this run's
+`runMeta`, and the **originating** call's `responseOriginMeta`.
+
+### Resume
+
+`run` writes to `--output`, defaulting to `data/results/<corpus>-<experiment>.jsonl` — a stable path
+with no timestamp in it, naming the corpus so the same experiment run against two corpora does not
+append into one file. `--output` is resolved against the data root and refused if it escapes.
+
+Re-running against the same file resumes it. A (document, run) pair is skipped only when an existing
+row matches on **corpus, experiment hash and `requestKey`**, so a changed document, prompt,
+representation, experiment definition or generation setting re-runs automatically. Error rows never
+block a retry, and `report` refuses a file that mixes corpora or experiment definitions rather than
+summing across them.
+
+Because resume runs before the cache is consulted, `--no-cache` and `--refresh-cache` would be
+no-ops against a file that already holds completed rows. Rather than silently skipping the requests
+you asked to re-execute, `run` fails and tells you to pass a fresh `--output`.
+
+All completions flow through a single JSONL writer queue, one flushed line per write, so concurrent
+tasks cannot interleave and a crash leaves whole rows or nothing.
+
+### Cost control
+
+`--max-cost` is required; there is no unlimited mode. It is an **enforced bound**, not a mathematical
+guarantee — see the two edges at the end of this section.
+
+- Every request sets `max_completion_tokens` to the pricing config's `maxOutputTokens` (1024).
+  **This is a deliberate deviation from production**, which sets no cap: without it the reservation
+  bounds nothing at all, only guesses. Production should probably adopt the same cap — feedback
+  comments are short and 1024 is generous.
+- Input estimate: ASCII characters ÷ 3 plus one token per non-ASCII character, over the messages and
+  the canonical response schema. Non-ASCII is counted whole because CJK text and emoji routinely cost
+  about a token each, and dividing them by three would under-reserve.
+- Worst case per call = (input estimate + `maxOutputTokens`) priced, × (1 + retries). `plan` and
+  `run` call the same function, so a plan's projected maximum is never lower than what a run can
+  reserve.
+- Before dispatch the run reserves the worst case. A reservation that would cross the ceiling is
+  refused, in-flight work finishes, and the run stops with a message. Cache hits reserve nothing. On
+  completion the reservation is replaced by the actual cost. If actuals ever push the committed total
+  past the ceiling, the run stops scheduling immediately and reports the overshoot.
+- The SDK's own retries are disabled (`maxRetries: 0`), so the only attempts are the ones the
+  reservation paid for.
+
+**The two edges, and why they are accepted.** The input estimate is a character heuristic, not the
+model's tokenizer, so a pathological input could tokenize worse than estimated and settle above its
+reservation; the ledger detects that after the fact and halts rather than preventing it. And a
+dispatched request that fails before returning usage may or may not have been billed — the harness
+charges its single-attempt share, which is a guess in the honest direction rather than a known
+figure. Both are accepted for a tool whose runs cost cents: the synthetic corpus plans at about
+$0.11. If the harness ever runs matrices costing real money, replace the heuristic with a tokenizer
+before trusting the ceiling to the last cent.
+
+Prices live in `src/pricing.json` with an `effectiveDate`. Check them when they look stale;
+API-reported usage is authoritative for final numbers.
+
+### Results and reports
+
+Result rows are a discriminated union on `status` (`success`, `refusal`, `error`, `skipped`), all
+sharing the same identifying fields. `skipped` ships now but is unused: skip-empty *execution*
+arrives in milestone 3. `report` handles all four statuses exhaustively and writes `summary.json`
+next to the results file, grouped per run configuration × modality plus an overall row.
+
+Every on-disk format has `schemaVersion: 1`, is described as a TypeScript type in
+[`src/schemas.ts`](src/schemas.ts), and is validated on every read; a bad file fails with a message
+naming the file and the field.
+
+### Version lockstep
+
+`shared/` has its own pinned `openai` and `zod` so the harness can import
+`shared/ai-analysis-messages.ts` in place, while the deployed function resolves both from
+`functions-v2/node_modules`. Behaviour parity requires identical versions, so
+`test/versions.test.ts` reads all three lockfiles and fails if they drift. Use `npm ci`, and commit
+lockfile changes.
+
+## Layout
+
+```
+harness.ts                 CLI: argv parsing and command dispatch
+src/schemas.ts             types, validators, canonicalJson / sha256Canonical
+src/corpus.ts              corpus layout, import, manifest read/write
+src/capability.ts          tile capability registry, document classification
+src/represent-text.ts      text representation variants
+src/messages.ts            request construction via shared/ai-analysis-messages
+src/cache.ts               response cache
+src/cost.ts                pricing, estimation, reservation ledger
+src/execute.ts             run expansion, OpenAI calls, concurrency, retries, JSONL writer
+src/report.ts              summary tables from result JSONL
+prompts/                   prompt files with provenance
+experiments/               experiment definitions
+examples/synthetic-corpus/ committed fixtures + expectations.json (no manifest — import makes it)
+test/                      jest suite
+data/                      generated at runtime; never committed
+```
+
+## DEVIATIONS
+
+Where the implementation departs from
+[docs/plans/CLUE-371-harness-implementation-1.md](../../docs/plans/CLUE-371-harness-implementation-1.md),
+and why.
+
+1. **`moduleResolution` is `bundler`, not `nodenext`.** The spec prescribes
+   `module: "nodenext"` / `moduleResolution: "nodenext"`. That configuration cannot type-check this
+   repository: `shared/package.json` declares `"type": "module"`, so every `shared/**` file is ESM,
+   and every relative import in `shared/ai-summarizer/**` (which `represent-text.ts` must import) is
+   extensionless. NodeNext rejects extensionless relative imports in ESM with TS2835, which then
+   cascades into dozens of downstream `implicit any` errors. Adding extensions across `shared/`
+   would be a large change to production code and is well out of milestone 1's scope. `bundler`
+   resolution keeps everything else the spec asked for — `strict`, `target: es2022`, `.js` suffixes
+   on the harness's own relative imports, `npm run typecheck` covering the shared files the harness
+   imports, `tsx` for the CLI and the ts-jest ESM preset for tests.
+2. **`functions-v2/jest.config.js` maps `openai` and `zod` to its own copies.** Once `shared/` has
+   its own `node_modules`, jest would otherwise load two copies of zod, and the `expect.any(ZodEnum)`
+   assertions in `test/on-analysis-document-imaged.test.ts` and
+   `test/ai-analysis-messages-integration.test.ts` would fail on cross-copy `instanceof`. The mapping
+   uses the same mechanism the config already uses for `firebase-admin`, and it matches deployment,
+   where `shared/node_modules` does not exist and both packages resolve from
+   `functions-v2/node_modules`.
+3. **The "no Firebase in the module graph" check is static.** Jest exposes no ESM module registry, so
+   `test/shared-module.test.ts` walks the import graph out from `shared/ai-analysis-messages.ts` and
+   asserts no reachable bare specifier is a Firebase or `@google-cloud` package, alongside actually
+   importing the module and running each builder. The static walk also catches a Firebase import
+   added to a transitive dependency rather than only one that happens to execute.
+4. **The authored prompt inside a Question tile contributes nothing to modality.** The spec says the
+   prompt "does not count as student text" and is silent on whether it can make a document need an
+   image. It is authored content rather than student work, and modality exists to describe a
+   student's work style, so the prompt contributes neither text nor a visual requirement. Its
+   classification is still recorded, with `role: "prompt"`.
+5. **`retrievedAt` is `null` for synthetic documents and the import time otherwise.** The spec's
+   manifest example shows `null` for a synthetic document but does not say what to write for `demo`
+   or `qa`. A synthetic document was authored in the repository rather than retrieved from anywhere.
+6. **`expectations.json` carries an explicit `expectDistinctiveInDefaultSummary` flag.** The spec
+   derives that requirement from the handler tier (`full` or `partial`), but two fixtures have no
+   place to put a marker the handler would emit: the placeholder handler returns an empty string, and
+   the empty document is intentionally contentless. The flag defaults to the tier rule and is set
+   explicitly (with a `notes` line) where it cannot hold.
+7. **`historical` gained an optional `contentSha256`.** The spec fixes the historical record's shape
+   without a hash of the input it ran against, which makes the "never compare unless the content hash
+   matches" rule unenforceable. `historicalIsComparable` requires that field, so a record without it
+   is never treated as comparable — the safe answer, and the only one available today since nothing
+   writes historical records until milestone 6.
+8. **`main(argv, deps)` accepts an injectable `dataRoot` and `createCompletion`.** The smoke test
+   drives the real CLI, argv parsing included, with a mocked backend and its own corpus, cache and
+   results — still inside `data/`, so the one-artifact-root rule holds.
+9. **`plan`'s per-run line shows worst case per run** in addition to the required total.
+10. **Estimation counts canonical-JSON length, not just visible text.** "Messages text length ÷ 3"
+    is implemented as `canonicalJson(messages).length / 3`, which includes structural overhead. That
+    is deterministic and conservative in the right direction.
+
+### Verified against a real API call?
+
+No. Acceptance criterion 13 (one real `text-baselines` run under $0.50) needs `OPENAI_API_KEY` and is
+verified by a human. Everything else, including the full mocked end-to-end path, is covered by
+`npm test`.

--- a/scripts/ai-harness/examples/synthetic-corpus/documents/ai.json
+++ b/scripts/ai-harness/examples/synthetic-corpus/documents/ai.json
@@ -1,0 +1,25 @@
+{
+  "rowOrder": [
+    "row-1"
+  ],
+  "rowMap": {
+    "row-1": {
+      "id": "row-1",
+      "isSectionHeader": false,
+      "tiles": [
+        {
+          "tileId": "ai-tile"
+        }
+      ]
+    }
+  },
+  "tileMap": {
+    "ai-tile": {
+      "id": "ai-tile",
+      "content": {
+        "type": "AI",
+        "fixtureMarker": "ai-fixture-marker"
+      }
+    }
+  }
+}

--- a/scripts/ai-harness/examples/synthetic-corpus/documents/bar-graph.json
+++ b/scripts/ai-harness/examples/synthetic-corpus/documents/bar-graph.json
@@ -1,0 +1,69 @@
+{
+  "rowOrder": [
+    "row-1"
+  ],
+  "rowMap": {
+    "row-1": {
+      "id": "row-1",
+      "isSectionHeader": false,
+      "tiles": [
+        {
+          "tileId": "bar-graph-tile"
+        }
+      ]
+    }
+  },
+  "tileMap": {
+    "bar-graph-tile": {
+      "id": "bar-graph-tile",
+      "content": {
+        "type": "BarGraph",
+        "fixtureMarker": "bar-graph-fixture-marker",
+        "yAxisLabel": "Count",
+        "primaryAttribute": "bar-graph-data-x"
+      }
+    }
+  },
+  "sharedModelMap": {
+    "shared-bar-graph-data": {
+      "sharedModel": {
+        "type": "SharedDataSet",
+        "id": "shared-bar-graph-data",
+        "providerId": "bar-graph-tile",
+        "dataSet": {
+          "id": "bar-graph-data",
+          "name": "Latch votes",
+          "attributes": [
+            {
+              "id": "bar-graph-data-x",
+              "name": "Trial",
+              "values": [
+                "1",
+                "2"
+              ]
+            },
+            {
+              "id": "bar-graph-data-y",
+              "name": "Height (cm)",
+              "values": [
+                "12",
+                "19"
+              ]
+            }
+          ],
+          "cases": [
+            {
+              "__id__": "bar-graph-data-case-1"
+            },
+            {
+              "__id__": "bar-graph-data-case-2"
+            }
+          ]
+        }
+      },
+      "tiles": [
+        "bar-graph-tile"
+      ]
+    }
+  }
+}

--- a/scripts/ai-harness/examples/synthetic-corpus/documents/data-card.json
+++ b/scripts/ai-harness/examples/synthetic-corpus/documents/data-card.json
@@ -1,0 +1,68 @@
+{
+  "rowOrder": [
+    "row-1"
+  ],
+  "rowMap": {
+    "row-1": {
+      "id": "row-1",
+      "isSectionHeader": false,
+      "tiles": [
+        {
+          "tileId": "data-card-tile"
+        }
+      ]
+    }
+  },
+  "tileMap": {
+    "data-card-tile": {
+      "id": "data-card-tile",
+      "content": {
+        "type": "DataCard",
+        "fixtureMarker": "data-card-fixture-marker",
+        "caseIndex": 0
+      }
+    }
+  },
+  "sharedModelMap": {
+    "shared-data-card-data": {
+      "sharedModel": {
+        "type": "SharedDataSet",
+        "id": "shared-data-card-data",
+        "providerId": "data-card-tile",
+        "dataSet": {
+          "id": "data-card-data",
+          "name": "Latch cards",
+          "attributes": [
+            {
+              "id": "data-card-data-x",
+              "name": "Trial",
+              "values": [
+                "1",
+                "2"
+              ]
+            },
+            {
+              "id": "data-card-data-y",
+              "name": "Height (cm)",
+              "values": [
+                "12",
+                "19"
+              ]
+            }
+          ],
+          "cases": [
+            {
+              "__id__": "data-card-data-case-1"
+            },
+            {
+              "__id__": "data-card-data-case-2"
+            }
+          ]
+        }
+      },
+      "tiles": [
+        "data-card-tile"
+      ]
+    }
+  }
+}

--- a/scripts/ai-harness/examples/synthetic-corpus/documents/dataflow.json
+++ b/scripts/ai-harness/examples/synthetic-corpus/documents/dataflow.json
@@ -1,0 +1,103 @@
+{
+  "rowOrder": [
+    "row-1"
+  ],
+  "rowMap": {
+    "row-1": {
+      "id": "row-1",
+      "isSectionHeader": false,
+      "tiles": [
+        {
+          "tileId": "dataflow-tile"
+        }
+      ]
+    }
+  },
+  "tileMap": {
+    "dataflow-tile": {
+      "id": "dataflow-tile",
+      "content": {
+        "type": "Dataflow",
+        "programDataRate": 1000,
+        "program": {
+          "id": "dataflow-program",
+          "nodes": {
+            "node-1": {
+              "id": "node-1",
+              "name": "Number",
+              "x": 0,
+              "y": 0,
+              "data": {
+                "type": "Number",
+                "orderedDisplayName": "Number 1",
+                "nodeValue": 5
+              }
+            },
+            "node-2": {
+              "id": "node-2",
+              "name": "Math",
+              "x": 200,
+              "y": 0,
+              "data": {
+                "type": "Math",
+                "orderedDisplayName": "Math 1",
+                "mathOperator": "Add"
+              }
+            }
+          },
+          "connections": {
+            "connection-1": {
+              "id": "connection-1",
+              "source": "node-1",
+              "sourceOutput": "value",
+              "target": "node-2",
+              "targetInput": "num1"
+            }
+          }
+        }
+      }
+    }
+  },
+  "sharedModelMap": {
+    "shared-dataflow-data": {
+      "sharedModel": {
+        "type": "SharedDataSet",
+        "id": "shared-dataflow-data",
+        "providerId": "dataflow-tile",
+        "dataSet": {
+          "id": "dataflow-data",
+          "name": "dataflow-fixture-marker",
+          "attributes": [
+            {
+              "id": "dataflow-data-x",
+              "name": "Trial",
+              "values": [
+                "1",
+                "2"
+              ]
+            },
+            {
+              "id": "dataflow-data-y",
+              "name": "Height (cm)",
+              "values": [
+                "12",
+                "19"
+              ]
+            }
+          ],
+          "cases": [
+            {
+              "__id__": "dataflow-data-case-1"
+            },
+            {
+              "__id__": "dataflow-data-case-2"
+            }
+          ]
+        }
+      },
+      "tiles": [
+        "dataflow-tile"
+      ]
+    }
+  }
+}

--- a/scripts/ai-harness/examples/synthetic-corpus/documents/diagram.json
+++ b/scripts/ai-harness/examples/synthetic-corpus/documents/diagram.json
@@ -1,0 +1,44 @@
+{
+  "rowOrder": [
+    "row-1"
+  ],
+  "rowMap": {
+    "row-1": {
+      "id": "row-1",
+      "isSectionHeader": false,
+      "tiles": [
+        {
+          "tileId": "diagram-tile"
+        }
+      ]
+    }
+  },
+  "tileMap": {
+    "diagram-tile": {
+      "id": "diagram-tile",
+      "content": {
+        "type": "Diagram",
+        "fixtureMarker": "diagram-fixture-marker"
+      }
+    }
+  },
+  "sharedModelMap": {
+    "shared-diagram-variables": {
+      "sharedModel": {
+        "type": "SharedVariables",
+        "id": "shared-diagram-variables",
+        "variables": [
+          {
+            "id": "diagram-var-1",
+            "name": "latchForce",
+            "displayName": "Latch force",
+            "unit": "N",
+            "value": 4,
+            "description": "Force needed to open the latch"
+          }
+        ]
+      },
+      "tiles": []
+    }
+  }
+}

--- a/scripts/ai-harness/examples/synthetic-corpus/documents/drawing.json
+++ b/scripts/ai-harness/examples/synthetic-corpus/documents/drawing.json
@@ -1,0 +1,49 @@
+{
+  "rowOrder": [
+    "row-1"
+  ],
+  "rowMap": {
+    "row-1": {
+      "id": "row-1",
+      "isSectionHeader": false,
+      "tiles": [
+        {
+          "tileId": "drawing-tile"
+        }
+      ]
+    }
+  },
+  "tileMap": {
+    "drawing-tile": {
+      "id": "drawing-tile",
+      "content": {
+        "type": "Drawing",
+        "fixtureMarker": "drawing-fixture-marker",
+        "objects": [
+          {
+            "type": "rectangle",
+            "x": 10,
+            "y": 10,
+            "width": 120,
+            "height": 60,
+            "fill": "#ffffff",
+            "stroke": "#000000",
+            "strokeWidth": 2,
+            "strokeDashArray": "solid"
+          },
+          {
+            "type": "ellipse",
+            "x": 160,
+            "y": 40,
+            "rx": 30,
+            "ry": 20,
+            "fill": "#cfe8ff",
+            "stroke": "#000000",
+            "strokeWidth": 2,
+            "strokeDashArray": "solid"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/scripts/ai-harness/examples/synthetic-corpus/documents/empty.json
+++ b/scripts/ai-harness/examples/synthetic-corpus/documents/empty.json
@@ -1,0 +1,5 @@
+{
+  "rowOrder": [],
+  "rowMap": {},
+  "tileMap": {}
+}

--- a/scripts/ai-harness/examples/synthetic-corpus/documents/error-test.json
+++ b/scripts/ai-harness/examples/synthetic-corpus/documents/error-test.json
@@ -1,0 +1,26 @@
+{
+  "rowOrder": [
+    "row-1"
+  ],
+  "rowMap": {
+    "row-1": {
+      "id": "row-1",
+      "isSectionHeader": false,
+      "tiles": [
+        {
+          "tileId": "error-test-tile"
+        }
+      ]
+    }
+  },
+  "tileMap": {
+    "error-test-tile": {
+      "id": "error-test-tile",
+      "content": {
+        "type": "ErrorTest",
+        "fixtureMarker": "error-test-fixture-marker",
+        "failureMode": "render"
+      }
+    }
+  }
+}

--- a/scripts/ai-harness/examples/synthetic-corpus/documents/expression.json
+++ b/scripts/ai-harness/examples/synthetic-corpus/documents/expression.json
@@ -1,0 +1,26 @@
+{
+  "rowOrder": [
+    "row-1"
+  ],
+  "rowMap": {
+    "row-1": {
+      "id": "row-1",
+      "isSectionHeader": false,
+      "tiles": [
+        {
+          "tileId": "expression-tile"
+        }
+      ]
+    }
+  },
+  "tileMap": {
+    "expression-tile": {
+      "id": "expression-tile",
+      "content": {
+        "type": "Expression",
+        "fixtureMarker": "expression-fixture-marker",
+        "latexStr": "F = k \\cdot x"
+      }
+    }
+  }
+}

--- a/scripts/ai-harness/examples/synthetic-corpus/documents/geometry.json
+++ b/scripts/ai-harness/examples/synthetic-corpus/documents/geometry.json
@@ -1,0 +1,78 @@
+{
+  "rowOrder": [
+    "row-1"
+  ],
+  "rowMap": {
+    "row-1": {
+      "id": "row-1",
+      "isSectionHeader": false,
+      "tiles": [
+        {
+          "tileId": "geometry-tile"
+        }
+      ]
+    }
+  },
+  "tileMap": {
+    "geometry-tile": {
+      "id": "geometry-tile",
+      "content": {
+        "type": "Geometry",
+        "fixtureMarker": "geometry-fixture-marker",
+        "objects": {},
+        "board": {
+          "xAxis": {
+            "min": -5,
+            "max": 5
+          },
+          "yAxis": {
+            "min": -5,
+            "max": 5
+          }
+        }
+      }
+    }
+  },
+  "sharedModelMap": {
+    "shared-geometry-data": {
+      "sharedModel": {
+        "type": "SharedDataSet",
+        "id": "shared-geometry-data",
+        "providerId": "geometry-tile",
+        "dataSet": {
+          "id": "geometry-data",
+          "name": "Latch points",
+          "attributes": [
+            {
+              "id": "geometry-data-x",
+              "name": "Trial",
+              "values": [
+                "1",
+                "2"
+              ]
+            },
+            {
+              "id": "geometry-data-y",
+              "name": "Height (cm)",
+              "values": [
+                "12",
+                "19"
+              ]
+            }
+          ],
+          "cases": [
+            {
+              "__id__": "geometry-data-case-1"
+            },
+            {
+              "__id__": "geometry-data-case-2"
+            }
+          ]
+        }
+      },
+      "tiles": [
+        "geometry-tile"
+      ]
+    }
+  }
+}

--- a/scripts/ai-harness/examples/synthetic-corpus/documents/graph.json
+++ b/scripts/ai-harness/examples/synthetic-corpus/documents/graph.json
@@ -1,0 +1,98 @@
+{
+  "rowOrder": [
+    "row-1"
+  ],
+  "rowMap": {
+    "row-1": {
+      "id": "row-1",
+      "isSectionHeader": false,
+      "tiles": [
+        {
+          "tileId": "graph-tile"
+        }
+      ]
+    }
+  },
+  "tileMap": {
+    "graph-tile": {
+      "id": "graph-tile",
+      "content": {
+        "type": "Graph",
+        "plotType": "scatterPlot",
+        "xAttributeLabel": "graph-fixture-marker",
+        "yAttributeLabel": "Height (cm)",
+        "axes": {
+          "bottom": {
+            "min": 0,
+            "max": 10
+          },
+          "left": {
+            "min": 0,
+            "max": 25
+          }
+        },
+        "layers": [
+          {
+            "editable": true,
+            "config": {
+              "dataset": "graph-data",
+              "_attributeDescriptions": {
+                "x": {
+                  "attributeID": "graph-data-x"
+                }
+              },
+              "_yAttributeDescriptions": [
+                {
+                  "attributeID": "graph-data-y"
+                }
+              ]
+            }
+          }
+        ],
+        "adornments": []
+      }
+    }
+  },
+  "sharedModelMap": {
+    "shared-graph-data": {
+      "sharedModel": {
+        "type": "SharedDataSet",
+        "id": "shared-graph-data",
+        "providerId": "graph-tile",
+        "dataSet": {
+          "id": "graph-data",
+          "name": "Latch trials",
+          "attributes": [
+            {
+              "id": "graph-data-x",
+              "name": "Trial",
+              "values": [
+                "1",
+                "2"
+              ]
+            },
+            {
+              "id": "graph-data-y",
+              "name": "Height (cm)",
+              "values": [
+                "12",
+                "19"
+              ]
+            }
+          ],
+          "cases": [
+            {
+              "__id__": "graph-data-case-1"
+            },
+            {
+              "__id__": "graph-data-case-2"
+            }
+          ]
+        }
+      },
+      "tiles": [
+        "graph-tile"
+      ]
+    }
+  }
+}

--- a/scripts/ai-harness/examples/synthetic-corpus/documents/iframe-interactive.json
+++ b/scripts/ai-harness/examples/synthetic-corpus/documents/iframe-interactive.json
@@ -1,0 +1,26 @@
+{
+  "rowOrder": [
+    "row-1"
+  ],
+  "rowMap": {
+    "row-1": {
+      "id": "row-1",
+      "isSectionHeader": false,
+      "tiles": [
+        {
+          "tileId": "iframe-interactive-tile"
+        }
+      ]
+    }
+  },
+  "tileMap": {
+    "iframe-interactive-tile": {
+      "id": "iframe-interactive-tile",
+      "content": {
+        "type": "IframeInteractive",
+        "fixtureMarker": "iframe-interactive-fixture-marker",
+        "url": "https://example.org/interactives/latch"
+      }
+    }
+  }
+}

--- a/scripts/ai-harness/examples/synthetic-corpus/documents/image.json
+++ b/scripts/ai-harness/examples/synthetic-corpus/documents/image.json
@@ -1,0 +1,26 @@
+{
+  "rowOrder": [
+    "row-1"
+  ],
+  "rowMap": {
+    "row-1": {
+      "id": "row-1",
+      "isSectionHeader": false,
+      "tiles": [
+        {
+          "tileId": "image-tile"
+        }
+      ]
+    }
+  },
+  "tileMap": {
+    "image-tile": {
+      "id": "image-tile",
+      "content": {
+        "type": "Image",
+        "url": "curriculum/images/latch-sketch.png",
+        "fixtureMarker": "image-fixture-marker"
+      }
+    }
+  }
+}

--- a/scripts/ai-harness/examples/synthetic-corpus/documents/mixed.json
+++ b/scripts/ai-harness/examples/synthetic-corpus/documents/mixed.json
@@ -1,0 +1,64 @@
+{
+  "rowOrder": [
+    "row-1",
+    "row-2"
+  ],
+  "rowMap": {
+    "row-1": {
+      "id": "row-1",
+      "isSectionHeader": false,
+      "tiles": [
+        {
+          "tileId": "mixed-text-tile"
+        }
+      ]
+    },
+    "row-2": {
+      "id": "row-2",
+      "isSectionHeader": false,
+      "tiles": [
+        {
+          "tileId": "mixed-drawing-tile"
+        }
+      ]
+    }
+  },
+  "tileMap": {
+    "mixed-text-tile": {
+      "id": "mixed-text-tile",
+      "content": {
+        "type": "Text",
+        "format": "markdown",
+        "text": "We drew the latch and then wrote up why it works. mixed-fixture-marker"
+      }
+    },
+    "mixed-drawing-tile": {
+      "id": "mixed-drawing-tile",
+      "content": {
+        "type": "Drawing",
+        "objects": [
+          {
+            "type": "rectangle",
+            "x": 5,
+            "y": 5,
+            "width": 90,
+            "height": 45,
+            "fill": "#ffffff",
+            "stroke": "#000000",
+            "strokeWidth": 2,
+            "strokeDashArray": "solid"
+          },
+          {
+            "type": "text",
+            "x": 12,
+            "y": 60,
+            "width": 120,
+            "height": 20,
+            "stroke": "#000000",
+            "text": "hinge"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/scripts/ai-harness/examples/synthetic-corpus/documents/numberline.json
+++ b/scripts/ai-harness/examples/synthetic-corpus/documents/numberline.json
@@ -1,0 +1,70 @@
+{
+  "rowOrder": [
+    "row-1"
+  ],
+  "rowMap": {
+    "row-1": {
+      "id": "row-1",
+      "isSectionHeader": false,
+      "tiles": [
+        {
+          "tileId": "numberline-tile"
+        }
+      ]
+    }
+  },
+  "tileMap": {
+    "numberline-tile": {
+      "id": "numberline-tile",
+      "content": {
+        "type": "Numberline",
+        "fixtureMarker": "numberline-fixture-marker",
+        "min": 0,
+        "max": 10,
+        "points": {}
+      }
+    }
+  },
+  "sharedModelMap": {
+    "shared-numberline-data": {
+      "sharedModel": {
+        "type": "SharedDataSet",
+        "id": "shared-numberline-data",
+        "providerId": "numberline-tile",
+        "dataSet": {
+          "id": "numberline-data",
+          "name": "Latch forces",
+          "attributes": [
+            {
+              "id": "numberline-data-x",
+              "name": "Trial",
+              "values": [
+                "1",
+                "2"
+              ]
+            },
+            {
+              "id": "numberline-data-y",
+              "name": "Height (cm)",
+              "values": [
+                "12",
+                "19"
+              ]
+            }
+          ],
+          "cases": [
+            {
+              "__id__": "numberline-data-case-1"
+            },
+            {
+              "__id__": "numberline-data-case-2"
+            }
+          ]
+        }
+      },
+      "tiles": [
+        "numberline-tile"
+      ]
+    }
+  }
+}

--- a/scripts/ai-harness/examples/synthetic-corpus/documents/placeholder.json
+++ b/scripts/ai-harness/examples/synthetic-corpus/documents/placeholder.json
@@ -1,0 +1,31 @@
+{
+  "rowOrder": [
+    "section-1",
+    "row-2"
+  ],
+  "rowMap": {
+    "section-1": {
+      "id": "section-1",
+      "isSectionHeader": true,
+      "sectionId": "placeholder-fixture-marker"
+    },
+    "row-2": {
+      "id": "row-2",
+      "isSectionHeader": false,
+      "tiles": [
+        {
+          "tileId": "placeholder-tile"
+        }
+      ]
+    }
+  },
+  "tileMap": {
+    "placeholder-tile": {
+      "id": "placeholder-tile",
+      "content": {
+        "type": "Placeholder",
+        "sectionId": "placeholder-fixture-marker"
+      }
+    }
+  }
+}

--- a/scripts/ai-harness/examples/synthetic-corpus/documents/question.json
+++ b/scripts/ai-harness/examples/synthetic-corpus/documents/question.json
@@ -1,0 +1,63 @@
+{
+  "rowOrder": [
+    "row-1"
+  ],
+  "rowMap": {
+    "row-1": {
+      "id": "row-1",
+      "isSectionHeader": false,
+      "tiles": [
+        {
+          "tileId": "question-tile"
+        }
+      ]
+    }
+  },
+  "tileMap": {
+    "question-tile": {
+      "id": "question-tile",
+      "content": {
+        "type": "Question",
+        "questionId": "question-fixture-marker",
+        "rowOrder": [
+          "question-row-1",
+          "question-row-2"
+        ],
+        "rowMap": {
+          "question-row-1": {
+            "id": "question-row-1",
+            "tiles": [
+              {
+                "tileId": "question-prompt"
+              }
+            ]
+          },
+          "question-row-2": {
+            "id": "question-row-2",
+            "tiles": [
+              {
+                "tileId": "question-response"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "question-prompt": {
+      "id": "question-prompt",
+      "content": {
+        "type": "Text",
+        "format": "markdown",
+        "text": "What problem does your design solve?"
+      }
+    },
+    "question-response": {
+      "id": "question-response",
+      "content": {
+        "type": "Text",
+        "format": "markdown",
+        "text": "It keeps the lunchbox shut on the bus."
+      }
+    }
+  }
+}

--- a/scripts/ai-harness/examples/synthetic-corpus/documents/simulator.json
+++ b/scripts/ai-harness/examples/synthetic-corpus/documents/simulator.json
@@ -1,0 +1,44 @@
+{
+  "rowOrder": [
+    "row-1"
+  ],
+  "rowMap": {
+    "row-1": {
+      "id": "row-1",
+      "isSectionHeader": false,
+      "tiles": [
+        {
+          "tileId": "simulator-tile"
+        }
+      ]
+    }
+  },
+  "tileMap": {
+    "simulator-tile": {
+      "id": "simulator-tile",
+      "content": {
+        "type": "Simulator",
+        "simulation": "terrarium"
+      },
+      "title": "simulator-fixture-marker"
+    }
+  },
+  "sharedModelMap": {
+    "shared-simulator-variables": {
+      "sharedModel": {
+        "type": "SharedVariables",
+        "id": "shared-simulator-variables",
+        "variables": [
+          {
+            "id": "simulator-var-1",
+            "name": "temperature",
+            "displayName": "Temperature",
+            "unit": "C",
+            "value": 22
+          }
+        ]
+      },
+      "tiles": []
+    }
+  }
+}

--- a/scripts/ai-harness/examples/synthetic-corpus/documents/starter.json
+++ b/scripts/ai-harness/examples/synthetic-corpus/documents/starter.json
@@ -1,0 +1,26 @@
+{
+  "rowOrder": [
+    "row-1"
+  ],
+  "rowMap": {
+    "row-1": {
+      "id": "row-1",
+      "isSectionHeader": false,
+      "tiles": [
+        {
+          "tileId": "starter-tile"
+        }
+      ]
+    }
+  },
+  "tileMap": {
+    "starter-tile": {
+      "id": "starter-tile",
+      "content": {
+        "type": "Starter",
+        "fixtureMarker": "starter-fixture-marker",
+        "text": "starter tile placeholder content"
+      }
+    }
+  }
+}

--- a/scripts/ai-harness/examples/synthetic-corpus/documents/table.json
+++ b/scripts/ai-harness/examples/synthetic-corpus/documents/table.json
@@ -1,0 +1,67 @@
+{
+  "rowOrder": [
+    "row-1"
+  ],
+  "rowMap": {
+    "row-1": {
+      "id": "row-1",
+      "isSectionHeader": false,
+      "tiles": [
+        {
+          "tileId": "table-tile"
+        }
+      ]
+    }
+  },
+  "tileMap": {
+    "table-tile": {
+      "id": "table-tile",
+      "content": {
+        "type": "Table",
+        "columnWidths": {}
+      }
+    }
+  },
+  "sharedModelMap": {
+    "shared-table-data": {
+      "sharedModel": {
+        "type": "SharedDataSet",
+        "id": "shared-table-data",
+        "providerId": "table-tile",
+        "dataSet": {
+          "id": "table-data",
+          "name": "table-fixture-marker",
+          "attributes": [
+            {
+              "id": "table-data-x",
+              "name": "Latch design",
+              "values": [
+                "hook",
+                "magnet"
+              ]
+            },
+            {
+              "id": "table-data-y",
+              "name": "Force to open (N)",
+              "values": [
+                "4",
+                "2"
+              ]
+            }
+          ],
+          "cases": [
+            {
+              "__id__": "table-case-1"
+            },
+            {
+              "__id__": "table-case-2"
+            }
+          ]
+        }
+      },
+      "tiles": [
+        "table-tile"
+      ]
+    }
+  }
+}

--- a/scripts/ai-harness/examples/synthetic-corpus/documents/text.json
+++ b/scripts/ai-harness/examples/synthetic-corpus/documents/text.json
@@ -1,0 +1,26 @@
+{
+  "rowOrder": [
+    "row-1"
+  ],
+  "rowMap": {
+    "row-1": {
+      "id": "row-1",
+      "isSectionHeader": false,
+      "tiles": [
+        {
+          "tileId": "text-tile"
+        }
+      ]
+    }
+  },
+  "tileMap": {
+    "text-tile": {
+      "id": "text-tile",
+      "content": {
+        "type": "Text",
+        "format": "markdown",
+        "text": "Our lunchbox latch is for a first grader who cannot work a stiff clasp. text-fixture-marker"
+      }
+    }
+  }
+}

--- a/scripts/ai-harness/examples/synthetic-corpus/documents/timeline.json
+++ b/scripts/ai-harness/examples/synthetic-corpus/documents/timeline.json
@@ -1,0 +1,27 @@
+{
+  "rowOrder": [
+    "row-1"
+  ],
+  "rowMap": {
+    "row-1": {
+      "id": "row-1",
+      "isSectionHeader": false,
+      "tiles": [
+        {
+          "tileId": "timeline-tile"
+        }
+      ]
+    }
+  },
+  "tileMap": {
+    "timeline-tile": {
+      "id": "timeline-tile",
+      "content": {
+        "type": "Timeline",
+        "fixtureMarker": "timeline-fixture-marker",
+        "startTime": 0,
+        "endTime": 60
+      }
+    }
+  }
+}

--- a/scripts/ai-harness/examples/synthetic-corpus/documents/unknown.json
+++ b/scripts/ai-harness/examples/synthetic-corpus/documents/unknown.json
@@ -1,0 +1,26 @@
+{
+  "rowOrder": [
+    "row-1"
+  ],
+  "rowMap": {
+    "row-1": {
+      "id": "row-1",
+      "isSectionHeader": false,
+      "tiles": [
+        {
+          "tileId": "unknown-tile"
+        }
+      ]
+    }
+  },
+  "tileMap": {
+    "unknown-tile": {
+      "id": "unknown-tile",
+      "content": {
+        "type": "SomeFutureTile",
+        "fixtureMarker": "unknown-fixture-marker",
+        "label": "a tile type this build of CLUE has never heard of"
+      }
+    }
+  }
+}

--- a/scripts/ai-harness/examples/synthetic-corpus/documents/wave-runner.json
+++ b/scripts/ai-harness/examples/synthetic-corpus/documents/wave-runner.json
@@ -1,0 +1,26 @@
+{
+  "rowOrder": [
+    "row-1"
+  ],
+  "rowMap": {
+    "row-1": {
+      "id": "row-1",
+      "isSectionHeader": false,
+      "tiles": [
+        {
+          "tileId": "wave-runner-tile"
+        }
+      ]
+    }
+  },
+  "tileMap": {
+    "wave-runner-tile": {
+      "id": "wave-runner-tile",
+      "content": {
+        "type": "WaveRunner",
+        "fixtureMarker": "wave-runner-fixture-marker",
+        "envelopes": {}
+      }
+    }
+  }
+}

--- a/scripts/ai-harness/examples/synthetic-corpus/expectations.json
+++ b/scripts/ai-harness/examples/synthetic-corpus/expectations.json
@@ -1,0 +1,373 @@
+{
+  "schemaVersion": 1,
+  "corpus": "synthetic-corpus",
+  "documents": {
+    "ai": {
+      "expectDistinctiveInDefaultSummary": false,
+      "defaultSummaryMustSucceed": true,
+      "minimalSummaryMustSucceed": true,
+      "distinctiveString": "ai-fixture-marker",
+      "computedModality": "visual-only",
+      "tileTypes": [
+        "AI"
+      ],
+      "capability": {
+        "containsStudentText": false,
+        "requiresVisualRepresentation": true
+      },
+      "handlerTier": "fallback"
+    },
+    "bar-graph": {
+      "expectDistinctiveInDefaultSummary": false,
+      "defaultSummaryMustSucceed": true,
+      "minimalSummaryMustSucceed": true,
+      "distinctiveString": "bar-graph-fixture-marker",
+      "computedModality": "visual-only",
+      "tileTypes": [
+        "BarGraph"
+      ],
+      "capability": {
+        "containsStudentText": false,
+        "requiresVisualRepresentation": true
+      },
+      "handlerTier": "fallback"
+    },
+    "data-card": {
+      "expectDistinctiveInDefaultSummary": false,
+      "defaultSummaryMustSucceed": true,
+      "minimalSummaryMustSucceed": true,
+      "distinctiveString": "data-card-fixture-marker",
+      "computedModality": "visual-only",
+      "tileTypes": [
+        "DataCard"
+      ],
+      "capability": {
+        "containsStudentText": false,
+        "requiresVisualRepresentation": true
+      },
+      "handlerTier": "fallback"
+    },
+    "dataflow": {
+      "expectDistinctiveInDefaultSummary": true,
+      "defaultSummaryMustSucceed": true,
+      "minimalSummaryMustSucceed": true,
+      "distinctiveString": "dataflow-fixture-marker",
+      "computedModality": "mixed",
+      "tileTypes": [
+        "Dataflow"
+      ],
+      "capability": {
+        "containsStudentText": true,
+        "requiresVisualRepresentation": true
+      },
+      "handlerTier": "full"
+    },
+    "diagram": {
+      "expectDistinctiveInDefaultSummary": false,
+      "defaultSummaryMustSucceed": true,
+      "minimalSummaryMustSucceed": true,
+      "distinctiveString": "diagram-fixture-marker",
+      "computedModality": "visual-only",
+      "tileTypes": [
+        "Diagram"
+      ],
+      "capability": {
+        "containsStudentText": false,
+        "requiresVisualRepresentation": true
+      },
+      "handlerTier": "fallback"
+    },
+    "drawing": {
+      "expectDistinctiveInDefaultSummary": false,
+      "defaultSummaryMustSucceed": true,
+      "minimalSummaryMustSucceed": true,
+      "distinctiveString": "drawing-fixture-marker",
+      "computedModality": "visual-only",
+      "tileTypes": [
+        "Drawing"
+      ],
+      "capability": {
+        "containsStudentText": false,
+        "requiresVisualRepresentation": true
+      },
+      "handlerTier": "stub",
+      "notes": "No text objects, so the instance-level check keeps containsStudentText false. The stub handler emits one sentence — that weak summary is the measurement, not a failure."
+    },
+    "empty": {
+      "expectDistinctiveInDefaultSummary": false,
+      "defaultSummaryMustSucceed": true,
+      "minimalSummaryMustSucceed": true,
+      "distinctiveString": "empty-fixture-marker",
+      "computedModality": "empty",
+      "tileTypes": [],
+      "capability": {
+        "containsStudentText": false,
+        "requiresVisualRepresentation": false
+      },
+      "handlerTier": "full",
+      "notes": "Intentionally contentless, so there is nowhere to embed the distinctive string."
+    },
+    "error-test": {
+      "expectDistinctiveInDefaultSummary": false,
+      "defaultSummaryMustSucceed": true,
+      "minimalSummaryMustSucceed": true,
+      "distinctiveString": "error-test-fixture-marker",
+      "computedModality": "visual-only",
+      "tileTypes": [
+        "ErrorTest"
+      ],
+      "capability": {
+        "containsStudentText": false,
+        "requiresVisualRepresentation": true
+      },
+      "handlerTier": "fallback"
+    },
+    "expression": {
+      "expectDistinctiveInDefaultSummary": false,
+      "defaultSummaryMustSucceed": true,
+      "minimalSummaryMustSucceed": true,
+      "distinctiveString": "expression-fixture-marker",
+      "computedModality": "visual-only",
+      "tileTypes": [
+        "Expression"
+      ],
+      "capability": {
+        "containsStudentText": false,
+        "requiresVisualRepresentation": true
+      },
+      "handlerTier": "fallback"
+    },
+    "geometry": {
+      "expectDistinctiveInDefaultSummary": false,
+      "defaultSummaryMustSucceed": true,
+      "minimalSummaryMustSucceed": true,
+      "distinctiveString": "geometry-fixture-marker",
+      "computedModality": "visual-only",
+      "tileTypes": [
+        "Geometry"
+      ],
+      "capability": {
+        "containsStudentText": false,
+        "requiresVisualRepresentation": true
+      },
+      "handlerTier": "fallback"
+    },
+    "graph": {
+      "expectDistinctiveInDefaultSummary": true,
+      "defaultSummaryMustSucceed": true,
+      "minimalSummaryMustSucceed": true,
+      "distinctiveString": "graph-fixture-marker",
+      "computedModality": "visual-only",
+      "tileTypes": [
+        "Graph"
+      ],
+      "capability": {
+        "containsStudentText": false,
+        "requiresVisualRepresentation": true
+      },
+      "handlerTier": "full"
+    },
+    "iframe-interactive": {
+      "expectDistinctiveInDefaultSummary": false,
+      "defaultSummaryMustSucceed": true,
+      "minimalSummaryMustSucceed": true,
+      "distinctiveString": "iframe-interactive-fixture-marker",
+      "computedModality": "visual-only",
+      "tileTypes": [
+        "IframeInteractive"
+      ],
+      "capability": {
+        "containsStudentText": false,
+        "requiresVisualRepresentation": true
+      },
+      "handlerTier": "fallback"
+    },
+    "image": {
+      "expectDistinctiveInDefaultSummary": false,
+      "defaultSummaryMustSucceed": true,
+      "minimalSummaryMustSucceed": true,
+      "distinctiveString": "image-fixture-marker",
+      "computedModality": "visual-only",
+      "tileTypes": [
+        "Image"
+      ],
+      "capability": {
+        "containsStudentText": false,
+        "requiresVisualRepresentation": true
+      },
+      "handlerTier": "stub"
+    },
+    "mixed": {
+      "expectDistinctiveInDefaultSummary": true,
+      "defaultSummaryMustSucceed": true,
+      "minimalSummaryMustSucceed": true,
+      "distinctiveString": "mixed-fixture-marker",
+      "computedModality": "mixed",
+      "tileTypes": [
+        "Text",
+        "Drawing"
+      ],
+      "capability": {
+        "containsStudentText": true,
+        "requiresVisualRepresentation": true
+      },
+      "handlerTier": "full",
+      "notes": "handlerTier describes the Text tile that carries the marker. The Drawing tile is stub tier, and its text object is what the drawing instance-level check looks for."
+    },
+    "numberline": {
+      "expectDistinctiveInDefaultSummary": false,
+      "defaultSummaryMustSucceed": true,
+      "minimalSummaryMustSucceed": true,
+      "distinctiveString": "numberline-fixture-marker",
+      "computedModality": "visual-only",
+      "tileTypes": [
+        "Numberline"
+      ],
+      "capability": {
+        "containsStudentText": false,
+        "requiresVisualRepresentation": true
+      },
+      "handlerTier": "fallback"
+    },
+    "placeholder": {
+      "expectDistinctiveInDefaultSummary": true,
+      "defaultSummaryMustSucceed": true,
+      "minimalSummaryMustSucceed": true,
+      "distinctiveString": "placeholder-fixture-marker",
+      "computedModality": "empty",
+      "tileTypes": [
+        "Placeholder"
+      ],
+      "capability": {
+        "containsStudentText": false,
+        "requiresVisualRepresentation": false
+      },
+      "handlerTier": "full",
+      "notes": "A section a student has not started. The placeholder handler emits nothing, so the marker appears via the section heading."
+    },
+    "question": {
+      "expectDistinctiveInDefaultSummary": true,
+      "defaultSummaryMustSucceed": true,
+      "minimalSummaryMustSucceed": true,
+      "distinctiveString": "question-fixture-marker",
+      "computedModality": "text-only",
+      "tileTypes": [
+        "Question",
+        "Text"
+      ],
+      "capability": {
+        "containsStudentText": true,
+        "requiresVisualRepresentation": false
+      },
+      "handlerTier": "partial",
+      "notes": "The authored prompt is not student text; the response tile is what makes this document text-only."
+    },
+    "simulator": {
+      "expectDistinctiveInDefaultSummary": true,
+      "defaultSummaryMustSucceed": true,
+      "minimalSummaryMustSucceed": true,
+      "distinctiveString": "simulator-fixture-marker",
+      "computedModality": "visual-only",
+      "tileTypes": [
+        "Simulator"
+      ],
+      "capability": {
+        "containsStudentText": false,
+        "requiresVisualRepresentation": true
+      },
+      "handlerTier": "partial",
+      "notes": "The simulator handler describes the built-in simulation, not the tile, so the marker rides in the tile title."
+    },
+    "starter": {
+      "expectDistinctiveInDefaultSummary": false,
+      "defaultSummaryMustSucceed": true,
+      "minimalSummaryMustSucceed": true,
+      "distinctiveString": "starter-fixture-marker",
+      "computedModality": "visual-only",
+      "tileTypes": [
+        "Starter"
+      ],
+      "capability": {
+        "containsStudentText": false,
+        "requiresVisualRepresentation": true
+      },
+      "handlerTier": "fallback"
+    },
+    "table": {
+      "expectDistinctiveInDefaultSummary": true,
+      "defaultSummaryMustSucceed": true,
+      "minimalSummaryMustSucceed": true,
+      "distinctiveString": "table-fixture-marker",
+      "computedModality": "text-only",
+      "tileTypes": [
+        "Table"
+      ],
+      "capability": {
+        "containsStudentText": true,
+        "requiresVisualRepresentation": false
+      },
+      "handlerTier": "full"
+    },
+    "text": {
+      "expectDistinctiveInDefaultSummary": true,
+      "defaultSummaryMustSucceed": true,
+      "minimalSummaryMustSucceed": true,
+      "distinctiveString": "text-fixture-marker",
+      "computedModality": "text-only",
+      "tileTypes": [
+        "Text"
+      ],
+      "capability": {
+        "containsStudentText": true,
+        "requiresVisualRepresentation": false
+      },
+      "handlerTier": "full"
+    },
+    "timeline": {
+      "expectDistinctiveInDefaultSummary": false,
+      "defaultSummaryMustSucceed": true,
+      "minimalSummaryMustSucceed": true,
+      "distinctiveString": "timeline-fixture-marker",
+      "computedModality": "visual-only",
+      "tileTypes": [
+        "Timeline"
+      ],
+      "capability": {
+        "containsStudentText": false,
+        "requiresVisualRepresentation": true
+      },
+      "handlerTier": "fallback"
+    },
+    "unknown": {
+      "expectDistinctiveInDefaultSummary": false,
+      "defaultSummaryMustSucceed": true,
+      "minimalSummaryMustSucceed": true,
+      "distinctiveString": "unknown-fixture-marker",
+      "computedModality": "visual-only",
+      "tileTypes": [
+        "SomeFutureTile"
+      ],
+      "capability": {
+        "containsStudentText": false,
+        "requiresVisualRepresentation": true
+      },
+      "handlerTier": "fallback",
+      "notes": "An unregistered tile type, which is what \"Unknown\" means in practice. It is conservatively classified as needing an image."
+    },
+    "wave-runner": {
+      "expectDistinctiveInDefaultSummary": false,
+      "defaultSummaryMustSucceed": true,
+      "minimalSummaryMustSucceed": true,
+      "distinctiveString": "wave-runner-fixture-marker",
+      "computedModality": "visual-only",
+      "tileTypes": [
+        "WaveRunner"
+      ],
+      "capability": {
+        "containsStudentText": false,
+        "requiresVisualRepresentation": true
+      },
+      "handlerTier": "fallback"
+    }
+  }
+}

--- a/scripts/ai-harness/experiments/text-baselines.json
+++ b/scripts/ai-harness/experiments/text-baselines.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "name": "text-baselines",
+  "runs": [
+    { "id": "text-default", "message": "text-only", "textVariant": "default", "prompt": "categorize-design-default" },
+    { "id": "text-minimal", "message": "text-only", "textVariant": "minimal", "prompt": "categorize-design-default" }
+  ]
+}

--- a/scripts/ai-harness/harness.ts
+++ b/scripts/ai-harness/harness.ts
@@ -1,0 +1,360 @@
+/**
+ * CLUE AI evaluation harness (CLUE-371, milestone 1).
+ *
+ *   npx tsx harness.ts import    --from <dir> --corpus <name> [--source synthetic|demo|qa] [--prune]
+ *   npx tsx harness.ts represent --corpus <name> --variants default,minimal
+ *   npx tsx harness.ts plan      --corpus <name> --experiment <file>
+ *   npx tsx harness.ts run       --corpus <name> --experiment <file> --max-cost <usd>
+ *                                [--output <file>] [--no-cache | --refresh-cache]
+ *   npx tsx harness.ts report    --results <file>.jsonl
+ *
+ * See README.md for setup and per-command prerequisites.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import dotenv from "dotenv";
+import {
+  corpusPaths, defaultDataRoot, harnessRoot, importCorpus, readCorpusDocument, readJsonFile, readManifest,
+  readRepresentation, representationIsFresh, representationPath, writeJsonFile
+} from "./src/corpus.js";
+import { ResponseCache, cacheOptionsFor } from "./src/cache.js";
+import { CostLedger, loadPricingConfig, pricingFor } from "./src/cost.js";
+import {
+  CreateCompletion, buildTasks, currentRunMeta, kDefaultModel, openAiCompletion, readResultRows, runTasks
+} from "./src/execute.js";
+import { getTextVariant, textVariantIds } from "./src/represent-text.js";
+import { formatSummaryTable, summarizeResults, summaryPathFor, writeSummary } from "./src/report.js";
+import {
+  CorpusSource, corpusSources, kSchemaVersion, sha256Canonical, validateExperimentFile
+} from "./src/schemas.js";
+
+export interface HarnessDeps {
+  /** Injected by the smoke test so the whole CLI can run without a network or an API key. */
+  createCompletion?: CreateCompletion;
+  log?: (message: string) => void;
+  now?: () => Date;
+  /**
+   * Overridden by tests so they get their own corpora, caches and results. It must still point
+   * inside `data/` — nothing derived from a document is ever written outside that tree.
+   */
+  dataRoot?: string;
+}
+
+const promptsDir = path.join(harnessRoot, "prompts");
+
+// ---------------------------------------------------------------------------
+// argv
+// ---------------------------------------------------------------------------
+
+export interface ParsedArgs {
+  command: string;
+  flags: Record<string, string | true>;
+}
+
+const kBooleanFlags = new Set(["prune", "no-cache", "refresh-cache"]);
+
+/** Plain `--name value` pairs; a handful of flags are boolean. Unknown flags are errors. */
+export function parseArgs(argv: string[], knownFlags: Record<string, readonly string[]>): ParsedArgs {
+  const [command, ...rest] = argv;
+  if (!command) {
+    throw new Error(`Usage: harness.ts <${Object.keys(knownFlags).join("|")}> [flags]`);
+  }
+  const allowed = knownFlags[command];
+  if (!allowed) {
+    throw new Error(`Unknown command "${command}". Known commands: ${Object.keys(knownFlags).join(", ")}`);
+  }
+
+  const flags: Record<string, string | true> = {};
+  for (let index = 0; index < rest.length; index += 1) {
+    const token = rest[index];
+    if (!token.startsWith("--")) {
+      throw new Error(`Unexpected argument "${token}"; flags are --name value pairs`);
+    }
+    const name = token.slice(2);
+    if (!allowed.includes(name)) {
+      throw new Error(`Unknown flag "--${name}" for command "${command}". ` +
+        `Known flags: ${allowed.map((flag) => `--${flag}`).join(", ")}`);
+    }
+    if (name in flags) throw new Error(`Flag "--${name}" was given more than once`);
+    if (kBooleanFlags.has(name)) {
+      flags[name] = true;
+      continue;
+    }
+    const value = rest[index + 1];
+    if (value === undefined || value.startsWith("--")) {
+      throw new Error(`Flag "--${name}" needs a value`);
+    }
+    flags[name] = value;
+    index += 1;
+  }
+  return { command, flags };
+}
+
+const kKnownFlags = {
+  import: ["from", "corpus", "source", "prune"],
+  represent: ["corpus", "variants"],
+  plan: ["corpus", "experiment"],
+  run: ["corpus", "experiment", "max-cost", "output", "no-cache", "refresh-cache"],
+  report: ["results"]
+} as const;
+
+function required(flags: Record<string, string | true>, name: string): string {
+  const value = flags[name];
+  if (typeof value !== "string") throw new Error(`--${name} is required`);
+  return value;
+}
+
+// ---------------------------------------------------------------------------
+// Commands
+// ---------------------------------------------------------------------------
+
+function dataRootFor(deps: HarnessDeps): string {
+  return deps.dataRoot ?? defaultDataRoot();
+}
+
+/**
+ * Names the corpus as well as the experiment, so running the same experiment against two corpora does
+ * not append both into one file. Routed through the same containment check as `--output`: the corpus
+ * name and experiment name are both validated, but the check is cheap and this is the path that
+ * writes student work.
+ */
+function defaultOutputFile(dataRoot: string, corpus: string, experimentName: string): string {
+  // Absolute, so it resolves identically whatever the relative base is.
+  return resolveDataPath(path.join(dataRoot, "results", `${corpus}-${experimentName}.jsonl`),
+    "--output", dataRoot);
+}
+
+/**
+ * Resolves a results path and refuses anything outside the data root.
+ *
+ * Relative paths resolve against the harness directory, the same base as `--from` and `--experiment`
+ * and the same way the README writes them (`data/results/…`). Containment is then checked against the
+ * data root separately: result rows carry student work and never leave `data/`.
+ */
+export function resolveDataPath(
+  value: string, flag: string, dataRoot: string, base: string = harnessRoot
+): string {
+  const resolved = path.resolve(base, value);
+  const relative = path.relative(dataRoot, resolved);
+  if (relative === "" || relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error(`${flag} must name a file inside the harness data directory (${dataRoot}); ` +
+      `"${value}" resolves to ${resolved}. Result rows contain student work and never leave data/. ` +
+      `Try a path like "${path.join(path.relative(harnessRoot, dataRoot), "results", "my-run.jsonl")}".`);
+  }
+  return resolved;
+}
+
+function loadExperiment(file: string) {
+  const resolved = path.isAbsolute(file) ? file : path.resolve(harnessRoot, file);
+  const raw = readJsonFile(resolved);
+  const experiment = validateExperimentFile(raw, resolved, {
+    knownTextVariants: textVariantIds,
+    promptExists: (name) => fs.existsSync(path.join(promptsDir, `${name}.json`))
+  });
+  return { experiment, experimentSha256: sha256Canonical(raw), file: resolved };
+}
+
+function commandImport(flags: Record<string, string | true>, deps: HarnessDeps): void {
+  const log = deps.log ?? console.log;
+  const corpus = required(flags, "corpus");
+  const source = (flags.source ?? "synthetic") as CorpusSource;
+  if (!corpusSources.includes(source)) {
+    throw new Error(`--source must be one of ${corpusSources.join(", ")}, got "${String(source)}"`);
+  }
+  const result = importCorpus({
+    from: path.resolve(harnessRoot, required(flags, "from")),
+    corpus,
+    source,
+    prune: flags.prune === true,
+    dataRoot: dataRootFor(deps),
+    now: deps.now
+  });
+  for (const warning of result.warnings) log(`warning: ${warning}`);
+  log(`Imported ${result.imported.length} document(s) into corpus "${corpus}" ` +
+    `(${result.missing.length} missing, ${result.pruned.length} pruned).`);
+}
+
+function commandRepresent(flags: Record<string, string | true>, deps: HarnessDeps): void {
+  const log = deps.log ?? console.log;
+  const now = deps.now ?? (() => new Date());
+  const corpus = required(flags, "corpus");
+  const paths = corpusPaths(dataRootFor(deps), corpus);
+  const manifest = readManifest(paths);
+  const variantIds = required(flags, "variants").split(",").map((id) => id.trim()).filter(Boolean);
+  if (variantIds.length === 0) throw new Error("--variants needs at least one variant id");
+
+  let written = 0;
+  let reused = 0;
+  for (const variantId of variantIds) {
+    const variant = getTextVariant(variantId);
+    for (const document of manifest.documents) {
+      const file = representationPath(paths, variant.id, document.id);
+      if (fs.existsSync(file)) {
+        try {
+          if (representationIsFresh(readRepresentation(file), {
+            docId: document.id,
+            variantId: variant.id,
+            contentSha256: document.contentSha256,
+            variantVersion: variant.variantVersion
+          })) {
+            reused += 1;
+            continue;
+          }
+        } catch {
+          // An unreadable or invalid envelope is simply stale; regenerate it.
+        }
+      }
+      const content = readCorpusDocument(paths, document);
+      writeJsonFile(file, {
+        schemaVersion: kSchemaVersion,
+        docId: document.id,
+        variantId: variant.id,
+        variantVersion: variant.variantVersion,
+        sourceContentSha256: document.contentSha256,
+        generatedAt: now().toISOString(),
+        markdown: variant.render(content)
+      });
+      written += 1;
+    }
+  }
+  log(`Wrote ${written} representation(s), reused ${reused} still-fresh one(s).`);
+}
+
+function commandPlan(flags: Record<string, string | true>, deps: HarnessDeps): void {
+  const log = deps.log ?? console.log;
+  const corpus = required(flags, "corpus");
+  const { experiment } = loadExperiment(required(flags, "experiment"));
+  const pricingConfig = loadPricingConfig();
+  const pricing = pricingFor(pricingConfig, kDefaultModel);
+  const { tasks } = buildTasks({
+    corpusPaths: corpusPaths(dataRootFor(deps), corpus),
+    experiment,
+    promptsDir,
+    pricing
+  });
+
+  log(`Experiment "${experiment.name}": ${experiment.runs.length} run(s) × ` +
+    `${tasks.length / Math.max(1, experiment.runs.length)} document(s) = ${tasks.length} call(s).`);
+  log(`Model ${kDefaultModel}, prices effective ${pricingConfig.effectiveDate}, ` +
+    `max_completion_tokens ${pricing.maxOutputTokens}.`);
+  let total = 0;
+  for (const run of experiment.runs) {
+    const runTasksForRun = tasks.filter((task) => task.runId === run.id);
+    const runTotal = runTasksForRun.reduce((sum, task) => sum + task.worstCaseUsd, 0);
+    total += runTotal;
+    log(`  ${run.id}: ${runTasksForRun.length} call(s), worst case $${runTotal.toFixed(4)}`);
+  }
+  log(`Worst-case total (retries included): $${total.toFixed(4)}. No network access was used.`);
+}
+
+async function commandRun(flags: Record<string, string | true>, deps: HarnessDeps): Promise<void> {
+  const log = deps.log ?? console.log;
+  const corpus = required(flags, "corpus");
+  const { experiment, experimentSha256 } = loadExperiment(required(flags, "experiment"));
+  const maxCost = Number(required(flags, "max-cost"));
+  if (!Number.isFinite(maxCost) || maxCost <= 0) {
+    throw new Error(`--max-cost must be a positive number of US dollars, got "${String(flags["max-cost"])}"`);
+  }
+
+  const dataRoot = dataRootFor(deps);
+  const pricingConfig = loadPricingConfig();
+  const pricing = pricingFor(pricingConfig, kDefaultModel);
+  const { tasks } = buildTasks({
+    corpusPaths: corpusPaths(dataRoot, corpus),
+    experiment,
+    promptsDir,
+    pricing
+  });
+
+  const outputFile = typeof flags.output === "string"
+    ? resolveDataPath(flags.output, "--output", dataRoot)
+    : defaultOutputFile(dataRoot, corpus, experiment.name);
+
+  const cacheOptions = cacheOptionsFor(flags["no-cache"] === true, flags["refresh-cache"] === true);
+  // Resume runs before the cache is ever consulted, so completed rows in the output file would make
+  // both flags no-ops: the run would skip the very requests the user asked to re-execute. Fail loudly
+  // rather than silently doing nothing (or appending a second set of rows to the same file).
+  if (!cacheOptions.read) {
+    const alreadyComplete = readResultRows(outputFile)
+      .filter((row) => row.status !== "error" && row.requestKey !== null &&
+        row.corpus === corpus && row.experimentSha256 === experimentSha256);
+    if (alreadyComplete.length > 0) {
+      const flag = flags["no-cache"] === true ? "--no-cache" : "--refresh-cache";
+      throw new Error(`${flag} asks for fresh API calls, but ${outputFile} already holds ` +
+        `${alreadyComplete.length} completed row(s) for this corpus and experiment, which resume would ` +
+        "skip before the cache is consulted. Pass a fresh --output (or delete that file) to re-execute.");
+    }
+  }
+  const createCompletion = deps.createCompletion ?? openAiCompletion(requireApiKey());
+
+  const ledger = new CostLedger(maxCost);
+  const summary = await runTasks({
+    corpus,
+    experiment,
+    experimentSha256,
+    tasks,
+    outputFile,
+    ledger,
+    cache: new ResponseCache(path.join(dataRoot, "cache"), cacheOptions),
+    pricing,
+    runMeta: currentRunMeta(deps.now?.()),
+    createCompletion,
+    log
+  });
+
+  log(`Wrote ${summary.written} row(s) to ${outputFile} ` +
+    `(${summary.resumed} already complete, ${summary.cacheHits} from cache, ${summary.apiCalls} API call(s)).`);
+  log(`Reserved at peak $${summary.reservedPeakUsd.toFixed(4)} of the $${maxCost.toFixed(4)} ceiling; ` +
+    `actually spent $${summary.incurredUsd.toFixed(4)}.`);
+  if (summary.stoppedOnCeiling) log("Stopped early: the spend ceiling was reached.");
+}
+
+function commandReport(flags: Record<string, string | true>, deps: HarnessDeps): void {
+  const log = deps.log ?? console.log;
+  // Reports are derived from student work, so both the file read and the summary written beside it
+  // stay inside the data root.
+  const resultsFile = resolveDataPath(required(flags, "results"), "--results", dataRootFor(deps));
+  const rows = readResultRows(resultsFile);
+  const summary = summarizeResults(rows, resultsFile, deps.now?.());
+  const summaryFile = resolveDataPath(summaryPathFor(resultsFile), "--results", dataRootFor(deps));
+  log(formatSummaryTable(summary));
+  log(`\nWrote ${writeSummary(summary, summaryFile)}`);
+}
+
+function requireApiKey(): string {
+  dotenv.config({ path: path.join(harnessRoot, "..", ".env") });
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new Error("OPENAI_API_KEY is not set. Put it in scripts/.env or export it in your environment.");
+  }
+  return apiKey;
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+export async function main(argv: string[], deps: HarnessDeps = {}): Promise<void> {
+  const { command, flags } = parseArgs(argv, kKnownFlags);
+  switch (command) {
+    case "import": return commandImport(flags, deps);
+    case "represent": return commandRepresent(flags, deps);
+    case "plan": return commandPlan(flags, deps);
+    case "run": return commandRun(flags, deps);
+    case "report": return commandReport(flags, deps);
+    default: throw new Error(`Unknown command "${command}"`);
+  }
+}
+
+// Compared by basename rather than by the literal harness.ts path, so running through a symlink, a
+// compiled entry point or a differently-resolved path still starts the CLI instead of silently
+// importing it and doing nothing.
+const invokedDirectly = !!process.argv[1] &&
+  path.basename(process.argv[1]).replace(/\.[^.]+$/, "") === "harness";
+
+if (invokedDirectly) {
+  main(process.argv.slice(2)).catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/ai-harness/harness.ts
+++ b/scripts/ai-harness/harness.ts
@@ -314,11 +314,23 @@ function commandReport(flags: Record<string, string | true>, deps: HarnessDeps):
   // Reports are derived from student work, so both the file read and the summary written beside it
   // stay inside the data root.
   const resultsFile = resolveDataPath(required(flags, "results"), "--results", dataRootFor(deps));
+  // readResultRows treats a missing file as "no rows", which is what `run` needs when it creates a
+  // fresh output file. For `report` that is a typo waiting to be misread as a result: an all-zeros
+  // table and an empty summary.json written over whatever was there before.
+  if (!fs.existsSync(resultsFile)) {
+    throw new Error(`No results file at ${resultsFile}. Run \`harness.ts run\` first, or check ` +
+      "--results — the default output path is data/results/<corpus>-<experiment>.jsonl.");
+  }
   const rows = readResultRows(resultsFile);
+  if (rows.length === 0) {
+    throw new Error(`${resultsFile} contains no result rows, so there is nothing to report.`);
+  }
   const summary = summarizeResults(rows, resultsFile, deps.now?.());
   const summaryFile = resolveDataPath(summaryPathFor(resultsFile), "--results", dataRootFor(deps));
   log(formatSummaryTable(summary));
-  log(`\nWrote ${writeSummary(summary, summaryFile)}`);
+  log(`\nRead ${summary.rows} row(s) from ${resultsFile}; ` +
+    `${summary.currentRows} current, ${summary.superseded.rows} superseded by a later re-run.`);
+  log(`Wrote ${writeSummary(summary, summaryFile)}`);
 }
 
 function requireApiKey(): string {

--- a/scripts/ai-harness/jest.config.js
+++ b/scripts/ai-harness/jest.config.js
@@ -1,0 +1,11 @@
+/** ESM + ts-jest. The `test` script sets NODE_OPTIONS=--experimental-vm-modules. */
+export default {
+  preset: "ts-jest/presets/default-esm",
+  testEnvironment: "node",
+  extensionsToTreatAsEsm: [".ts"],
+  // NodeNext-style ".js" specifiers in TypeScript sources resolve back to the ".ts" files.
+  moduleNameMapper: { "^(\\.{1,2}/.*)\\.js$": "$1" },
+  transform: { "^.+\\.tsx?$": ["ts-jest", { useESM: true }] },
+  testMatch: ["<rootDir>/test/**/*.test.ts"],
+  testPathIgnorePatterns: ["/node_modules/", "/data/"]
+};

--- a/scripts/ai-harness/package-lock.json
+++ b/scripts/ai-harness/package-lock.json
@@ -1,0 +1,4420 @@
+{
+  "name": "clue-ai-harness",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "clue-ai-harness",
+      "version": "1.0.0",
+      "dependencies": {
+        "dotenv": "^16.4.5",
+        "openai": "6.45.0",
+        "zod": "3.25.76"
+      },
+      "devDependencies": {
+        "@types/jest": "^29.5.12",
+        "@types/node": "^20.14.0",
+        "jest": "^29.7.0",
+        "ts-jest": "^29.2.4",
+        "tsx": "^4.16.2",
+        "typescript": "~5.9.2"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-bigint": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-properties": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+      "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-static-block": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+      "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-attributes": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.29.7.tgz",
+      "integrity": "sha512-zGYcYfq/WmZ4V+kBIXQon9dSSc8ircGZqw9ZaNhhGj9nZkeBu1jHLBDQqYYi5WA9uawvA2sIMbry2nCFhf5Djg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-meta": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
+      "integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-numeric-separator": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-private-property-in-object": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-top-level-await": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+      "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz",
+      "integrity": "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.8",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.8",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/console": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+      "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/core": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
+      "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/reporters": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-changed-files": "^29.7.0",
+        "jest-config": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-resolve-dependencies": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/environment": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
+      "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.7.0",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/fake-timers": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+      "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@types/node": "*",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/globals": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+      "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/reporters": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
+      "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.1",
+        "strip-ansi": "^6.0.0",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/source-map": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
+      "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.2.9"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-result": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+      "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "collect-v8-coverage": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-sequencer": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+      "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/transform": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
+      "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "babel-plugin-istanbul": "^6.1.1",
+        "chalk": "^4.0.0",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pirates": "^4.0.4",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^4.0.2"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/types": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.12",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.12.tgz",
+      "integrity": "sha512-hhyNJ+nbR6ZR7pToHvllEFun9TL0sbL+tk/ON75lo+Xas054uez98qRbsuNt7MBCyZKK4+8Yli/OAGZhmfBZ/g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/graceful-fs": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
+      "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "29.5.14",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
+      "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/babel-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
+      "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/transform": "^29.7.0",
+        "@types/babel__core": "^7.1.14",
+        "babel-plugin-istanbul": "^6.1.1",
+        "babel-preset-jest": "^29.6.3",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.8.0"
+      }
+    },
+    "node_modules/babel-plugin-istanbul": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
+      "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-instrument": "^5.0.4",
+        "test-exclude": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-istanbul/node_modules/istanbul-lib-instrument": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.12.3",
+        "@babel/parser": "^7.14.7",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-jest-hoist": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
+      "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.3.3",
+        "@babel/types": "^7.3.3",
+        "@types/babel__core": "^7.1.14",
+        "@types/babel__traverse": "^7.0.6"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/babel-preset-current-node-syntax": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
+      "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-bigint": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.12.13",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5",
+        "@babel/plugin-syntax-import-attributes": "^7.24.7",
+        "@babel/plugin-syntax-import-meta": "^7.10.4",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+        "@babel/plugin-syntax-top-level-await": "^7.14.5"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/babel-preset-jest": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
+      "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-plugin-jest-hoist": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.13",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.13.tgz",
+      "integrity": "sha512-k9HNuUVMlqVjQ9UHzfPjIqiDbWw7WqT1AoT7GL8VwvF3r0ZfArtgiSPAlmupyNquNgOJHTuH4CKYf8ttMTWBTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stable-stringify": "2.x"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/bser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001809",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
+      "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/collect-v8-coverage": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
+      "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/create-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
+      "integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "prompts": "^2.0.1"
+      },
+      "bin": {
+        "create-jest": "bin/create-jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/dedent": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.404",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.404.tgz",
+      "integrity": "sha512-3WJtd7/lVq2Jnuz6wed1l9+1ZD2u2Tet1/1NBc4Iedkmgbu+I7YuAqdAQ8T+VZtnwysMsAf3IqSq9D1gyZjA2g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emittery": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fb-watchman": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bser": "2.1.1"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/import-local": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+      "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-instrument/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
+      "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "import-local": "^3.0.2",
+        "jest-cli": "^29.7.0"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-changed-files": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
+      "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^5.0.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-circus": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
+      "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "dedent": "^1.0.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^29.7.0",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "pretty-format": "^29.7.0",
+        "pure-rand": "^6.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-cli": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
+      "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "create-jest": "^29.7.0",
+        "exit": "^0.1.2",
+        "import-local": "^3.0.2",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "yargs": "^17.3.1"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+      "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/test-sequencer": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-jest": "^29.7.0",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-circus": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "parse-json": "^5.2.0",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-docblock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+      "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-each": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
+      "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-environment-node": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
+      "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-get-type": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-haste-map": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+      "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/graceful-fs": "^4.1.3",
+        "@types/node": "*",
+        "anymatch": "^3.0.3",
+        "fb-watchman": "^2.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "walker": "^1.0.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.2"
+      }
+    },
+    "node_modules/jest-leak-detector": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+      "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-message-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@jest/types": "^29.6.3",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-mock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-pnp-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "jest-resolve": "*"
+      },
+      "peerDependenciesMeta": {
+        "jest-resolve": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-regex-util": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
+      "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
+      "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-pnp-resolver": "^1.2.2",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "resolve": "^1.20.0",
+        "resolve.exports": "^2.0.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve-dependencies": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
+      "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-regex-util": "^29.6.3",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runner": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
+      "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/environment": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "graceful-fs": "^4.2.9",
+        "jest-docblock": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-leak-detector": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-resolve": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runtime": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
+      "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/globals": "^29.7.0",
+        "@jest/source-map": "^29.6.3",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "cjs-module-lexer": "^1.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-snapshot": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+      "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@babel/generator": "^7.7.2",
+        "@babel/plugin-syntax-jsx": "^7.7.2",
+        "@babel/plugin-syntax-typescript": "^7.7.2",
+        "@babel/types": "^7.3.3",
+        "@jest/expect-utils": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0",
+        "chalk": "^4.0.0",
+        "expect": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^29.7.0",
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jest-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-validate": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
+      "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "leven": "^3.1.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-validate/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-watcher": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
+      "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "jest-util": "^29.7.0",
+        "string-length": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-worker": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-util": "^29.7.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/makeerror": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+      "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.53",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+      "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.45.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.45.0.tgz",
+      "integrity": "sha512-5DQVNErssk0afNpTTHUm/qZPU4iKR9OYdNid8Ib4puq4gHNNvGWZht2zY4h9a8JMF949Ik6m8gQutllVPbjdnw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-node": ">=3.972.0 <4",
+        "@smithy/hash-node": ">=4.3.0 <5",
+        "@smithy/signature-v4": ">=5.4.0 <6",
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-node": {
+          "optional": true
+        },
+        "@smithy/hash-node": {
+          "optional": true
+        },
+        "@smithy/signature-v4": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve.exports": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
+      "integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/string-length": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tmpl": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-jest": {
+      "version": "29.4.12",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.12.tgz",
+      "integrity": "sha512-Ov6ClY53Fflh6BGAnY2DlTq1hYDrTycz2PVTXBWFW2CU+9zrEqAp9fWdGXl42EXO5RLSFAcAZ2JFKbP+zBTFfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bs-logger": "^0.2.6",
+        "fast-json-stable-stringify": "^2.1.0",
+        "handlebars": "^4.7.9",
+        "json5": "^2.2.3",
+        "lodash.memoize": "^4.1.2",
+        "make-error": "^1.3.6",
+        "semver": "^7.8.5",
+        "type-fest": "^4.41.0",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0-beta.0 <8",
+        "@jest/transform": "^29.0.0 || ^30.0.0",
+        "@jest/types": "^29.0.0 || ^30.0.0",
+        "babel-jest": "^29.0.0 || ^30.0.0",
+        "jest": "^29.0.0 || ^30.0.0",
+        "jest-util": "^29.0.0 || ^30.0.0",
+        "typescript": ">=4.3 <7"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@jest/transform": {
+          "optional": true
+        },
+        "@jest/types": {
+          "optional": true
+        },
+        "babel-jest": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jest-util": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-jest/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ts-jest/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.12",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.12.tgz",
+      "integrity": "sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
+      "integrity": "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/walker": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+      "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/write-file-atomic": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.7"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/scripts/ai-harness/package.json
+++ b/scripts/ai-harness/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "clue-ai-harness",
+  "version": "1.0.0",
+  "description": "Local evaluation harness for CLUE AI document analysis (CLUE-371)",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "dotenv": "^16.4.5",
+    "openai": "6.45.0",
+    "zod": "3.25.76"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.12",
+    "@types/node": "^20.14.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.2.4",
+    "tsx": "^4.16.2",
+    "typescript": "~5.9.2"
+  }
+}

--- a/scripts/ai-harness/prompts/categorize-design-default.json
+++ b/scripts/ai-harness/prompts/categorize-design-default.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": 1,
+  "name": "categorize-design-default",
+  "aiPrompt": {
+    "mainPrompt": "This is a picture of a student document.\nThey are working on engineering task. Please tell me which of the following areas of their design they are focusing on:\n- user: who's it for?\n- environment: where's it used?\n- form: what's it look like?\n- function: what does it do?\nand why you chose that area.\nOr if the document doesn't include enough content to clearly identify a focus area let me know by setting \"category\" to \"unknown\".\nYour answer should be a JSON document in the given format.",
+    "categorizationDescription": "Categorize the document based on its content.",
+    "categories": [
+      "user",
+      "environment",
+      "form",
+      "function"
+    ],
+    "keyIndicatorsPrompt": "What are the key indicators that support this categorization?",
+    "discussionPrompt": "Please provide any additional discussion or context regarding the categorization.",
+    "systemPrompt": "You are a teaching assistant in an engineering design course."
+  },
+  "provenance": {
+    "source": "shared/ai-analysis-messages.ts: defaultAiPrompt (the built-in categorize-design prompt)",
+    "retrievedAt": "2026-08-11",
+    "aiPromptSha256": "ae7396d315ce62950d0aed29b177f2dd7a7edc3c22e69afe0bf816af2a6312f2"
+  }
+}

--- a/scripts/ai-harness/src/cache.ts
+++ b/scripts/ai-harness/src/cache.ts
@@ -1,0 +1,99 @@
+/**
+ * On-disk response cache, keyed by the request key (see messages.ts).
+ *
+ * Successes and refusals are cached — a refusal is a real API response that cost real money, and
+ * re-running it would just spend the money again. Errors are never cached.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { ResponseOriginMeta, kSchemaVersion } from "./schemas.js";
+
+export interface CacheEntry {
+  schemaVersion: number;
+  key: string;
+  status: "success" | "refusal";
+  /** Present on success. */
+  parsed?: unknown;
+  /** The full response body as returned by the API. */
+  raw: unknown;
+  /** Present on refusal. */
+  refusal?: string;
+  usage: { promptTokens: number; completionTokens: number };
+  responseOriginMeta: ResponseOriginMeta;
+}
+
+export interface CacheOptions {
+  /** `--no-cache` turns both off; `--refresh-cache` turns reads off but leaves writes on. */
+  read: boolean;
+  write: boolean;
+}
+
+export const kDefaultCacheOptions: CacheOptions = { read: true, write: true };
+
+export function cacheOptionsFor(noCache: boolean, refreshCache: boolean): CacheOptions {
+  if (noCache && refreshCache) {
+    throw new Error("--no-cache and --refresh-cache cannot be combined");
+  }
+  if (noCache) return { read: false, write: false };
+  if (refreshCache) return { read: false, write: true };
+  return { ...kDefaultCacheOptions };
+}
+
+/**
+ * Returns the entry only if it is actually usable. JSON.parse succeeding is not enough: a file
+ * truncated at a record boundary can still parse, and the old cast let it through to
+ * `rowFromResponse`, which then crashed on a missing `usage`. Anything short of complete is a miss,
+ * which is what the module already promised.
+ */
+export function validateCacheEntry(value: unknown, key: string): CacheEntry | undefined {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const entry = value as Record<string, any>;
+  if (entry.schemaVersion !== kSchemaVersion || entry.key !== key) return undefined;
+  if (entry.status !== "success" && entry.status !== "refusal") return undefined;
+  // `!== undefined` rather than `in`: a key present but undefined is just as unusable, and this way
+  // the check holds for an in-memory object as well as for a file JSON.parse produced.
+  if (entry.raw === undefined) return undefined;
+
+  const usage = entry.usage;
+  if (usage === null || typeof usage !== "object") return undefined;
+  if (!Number.isFinite(usage.promptTokens) || !Number.isFinite(usage.completionTokens)) return undefined;
+
+  const meta = entry.responseOriginMeta;
+  if (meta === null || typeof meta !== "object" || typeof meta.date !== "string") return undefined;
+
+  if (entry.status === "refusal" && typeof entry.refusal !== "string") return undefined;
+  if (entry.status === "success" && entry.parsed === undefined) return undefined;
+
+  return entry as CacheEntry;
+}
+
+export class ResponseCache {
+  constructor(private readonly directory: string, private readonly options: CacheOptions = kDefaultCacheOptions) {}
+
+  pathFor(key: string): string {
+    return path.join(this.directory, key.slice(0, 2), `${key}.json`);
+  }
+
+  get(key: string): CacheEntry | undefined {
+    if (!this.options.read) return undefined;
+    const file = this.pathFor(key);
+    if (!fs.existsSync(file)) return undefined;
+    try {
+      return validateCacheEntry(JSON.parse(fs.readFileSync(file, "utf8")), key);
+    } catch {
+      // A truncated or corrupt cache file is a miss, not a crash.
+      return undefined;
+    }
+  }
+
+  put(entry: CacheEntry): void {
+    if (!this.options.write) return;
+    const file = this.pathFor(entry.key);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    // Write-then-rename, so a crash mid-write leaves either the old entry or none — never a partial
+    // file. A corrupt entry is already treated as a miss; this removes the state altogether.
+    const temporary = `${file}.${process.pid}.tmp`;
+    fs.writeFileSync(temporary, `${JSON.stringify(entry, null, 2)}\n`, "utf8");
+    fs.renameSync(temporary, file);
+  }
+}

--- a/scripts/ai-harness/src/cache.ts
+++ b/scripts/ai-harness/src/cache.ts
@@ -61,8 +61,14 @@ export function validateCacheEntry(value: unknown, key: string): CacheEntry | un
   const meta = entry.responseOriginMeta;
   if (meta === null || typeof meta !== "object" || typeof meta.date !== "string") return undefined;
 
-  if (entry.status === "refusal" && typeof entry.refusal !== "string") return undefined;
-  if (entry.status === "success" && entry.parsed === undefined) return undefined;
+  // The cache must agree with the run loop about what a usable response is. A completion carrying
+  // neither parsed content nor refusal text is classified there as an "unparsed" error and never
+  // cached, so an entry in either of those shapes is damaged rather than replayable — treat it as a
+  // miss and let the request go out again, instead of quietly serving an error back as a success.
+  if (entry.status === "refusal" && (typeof entry.refusal !== "string" || entry.refusal.length === 0)) {
+    return undefined;
+  }
+  if (entry.status === "success" && entry.parsed == null) return undefined;
 
   return entry as CacheEntry;
 }

--- a/scripts/ai-harness/src/capability.ts
+++ b/scripts/ai-harness/src/capability.ts
@@ -139,6 +139,8 @@ function rowsOf(container: any): RowLike[] {
  * top-level tileMap, exactly as handleQuestionTile() in shared/ai-summarizer does):
  * - the first row holds the authored prompt, which is not student work and contributes nothing;
  * - the remaining rows are the student response and classify individually by their own types;
+ * - a Question nested inside a prompt stays authored all the way down: its own rows do not get to
+ *   reintroduce "student", because the whole subtree is curriculum content;
  * - a missing tile reference is skipped and recorded as a warning;
  * - a tile referenced twice counts once;
  * - nested Questions recurse, up to kMaxQuestionDepth.
@@ -179,7 +181,10 @@ export function classifyDocument(content: any): DocumentClassification {
       questionRows.forEach((row, rowIndex) => {
         for (const ref of row.tiles ?? []) {
           if (!ref?.tileId) continue;
-          visit(ref.tileId, rowIndex === 0 ? "prompt" : "student", depth + 1);
+          // Role is inherited, not recomputed from row position: once we are inside an authored
+          // prompt, everything below it is authored too. Recomputing would let a Question nested in
+          // a prompt hand "student" back to its own later rows.
+          visit(ref.tileId, role === "prompt" || rowIndex === 0 ? "prompt" : "student", depth + 1);
         }
       });
       return;

--- a/scripts/ai-harness/src/capability.ts
+++ b/scripts/ai-harness/src/capability.ts
@@ -1,0 +1,220 @@
+/**
+ * Per-tile-type capability registry plus document classification.
+ *
+ * The type-level flags say what a tile *can* hold. Classifying a real document also applies
+ * instance-level checks (does this Text tile actually have text?), so `computedModality` describes
+ * the document in front of us rather than the tile types it happens to use.
+ */
+import { tileTypes } from "../../../shared/tile-types.js";
+import { slateToMarkdown } from "../../../shared/slate-to-markdown.js";
+import type { Modality } from "./schemas.js";
+
+export interface TileRepresentationCapability {
+  /** Can students author text content in this tile type? */
+  containsStudentText: boolean;
+  /** How well the current text summarizer carries this tile type. */
+  summaryFidelity: "full" | "partial" | "stub" | "fallback";
+  /** Does an image add information that text cannot carry? */
+  requiresVisualRepresentation: boolean;
+}
+
+function capability(
+  containsStudentText: boolean,
+  summaryFidelity: TileRepresentationCapability["summaryFidelity"],
+  requiresVisualRepresentation: boolean
+): TileRepresentationCapability {
+  return { containsStudentText, summaryFidelity, requiresVisualRepresentation };
+}
+
+/**
+ * Unlisted tile types are conservatively treated as visual so nothing silently drops out of an
+ * image-based representation.
+ */
+export const unknownTileCapability: TileRepresentationCapability = capability(false, "fallback", true);
+
+/**
+ * Several `fallback` types can in fact hold typed text (DataCard field values, for one). Milestone 1
+ * records that as a known simplification rather than guessing per type; instance-level checks may
+ * upgrade them in milestone 3, and anything noticed while authoring fixtures is recorded in the
+ * synthetic corpus's expectations.json.
+ */
+export const tileCapabilities: Record<string, TileRepresentationCapability> = {
+  Text: capability(true, "full", false),
+  Table: capability(true, "full", false),
+  Dataflow: capability(true, "full", true),
+  Graph: capability(false, "full", true),
+  Simulator: capability(false, "partial", true),
+  // A Question tile is a container: its children classify individually (see classifyDocument).
+  Question: capability(false, "partial", false),
+  Drawing: capability(true, "stub", true),
+  Image: capability(false, "stub", true),
+  Geometry: capability(false, "fallback", true),
+  Diagram: capability(false, "fallback", true),
+  BarGraph: capability(false, "fallback", true),
+  DataCard: capability(false, "fallback", true),
+  Numberline: capability(false, "fallback", true),
+  Expression: capability(false, "fallback", true),
+  Timeline: capability(false, "fallback", true),
+  WaveRunner: capability(false, "fallback", true),
+  AI: capability(false, "fallback", true),
+  ErrorTest: capability(false, "fallback", true),
+  Starter: capability(false, "fallback", true),
+  IframeInteractive: capability(false, "fallback", true),
+  Placeholder: capability(false, "full", false),
+  Unknown: unknownTileCapability
+};
+
+export function getTileCapability(tileType: string): TileRepresentationCapability {
+  return tileCapabilities[tileType] ?? unknownTileCapability;
+}
+
+/** Every registered tile type must have a record; a missing one is a bug, not a default. */
+export function missingCapabilityTypes(): string[] {
+  return tileTypes.filter((type) => !(type in tileCapabilities));
+}
+
+// ---------------------------------------------------------------------------
+// Instance-level checks
+// ---------------------------------------------------------------------------
+
+/** A Text tile counts as student text only when its content is non-empty after trimming. */
+export function textTileHasContent(content: any): boolean {
+  const text = content?.text;
+  if (typeof text !== "string") return false;
+  if (content.format === "slate") {
+    try {
+      return slateToMarkdown(text).trim().length > 0;
+    } catch {
+      return text.trim().length > 0;
+    }
+  }
+  return text.trim().length > 0;
+}
+
+/** A Drawing tile counts as student text only when it has text objects that actually say something. */
+export function drawingTileHasText(content: any): boolean {
+  const objects = content?.objects;
+  if (!Array.isArray(objects)) return false;
+  return objects.some((object: any) =>
+    object?.type === "text" && typeof object.text === "string" && object.text.trim().length > 0);
+}
+
+// ---------------------------------------------------------------------------
+// Document classification
+// ---------------------------------------------------------------------------
+
+/** How deep nested Question tiles may recurse before we assume a cycle. */
+export const kMaxQuestionDepth = 8;
+
+export interface ClassifiedTile {
+  tileId: string;
+  tileType: string;
+  /** "student" for ordinary tiles and Question responses; "prompt" for a Question's authored prompt. */
+  role: "student" | "prompt";
+  capability: TileRepresentationCapability;
+  /** Type capability narrowed by the instance-level checks above. */
+  hasStudentText: boolean;
+  requiresVisualRepresentation: boolean;
+}
+
+export interface DocumentClassification {
+  computedModality: Modality;
+  tiles: ClassifiedTile[];
+  warnings: string[];
+}
+
+interface TileRef { tileId?: string }
+interface RowLike { tiles?: TileRef[]; isSectionHeader?: boolean }
+
+function rowsOf(container: any): RowLike[] {
+  const { rowOrder, rowMap } = container ?? {};
+  if (!Array.isArray(rowOrder) || !rowMap) return [];
+  return rowOrder.map((rowId: string) => rowMap[rowId]).filter(Boolean);
+}
+
+/**
+ * Classifies every tile a document holds, following Question tiles into their nested rows.
+ *
+ * Rules for Question traversal (the nested rowOrder/rowMap resolves ids through the *document's*
+ * top-level tileMap, exactly as handleQuestionTile() in shared/ai-summarizer does):
+ * - the first row holds the authored prompt, which is not student work and contributes nothing;
+ * - the remaining rows are the student response and classify individually by their own types;
+ * - a missing tile reference is skipped and recorded as a warning;
+ * - a tile referenced twice counts once;
+ * - nested Questions recurse, up to kMaxQuestionDepth.
+ */
+export function classifyDocument(content: any): DocumentClassification {
+  const tileMap = content?.tileMap ?? {};
+  const tiles: ClassifiedTile[] = [];
+  const warnings: string[] = [];
+  const visited = new Set<string>();
+
+  const visit = (tileId: string, role: ClassifiedTile["role"], depth: number): void => {
+    if (visited.has(tileId)) return;
+    visited.add(tileId);
+
+    const tile = tileMap[tileId];
+    if (!tile || !tile.content) {
+      warnings.push(`tile reference "${tileId}" is not present in the document's tileMap`);
+      return;
+    }
+
+    const tileType = typeof tile.content.type === "string" ? tile.content.type : "Unknown";
+    const tileCapability = getTileCapability(tileType);
+
+    if (tileType === "Question") {
+      tiles.push({
+        tileId,
+        tileType,
+        role,
+        capability: tileCapability,
+        hasStudentText: false,
+        requiresVisualRepresentation: false
+      });
+      if (depth >= kMaxQuestionDepth) {
+        warnings.push(`question tile "${tileId}" exceeds the nesting depth cap of ${kMaxQuestionDepth}`);
+        return;
+      }
+      const questionRows = rowsOf(tile.content);
+      questionRows.forEach((row, rowIndex) => {
+        for (const ref of row.tiles ?? []) {
+          if (!ref?.tileId) continue;
+          visit(ref.tileId, rowIndex === 0 ? "prompt" : "student", depth + 1);
+        }
+      });
+      return;
+    }
+
+    let hasStudentText = tileCapability.containsStudentText;
+    if (tileType === "Text") hasStudentText = textTileHasContent(tile.content);
+    if (tileType === "Drawing") hasStudentText = drawingTileHasText(tile.content);
+    // An authored question prompt is not student work, whatever it happens to contain.
+    if (role === "prompt") hasStudentText = false;
+
+    tiles.push({
+      tileId,
+      tileType,
+      role,
+      capability: tileCapability,
+      hasStudentText,
+      requiresVisualRepresentation: role === "prompt" ? false : tileCapability.requiresVisualRepresentation
+    });
+  };
+
+  for (const row of rowsOf(content)) {
+    if (row.isSectionHeader) continue;
+    for (const ref of row.tiles ?? []) {
+      if (!ref?.tileId) continue;
+      visit(ref.tileId, "student", 0);
+    }
+  }
+
+  const hasText = tiles.some((tile) => tile.hasStudentText);
+  const hasVisual = tiles.some((tile) => tile.requiresVisualRepresentation);
+  const computedModality: Modality = hasText && hasVisual ? "mixed"
+    : hasText ? "text-only"
+    : hasVisual ? "visual-only"
+    : "empty";
+
+  return { computedModality, tiles, warnings };
+}

--- a/scripts/ai-harness/src/corpus.ts
+++ b/scripts/ai-harness/src/corpus.ts
@@ -28,6 +28,9 @@ export interface CorpusPaths {
 }
 
 export function corpusPaths(dataRoot: string, corpus: string): CorpusPaths {
+  if (!kDocumentIdPattern.test(corpus)) {
+    throw new Error(`--corpus must match ${kDocumentIdPattern}, got "${corpus}"`);
+  }
   const root = path.join(dataRoot, "corpus", corpus);
   return {
     root,
@@ -153,9 +156,7 @@ export function importCorpus(options: ImportOptions): ImportResult {
     throw new Error(`--source must be one of ${importableSources.join(", ")}; ` +
       `"${source}" documents are only produced by the (gated) pull command`);
   }
-  if (!kDocumentIdPattern.test(corpus)) {
-    throw new Error(`--corpus must match ${kDocumentIdPattern}, got "${corpus}"`);
-  }
+  const paths = corpusPaths(dataRoot, corpus);
 
   const sourceDir = path.resolve(from);
   const documentsDir = fs.existsSync(path.join(sourceDir, "documents"))
@@ -165,7 +166,6 @@ export function importCorpus(options: ImportOptions): ImportResult {
     throw new Error(`--from must name a directory containing document JSON files, got "${from}"`);
   }
 
-  const paths = corpusPaths(dataRoot, corpus);
   const existing = fs.existsSync(paths.manifest) ? readManifest(paths) : null;
   const previous = new Map((existing?.documents ?? []).map((entry) => [entry.id, entry]));
 

--- a/scripts/ai-harness/src/corpus.ts
+++ b/scripts/ai-harness/src/corpus.ts
@@ -1,0 +1,279 @@
+/**
+ * Corpus layout, the `import` command, and manifest read/write.
+ *
+ * Everything derived from documents lives under `data/` (gitignored). Committed example corpora live
+ * outside it, in `examples/`, and are copied in by `import`.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  CorpusManifest, CorpusSource, ManifestDocument, Modality, RepresentationEnvelope,
+  kDocumentIdPattern, kSchemaVersion, sha256Canonical, validateCorpusManifest, validateRepresentationEnvelope
+} from "./schemas.js";
+import { classifyDocument } from "./capability.js";
+
+/** The scripts/ai-harness directory. */
+export const harnessRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+export function defaultDataRoot(): string {
+  return path.join(harnessRoot, "data");
+}
+
+export interface CorpusPaths {
+  root: string;
+  documents: string;
+  representations: string;
+  manifest: string;
+}
+
+export function corpusPaths(dataRoot: string, corpus: string): CorpusPaths {
+  const root = path.join(dataRoot, "corpus", corpus);
+  return {
+    root,
+    documents: path.join(root, "documents"),
+    representations: path.join(root, "representations"),
+    manifest: path.join(root, "manifest.json")
+  };
+}
+
+export function readJsonFile(file: string): unknown {
+  let text: string;
+  try {
+    text = fs.readFileSync(file, "utf8");
+  } catch {
+    throw new Error(`${file}: cannot be read`);
+  }
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    throw new Error(`${file}: is not valid JSON (${(error as Error).message})`);
+  }
+}
+
+export function writeJsonFile(file: string, value: unknown): void {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+export function readManifest(paths: CorpusPaths): CorpusManifest {
+  return validateCorpusManifest(readJsonFile(paths.manifest), paths.manifest);
+}
+
+export function writeManifest(paths: CorpusPaths, manifest: CorpusManifest): void {
+  writeJsonFile(paths.manifest, manifest);
+}
+
+export function readCorpusDocument(paths: CorpusPaths, entry: ManifestDocument): unknown {
+  return readJsonFile(resolveCorpusFile(paths, entry));
+}
+
+/**
+ * Resolves a manifest entry's `file` inside its corpus, refusing anything that escapes. `import`
+ * only ever writes `documents/<id>.json`, but the manifest is a hand-editable file, and a `file` of
+ * `../../..` would otherwise make the harness read whatever it pointed at.
+ */
+export function resolveCorpusFile(paths: CorpusPaths, entry: ManifestDocument): string {
+  const resolved = path.resolve(paths.root, entry.file);
+  const relative = path.relative(paths.root, resolved);
+  if (relative === "" || relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error(`${paths.manifest}: document "${entry.id}" has a file "${entry.file}" that ` +
+      `resolves outside the corpus directory (${resolved})`);
+  }
+  return resolved;
+}
+
+// ---------------------------------------------------------------------------
+// Representations
+// ---------------------------------------------------------------------------
+
+export function representationPath(paths: CorpusPaths, variantId: string, docId: string): string {
+  return path.join(paths.representations, variantId, `${docId}.json`);
+}
+
+export function readRepresentation(file: string): RepresentationEnvelope {
+  return validateRepresentationEnvelope(readJsonFile(file), file);
+}
+
+export interface RepresentationIdentity {
+  docId: string;
+  variantId: string;
+  contentSha256: string;
+  variantVersion: number;
+}
+
+/**
+ * The envelope, not the file's existence, decides staleness: a representation is reusable only when
+ * it was produced for this document, by this variant, from this exact content, at this exact variant
+ * version. The docId/variantId checks matter because the path alone proves nothing — a `default`
+ * envelope copied onto a `minimal` path would otherwise pass, silently making the two variants
+ * identical and quietly ruining the comparison the harness exists to make.
+ */
+export function representationIsFresh(
+  envelope: RepresentationEnvelope, expected: RepresentationIdentity
+): boolean {
+  return envelope.docId === expected.docId &&
+    envelope.variantId === expected.variantId &&
+    envelope.sourceContentSha256 === expected.contentSha256 &&
+    envelope.variantVersion === expected.variantVersion;
+}
+
+// ---------------------------------------------------------------------------
+// import
+// ---------------------------------------------------------------------------
+
+export interface ImportOptions {
+  from: string;
+  corpus: string;
+  source: CorpusSource;
+  prune: boolean;
+  dataRoot: string;
+  /** Injected in tests so manifest timestamps are deterministic. */
+  now?: () => Date;
+}
+
+export interface ImportResult {
+  manifest: CorpusManifest;
+  imported: string[];
+  missing: string[];
+  pruned: string[];
+  warnings: string[];
+}
+
+/** `production` is not accepted here; only the (gated) `pull` command may set it. */
+export const importableSources: readonly CorpusSource[] = ["synthetic", "demo", "qa"];
+
+export function importCorpus(options: ImportOptions): ImportResult {
+  const { from, corpus, source, prune, dataRoot } = options;
+  // Stamped once, so every document in one import shares a retrievedAt and a new corpus's createdAt
+  // matches them rather than landing a few milliseconds earlier.
+  const importedAt = (options.now ?? (() => new Date()))().toISOString();
+
+  if (!importableSources.includes(source)) {
+    throw new Error(`--source must be one of ${importableSources.join(", ")}; ` +
+      `"${source}" documents are only produced by the (gated) pull command`);
+  }
+  if (!kDocumentIdPattern.test(corpus)) {
+    throw new Error(`--corpus must match ${kDocumentIdPattern}, got "${corpus}"`);
+  }
+
+  const sourceDir = path.resolve(from);
+  const documentsDir = fs.existsSync(path.join(sourceDir, "documents"))
+    ? path.join(sourceDir, "documents")
+    : sourceDir;
+  if (!fs.statSync(documentsDir, { throwIfNoEntry: false })?.isDirectory()) {
+    throw new Error(`--from must name a directory containing document JSON files, got "${from}"`);
+  }
+
+  const paths = corpusPaths(dataRoot, corpus);
+  const existing = fs.existsSync(paths.manifest) ? readManifest(paths) : null;
+  const previous = new Map((existing?.documents ?? []).map((entry) => [entry.id, entry]));
+
+  const warnings: string[] = [];
+  const imported: string[] = [];
+  const entries: ManifestDocument[] = [];
+  const seen = new Set<string>();
+
+  const sourceFiles = fs.readdirSync(documentsDir)
+    .filter((name) => name.endsWith(".json"))
+    .sort();
+
+  for (const name of sourceFiles) {
+    const id = path.basename(name, ".json");
+    if (!kDocumentIdPattern.test(id)) {
+      throw new Error(`${path.join(documentsDir, name)}: document id "${id}" must match ${kDocumentIdPattern}`);
+    }
+    if (seen.has(id)) {
+      throw new Error(`corpus "${corpus}": document id "${id}" is used by more than one source file`);
+    }
+    seen.add(id);
+
+    const relativeFile = path.join("documents", `${id}.json`);
+    const destination = path.join(paths.root, relativeFile);
+    // Belt and braces: an id can only produce a path inside the corpus, but check the resolved path.
+    if (path.relative(paths.root, path.resolve(destination)).startsWith("..")) {
+      throw new Error(`corpus "${corpus}": document "${id}" would be written outside the corpus directory`);
+    }
+
+    const content = readJsonFile(path.join(documentsDir, name));
+    const contentSha256 = sha256Canonical(content);
+    const classification = classifyDocument(content);
+    for (const warning of classification.warnings) warnings.push(`${id}: ${warning}`);
+
+    writeJsonFile(destination, content);
+    imported.push(id);
+
+    const before = previous.get(id);
+    entries.push({
+      id,
+      file: relativeFile,
+      source,
+      contentSha256,
+      // A synthetic document was authored here, not retrieved from anywhere.
+      retrievedAt: source === "synthetic" ? null : importedAt,
+      unit: before?.unit ?? null,
+      investigation: before?.investigation ?? null,
+      problem: before?.problem ?? null,
+      contextId: before?.contextId ?? null,
+      computedModality: classification.computedModality,
+      modalityOverride: before?.modalityOverride ?? null,
+      labels: before?.labels ?? {},
+      relatedSummaries: before?.relatedSummaries ?? [],
+      historical: before?.historical ?? null
+    });
+  }
+
+  const missing: string[] = [];
+  const pruned: string[] = [];
+  for (const entry of previous.values()) {
+    if (seen.has(entry.id)) continue;
+    if (prune) {
+      // Destructive on purpose: an entry removed from the manifest is unreachable, and once
+      // production corpora exist an unreachable copy of a student's document must not linger.
+      removeDocumentArtifacts(paths, entry);
+      pruned.push(entry.id);
+      continue;
+    }
+    missing.push(entry.id);
+    warnings.push(`${entry.id}: source file has disappeared; the manifest entry is kept ` +
+      "(pass --prune to remove it)");
+    entries.push(entry);
+  }
+
+  entries.sort((a, b) => a.id.localeCompare(b.id));
+  const manifest: CorpusManifest = {
+    schemaVersion: kSchemaVersion,
+    name: corpus,
+    createdAt: existing?.createdAt ?? importedAt,
+    documents: entries
+  };
+  writeManifest(paths, manifest);
+
+  return { manifest, imported, missing, pruned, warnings };
+}
+
+/** Deletes a document's copied content and every representation envelope generated from it. */
+export function removeDocumentArtifacts(paths: CorpusPaths, entry: ManifestDocument): string[] {
+  const removed: string[] = [];
+  const remove = (file: string) => {
+    if (!fs.existsSync(file)) return;
+    fs.rmSync(file);
+    removed.push(file);
+  };
+  try {
+    remove(resolveCorpusFile(paths, entry));
+  } catch {
+    // A manifest entry pointing outside the corpus is not ours to delete; leave it and move on.
+  }
+  if (fs.existsSync(paths.representations)) {
+    for (const variantId of fs.readdirSync(paths.representations)) {
+      remove(path.join(paths.representations, variantId, `${entry.id}.json`));
+    }
+  }
+  return removed;
+}
+
+/** Recomputes a document's modality from its current content. */
+export function computeModality(content: unknown): Modality {
+  return classifyDocument(content).computedModality;
+}

--- a/scripts/ai-harness/src/cost.ts
+++ b/scripts/ai-harness/src/cost.ts
@@ -1,0 +1,172 @@
+/**
+ * Pricing, worst-case estimation, and the reservation ledger that makes `--max-cost` a real bound.
+ *
+ * `plan` and `run` call the same `worstCaseUsd` so a plan's projected maximum is never lower than
+ * what a run can reserve.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { HarnessRequest } from "./messages.js";
+import { ModelPricing, PricingConfig, canonicalJson, validatePricingConfig } from "./schemas.js";
+
+const kPricingFile = path.join(path.dirname(fileURLToPath(import.meta.url)), "pricing.json");
+
+/** Conservative characters-per-token divisor used for pre-flight estimates. */
+export const kCharsPerToken = 3;
+
+/** Each request may be attempted this many extra times after the first. */
+export const kRetries = 2;
+
+export function loadPricingConfig(file: string = kPricingFile): PricingConfig {
+  const text = fs.readFileSync(file, "utf8");
+  return validatePricingConfig(JSON.parse(text), file);
+}
+
+export function pricingFor(config: PricingConfig, model: string, file: string = kPricingFile): ModelPricing {
+  const pricing = config.models[model];
+  if (!pricing) {
+    throw new Error(`${file}: no pricing for model "${model}" ` +
+      `(known models: ${Object.keys(config.models).join(", ")})`);
+  }
+  return pricing;
+}
+
+/**
+ * Conservative token estimate for a string. ASCII is counted at kCharsPerToken characters per token;
+ * anything outside ASCII is counted as a whole token per character, because CJK text and emoji
+ * routinely cost around one token each and dividing them by three would under-reserve.
+ */
+export function estimateTokensForText(text: string): number {
+  let asciiChars = 0;
+  let wideChars = 0;
+  for (const character of text) {
+    if (character.codePointAt(0)! < 128) asciiChars += 1;
+    else wideChars += 1;
+  }
+  return Math.ceil(asciiChars / kCharsPerToken) + wideChars;
+}
+
+/** Conservative input-token estimate: the message text plus the response schema. */
+export function estimateInputTokens(request: HarnessRequest): number {
+  return estimateTokensForText(canonicalJson(request.messages)) +
+    estimateTokensForText(canonicalJson(request.responseFormat));
+}
+
+export function priceTokens(promptTokens: number, completionTokens: number, pricing: ModelPricing): number {
+  return (promptTokens / 1_000_000) * pricing.inputPerMTokUsd +
+    (completionTokens / 1_000_000) * pricing.outputPerMTokUsd;
+}
+
+/**
+ * The single reservation formula. Worst case is a full input estimate, a completion that runs all the
+ * way to `max_completion_tokens`, and every retry being used.
+ */
+export function worstCaseUsd(request: HarnessRequest, pricing: ModelPricing, retries: number = kRetries): number {
+  const inputTokens = estimateInputTokens(request);
+  const outputTokens = request.generationSettings.max_completion_tokens;
+  return priceTokens(inputTokens, outputTokens, pricing) * (1 + retries);
+}
+
+export class CostCeilingExceeded extends Error {
+  constructor(public readonly requested: number, public readonly remaining: number) {
+    super(`Reserving $${requested.toFixed(4)} would exceed --max-cost; ` +
+      `only $${remaining.toFixed(4)} is left. No further requests were dispatched.`);
+    this.name = "CostCeilingExceeded";
+  }
+}
+
+export interface Reservation {
+  id: number;
+  amountUsd: number;
+}
+
+/**
+ * Reservations are taken before dispatch and replaced by the actual cost on completion. Because
+ * `reserve` is a single synchronous check-and-add, concurrent tasks cannot collectively overshoot
+ * the ceiling: whichever call would cross it is refused before its request is ever sent.
+ */
+export class CostLedger {
+  private nextId = 1;
+  private outstanding = new Map<number, number>();
+  private settledUsd = 0;
+
+  constructor(public readonly maxCostUsd: number) {
+    if (!(maxCostUsd > 0)) throw new Error(`--max-cost must be a positive number, got ${maxCostUsd}`);
+  }
+
+  /** Reserved (outstanding) plus settled — the most this run could still end up costing. */
+  get committedUsd(): number {
+    let total = this.settledUsd;
+    for (const amount of this.outstanding.values()) total += amount;
+    return total;
+  }
+
+  get incurredUsd(): number {
+    return this.settledUsd;
+  }
+
+  get remainingUsd(): number {
+    return this.maxCostUsd - this.committedUsd;
+  }
+
+  /** The peak of `committedUsd`, i.e. the total that was ever reserved for dispatched requests. */
+  private peakReservedUsd = 0;
+
+  get reservedPeakUsd(): number {
+    return this.peakReservedUsd;
+  }
+
+  /**
+   * Set when a settled actual cost pushes the committed total past the ceiling. Reservations are
+   * conservative, so this should not happen — but the input estimate is a character heuristic, not a
+   * tokenizer, so it can. Workers stop scheduling new requests once it trips.
+   */
+  private exceeded = false;
+
+  get hasExceededCeiling(): boolean {
+    return this.exceeded;
+  }
+
+  /** How far past the ceiling the run ended up, or 0. */
+  get overshootUsd(): number {
+    return Math.max(0, this.committedUsd - this.maxCostUsd);
+  }
+
+  reserve(amountUsd: number): Reservation {
+    if (this.committedUsd + amountUsd > this.maxCostUsd) {
+      throw new CostCeilingExceeded(amountUsd, this.remainingUsd);
+    }
+    const reservation = { id: this.nextId++, amountUsd };
+    this.outstanding.set(reservation.id, amountUsd);
+    this.peakReservedUsd = Math.max(this.peakReservedUsd, this.committedUsd);
+    return reservation;
+  }
+
+  /** Replaces a reservation with what the call actually cost. */
+  settle(reservation: Reservation, actualUsd: number): void {
+    if (!this.outstanding.delete(reservation.id)) {
+      throw new Error(`Reservation ${reservation.id} was already settled or released`);
+    }
+    this.settledUsd += actualUsd;
+    if (this.committedUsd > this.maxCostUsd) this.exceeded = true;
+  }
+
+  /**
+   * Drops a reservation for a request that was never dispatched. A request that *was* dispatched and
+   * then failed must not come through here: the provider may have billed it. Use settleFailedAttempt.
+   */
+  release(reservation: Reservation): void {
+    this.outstanding.delete(reservation.id);
+  }
+
+  /**
+   * Settles a dispatched request that failed before returning usage. The reservation covered
+   * (1 + retries) attempts; charging its single-attempt share keeps a run of failures from looking
+   * free, without pretending we know what the provider actually billed.
+   */
+  settleFailedAttempt(reservation: Reservation, attempts: number, totalAttempts: number): void {
+    const share = totalAttempts > 0 ? reservation.amountUsd * (Math.max(1, attempts) / totalAttempts) : 0;
+    this.settle(reservation, Math.min(share, reservation.amountUsd));
+  }
+}

--- a/scripts/ai-harness/src/cost.ts
+++ b/scripts/ai-harness/src/cost.ts
@@ -68,17 +68,29 @@ export function worstCaseUsd(request: HarnessRequest, pricing: ModelPricing, ret
   return priceTokens(inputTokens, outputTokens, pricing) * (1 + retries);
 }
 
+export interface Reservation {
+  id: number;
+  amountUsd: number;
+}
+
+/**
+ * What dispatched attempts that returned nothing are charged: their share of the reservation, which
+ * covered (1 + retries) attempts. A guess, but in the honest direction — see the README's note on the
+ * enforced bound.
+ */
+export function failedAttemptShareUsd(
+  reservation: Reservation, failedAttempts: number, totalAttempts: number
+): number {
+  if (failedAttempts <= 0 || totalAttempts <= 0) return 0;
+  return Math.min(reservation.amountUsd * (failedAttempts / totalAttempts), reservation.amountUsd);
+}
+
 export class CostCeilingExceeded extends Error {
   constructor(public readonly requested: number, public readonly remaining: number) {
     super(`Reserving $${requested.toFixed(4)} would exceed --max-cost; ` +
       `only $${remaining.toFixed(4)} is left. No further requests were dispatched.`);
     this.name = "CostCeilingExceeded";
   }
-}
-
-export interface Reservation {
-  id: number;
-  amountUsd: number;
 }
 
 /**
@@ -166,7 +178,18 @@ export class CostLedger {
    * free, without pretending we know what the provider actually billed.
    */
   settleFailedAttempt(reservation: Reservation, attempts: number, totalAttempts: number): void {
-    const share = totalAttempts > 0 ? reservation.amountUsd * (Math.max(1, attempts) / totalAttempts) : 0;
-    this.settle(reservation, Math.min(share, reservation.amountUsd));
+    this.settle(reservation, failedAttemptShareUsd(reservation, attempts, totalAttempts));
+  }
+
+  /**
+   * Settles a request that eventually succeeded after one or more dispatched attempts returned
+   * nothing. The earlier attempts are charged on the same basis as a request that never succeeded —
+   * they went out, so the provider may have billed them. Charging only the final response would make
+   * the two paths disagree about the identical event and let real spend drift past the ceiling.
+   */
+  settleAfterFailedAttempts(
+    reservation: Reservation, actualUsd: number, failedAttempts: number, totalAttempts: number
+  ): void {
+    this.settle(reservation, actualUsd + failedAttemptShareUsd(reservation, failedAttempts, totalAttempts));
   }
 }

--- a/scripts/ai-harness/src/execute.ts
+++ b/scripts/ai-harness/src/execute.ts
@@ -182,6 +182,8 @@ export class JsonlWriter {
 }
 
 export function readResultRows(file: string): ResultRow[] {
+  // A missing file means "nothing has run yet", which is exactly what resume needs on a fresh
+  // --output. Callers for which a missing file is a mistake — `report` — check before calling.
   if (!fs.existsSync(file)) return [];
   return fs.readFileSync(file, "utf8")
     .split("\n")
@@ -289,6 +291,7 @@ export interface RunSummary {
   written: number;
   resumed: number;
   cacheHits: number;
+  /** Requests actually dispatched, counting every retry — not tasks completed. */
   apiCalls: number;
   stoppedOnCeiling: boolean;
   reservedPeakUsd: number;
@@ -425,6 +428,9 @@ export async function runTasks(options: RunOptions): Promise<RunSummary> {
       while (attempts <= retries) {
         attempts += 1;
         try {
+          // Counted here, per dispatch: a request that succeeds on its third try made three calls,
+          // and one that exhausts its retries made three and reported none.
+          summary.apiCalls += 1;
           result = await createCompletion({ request: task.request, aiPrompt: task.aiPrompt });
           break;
         } catch (error) {
@@ -452,10 +458,11 @@ export async function runTasks(options: RunOptions): Promise<RunSummary> {
         continue;
       }
 
-      summary.apiCalls += 1;
-      // The call happened, so the money is spent whatever the response turned out to be.
+      // The call happened, so the money is spent whatever the response turned out to be — and any
+      // earlier attempts that failed on the way here were dispatched too, so they are charged on the
+      // same basis the all-failed path uses rather than being written off.
       const incurredThisRunUsd = priceTokens(result.usage.promptTokens, result.usage.completionTokens, pricing);
-      ledger.settle(reservation, incurredThisRunUsd);
+      ledger.settleAfterFailedAttempts(reservation, incurredThisRunUsd, attempts - 1, 1 + retries);
 
       if (result.parsed == null && result.refusal == null) {
         // A response with neither a parsed object nor a refusal is a failure, the same way production

--- a/scripts/ai-harness/src/execute.ts
+++ b/scripts/ai-harness/src/execute.ts
@@ -1,0 +1,516 @@
+/**
+ * Run expansion, OpenAI calls, concurrency, retries, resume, and the JSONL writer.
+ */
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import OpenAI from "openai";
+import { VERSION as kOpenAiSdkVersion } from "openai/version";
+import type { IAiPrompt, RelatedSummary } from "../../../shared/ai-analysis-messages.js";
+import {
+  CorpusPaths, harnessRoot, readJsonFile, readManifest, readRepresentation, representationIsFresh,
+  representationPath
+} from "./corpus.js";
+import { CacheEntry, ResponseCache } from "./cache.js";
+import { CostCeilingExceeded, CostLedger, kRetries, priceTokens, worstCaseUsd } from "./cost.js";
+import { HarnessRequest, buildRequest, requestKeyFor, responseFormatFor } from "./messages.js";
+import { getTextVariant } from "./represent-text.js";
+import {
+  ExperimentFile, ExperimentRun, ManifestDocument, ModelPricing, ResponseOriginMeta, ResultRow, RunMeta,
+  effectiveModality, kSchemaVersion, validatePromptFile, validateResultRow
+} from "./schemas.js";
+
+export const kDefaultModel = "gpt-4o-mini";
+export const kDefaultConcurrency = 4;
+
+// ---------------------------------------------------------------------------
+// Run metadata
+// ---------------------------------------------------------------------------
+
+function git(args: string[]): string | null {
+  try {
+    return execFileSync("git", args, { cwd: harnessRoot, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] })
+      .trim();
+  } catch {
+    return null;
+  }
+}
+
+export function currentRunMeta(now: Date = new Date()): RunMeta {
+  const status = git(["status", "--porcelain"]);
+  return {
+    date: now.toISOString(),
+    openaiSdkVersion: kOpenAiSdkVersion,
+    gitCommit: git(["rev-parse", "HEAD"]),
+    gitDirty: status === null ? false : status.length > 0
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Task expansion
+// ---------------------------------------------------------------------------
+
+export interface RunTask {
+  docId: string;
+  runId: string;
+  run: ExperimentRun;
+  modality: ManifestDocument["computedModality"];
+  promptName: string;
+  promptSha256: string;
+  aiPrompt: IAiPrompt;
+  request: HarnessRequest;
+  requestKey: string;
+  worstCaseUsd: number;
+}
+
+export interface BuildTasksOptions {
+  corpusPaths: CorpusPaths;
+  experiment: ExperimentFile;
+  promptsDir: string;
+  pricing: ModelPricing;
+  model?: string;
+  retries?: number;
+}
+
+export interface BuildTasksResult {
+  tasks: RunTask[];
+  documents: ManifestDocument[];
+}
+
+/**
+ * Expands (runs × documents) into concrete requests. `plan` and `run` both go through here, so the
+ * cost they compute comes from exactly the same requests.
+ */
+export function buildTasks(options: BuildTasksOptions): BuildTasksResult {
+  const { corpusPaths: paths, experiment, promptsDir, pricing } = options;
+  const model = options.model ?? kDefaultModel;
+  const manifest = readManifest(paths);
+  const prompts = new Map<string, { aiPrompt: IAiPrompt; sha256: string }>();
+
+  const loadPrompt = (name: string) => {
+    const cached = prompts.get(name);
+    if (cached) return cached;
+    const file = path.join(promptsDir, `${name}.json`);
+    const promptFile = validatePromptFile(readJsonFile(file), file);
+    const entry = { aiPrompt: promptFile.aiPrompt as IAiPrompt, sha256: promptFile.provenance.aiPromptSha256 };
+    prompts.set(name, entry);
+    return entry;
+  };
+
+  const tasks: RunTask[] = [];
+  for (const run of experiment.runs) {
+    const variant = getTextVariant(run.textVariant);
+    const { aiPrompt, sha256 } = loadPrompt(run.prompt);
+    for (const document of manifest.documents) {
+      const file = representationPath(paths, variant.id, document.id);
+      if (!fs.existsSync(file)) {
+        throw new Error(`Missing representation ${file}. Run: harness.ts represent --corpus ${manifest.name} ` +
+          `--variants ${variant.id}`);
+      }
+      const envelope = readRepresentation(file);
+      if (!representationIsFresh(envelope, {
+        docId: document.id,
+        variantId: variant.id,
+        contentSha256: document.contentSha256,
+        variantVersion: variant.variantVersion
+      })) {
+        throw new Error(`Stale or mismatched representation ${file} (it reports docId ` +
+          `"${envelope.docId}" / variant "${envelope.variantId}" at version ${envelope.variantVersion}). ` +
+          `Run: harness.ts represent --corpus ${manifest.name} --variants ${variant.id}`);
+      }
+
+      const relatedSummaries = document.relatedSummaries as unknown as RelatedSummary[];
+      const request = buildRequest({
+        model,
+        aiPrompt,
+        message: run.message,
+        markdown: envelope.markdown,
+        relatedSummaries,
+        generationSettings: { max_completion_tokens: pricing.maxOutputTokens }
+      });
+      tasks.push({
+        docId: document.id,
+        runId: run.id,
+        run,
+        modality: effectiveModality(document),
+        promptName: run.prompt,
+        promptSha256: sha256,
+        aiPrompt,
+        request,
+        requestKey: requestKeyFor(request),
+        worstCaseUsd: worstCaseUsd(request, pricing, options.retries)
+      });
+    }
+  }
+  return { tasks, documents: manifest.documents };
+}
+
+// ---------------------------------------------------------------------------
+// JSONL writer
+// ---------------------------------------------------------------------------
+
+/**
+ * Every completion goes through one writer. Writes are serialized on a promise chain and each row is
+ * appended (and flushed) on its own, so concurrent tasks cannot interleave and a crash leaves whole
+ * rows or nothing.
+ */
+export class JsonlWriter {
+  private queue: Promise<void> = Promise.resolve();
+  private firstFailure: unknown;
+
+  constructor(private readonly file: string) {
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+  }
+
+  write(row: unknown): Promise<void> {
+    const line = `${JSON.stringify(row)}\n`;
+    const append = this.queue.then(() => fsp.appendFile(this.file, line, "utf8"));
+    // The stored queue swallows failures so one bad append cannot poison the chain: without this, a
+    // rejected head makes every later write — including the error row explaining the failure — reject
+    // with the same stale error. The first failure is remembered and rethrown by close().
+    this.queue = append.catch((error) => {
+      if (this.firstFailure === undefined) this.firstFailure = error;
+    });
+    return append;
+  }
+
+  async close(): Promise<void> {
+    await this.queue;
+    if (this.firstFailure !== undefined) throw this.firstFailure;
+  }
+}
+
+export function readResultRows(file: string): ResultRow[] {
+  if (!fs.existsSync(file)) return [];
+  return fs.readFileSync(file, "utf8")
+    .split("\n")
+    .filter((line) => line.trim().length > 0)
+    .map((line, index) => {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(line);
+      } catch (error) {
+        throw new Error(`${file}: line ${index + 1} is not valid JSON (${(error as Error).message})`);
+      }
+      return validateResultRow(parsed, `${file}:${index + 1}`);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Completions
+// ---------------------------------------------------------------------------
+
+export interface CompletionResult {
+  parsed: unknown | null;
+  refusal: string | null;
+  raw: unknown;
+  usage: { promptTokens: number; completionTokens: number };
+  originMeta: ResponseOriginMeta;
+  /** The choice's finish_reason, passed through so an unparsed response can say why. */
+  finish_reason?: string | null;
+}
+
+export interface CompletionRequest {
+  request: HarnessRequest;
+  aiPrompt: IAiPrompt;
+}
+
+export type CreateCompletion = (request: CompletionRequest) => Promise<CompletionResult>;
+
+/** The real backend. Deliberately the same call shape production makes, plus the completion cap. */
+export function openAiCompletion(apiKey: string): CreateCompletion {
+  // The harness owns retries: it reserves cost for (1 + kRetries) attempts before dispatching, so the
+  // SDK retrying on top of that (its default maxRetries is 2) could bill up to three times what was
+  // reserved and quietly break the --max-cost bound. The timeout keeps a hung request from parking a
+  // reservation forever.
+  const client = new OpenAI({ apiKey, maxRetries: 0, timeout: 120_000 });
+  return async ({ request, aiPrompt }) => {
+    const completion: any = await client.chat.completions.parse({
+      model: request.model,
+      messages: request.messages,
+      response_format: responseFormatFor(aiPrompt),
+      max_completion_tokens: request.generationSettings.max_completion_tokens
+    });
+    const choice = completion.choices?.[0];
+    const message = choice?.message ?? {};
+    return {
+      parsed: message.parsed ?? null,
+      refusal: message.refusal ?? null,
+      finish_reason: choice?.finish_reason ?? null,
+      raw: completion,
+      usage: {
+        promptTokens: completion.usage?.prompt_tokens ?? 0,
+        completionTokens: completion.usage?.completion_tokens ?? 0
+      },
+      originMeta: {
+        date: new Date().toISOString(),
+        modelReturned: completion.model ?? null,
+        systemFingerprint: completion.system_fingerprint ?? null
+      }
+    };
+  };
+}
+
+/** 429, 5xx and network failures are worth another try; nothing else is. */
+export function isTransientError(error: unknown): boolean {
+  const status = (error as any)?.status ?? (error as any)?.response?.status;
+  // 408 request timeout and 409 conflict join 429 and 5xx: the SDK's own retry policy covered these,
+  // and A1 turned that off, so the harness's policy has to.
+  if (typeof status === "number") return [408, 409, 429].includes(status) || status >= 500;
+  const code = (error as any)?.code;
+  return typeof code === "string" &&
+    ["ECONNRESET", "ECONNREFUSED", "ETIMEDOUT", "EAI_AGAIN", "EPIPE", "ENOTFOUND"].includes(code);
+}
+
+// ---------------------------------------------------------------------------
+// The run loop
+// ---------------------------------------------------------------------------
+
+export interface RunOptions {
+  corpus: string;
+  experiment: ExperimentFile;
+  experimentSha256: string;
+  tasks: RunTask[];
+  outputFile: string;
+  ledger: CostLedger;
+  cache: ResponseCache;
+  pricing: ModelPricing;
+  runMeta: RunMeta;
+  createCompletion: CreateCompletion;
+  concurrency?: number;
+  retries?: number;
+  /** Overridden in tests so retries do not actually sleep. */
+  sleep?: (ms: number) => Promise<void>;
+  log?: (message: string) => void;
+}
+
+export interface RunSummary {
+  written: number;
+  resumed: number;
+  cacheHits: number;
+  apiCalls: number;
+  stoppedOnCeiling: boolean;
+  reservedPeakUsd: number;
+  incurredUsd: number;
+  /** How far actual spend ended up past `--max-cost`, or 0. See the README on the enforced bound. */
+  overshootUsd: number;
+}
+
+const defaultSleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+export async function runTasks(options: RunOptions): Promise<RunSummary> {
+  const {
+    corpus, experiment, experimentSha256, tasks, outputFile, ledger, cache, pricing, runMeta, createCompletion
+  } = options;
+  const concurrency = options.concurrency ?? kDefaultConcurrency;
+  const retries = options.retries ?? kRetries;
+  const sleep = options.sleep ?? defaultSleep;
+  const log = options.log ?? (() => undefined);
+
+  // Resume: an existing row for this (docId, runId) blocks a rerun only when its requestKey matches,
+  // so a changed document, prompt, representation, experiment or generation setting re-runs. Error
+  // rows never block a rerun.
+  // Resume identity also spans the corpus and the experiment definition. Without them, two corpora
+  // sharing a document id (or the same experiment edited between runs) would resume each other's
+  // rows: the requestKey covers the request, but not which corpus or experiment produced it.
+  const resumeKey = (row: { corpus: string; experimentSha256: string; docId: string; runId: string;
+    requestKey: string | null }) =>
+    `${row.corpus}\u0001${row.experimentSha256}\u0001${row.docId}\u0001${row.runId}\u0001${row.requestKey}`;
+  const completed = new Set<string>();
+  for (const row of readResultRows(outputFile)) {
+    if (row.status === "error" || row.requestKey === null) continue;
+    completed.add(resumeKey(row));
+  }
+
+  const writer = new JsonlWriter(outputFile);
+  const summary: RunSummary = {
+    written: 0, resumed: 0, cacheHits: 0, apiCalls: 0, stoppedOnCeiling: false, reservedPeakUsd: 0,
+    incurredUsd: 0, overshootUsd: 0
+  };
+
+  const taskResumeKey = (task: RunTask) =>
+    resumeKey({ corpus, experimentSha256, docId: task.docId, runId: task.runId, requestKey: task.requestKey });
+  const pending = tasks.filter((task) => {
+    if (completed.has(taskResumeKey(task))) {
+      summary.resumed += 1;
+      return false;
+    }
+    return true;
+  });
+
+  const common = (task: RunTask) => ({
+    schemaVersion: kSchemaVersion,
+    experiment: experiment.name,
+    experimentSha256,
+    runId: task.runId,
+    corpus,
+    docId: task.docId,
+    modality: task.modality,
+    message: task.run.message,
+    textVariant: task.run.textVariant,
+    prompt: { name: task.promptName, sha256: task.promptSha256 },
+    requestKey: task.requestKey,
+    runMeta
+  });
+
+  const rowFromResponse = (
+    task: RunTask, entry: CacheEntry, source: "api" | "cache", incurredThisRunUsd: number
+  ): ResultRow => {
+    const modeledUsd = priceTokens(entry.usage.promptTokens, entry.usage.completionTokens, pricing);
+    const usage = { ...entry.usage, source };
+    const cost = { modeledUsd, incurredThisRunUsd };
+    if (entry.status === "refusal") {
+      return {
+        ...common(task),
+        status: "refusal",
+        refusal: entry.refusal ?? "",
+        usage,
+        cost,
+        responseOriginMeta: entry.responseOriginMeta
+      };
+    }
+    return {
+      ...common(task),
+      status: "success",
+      response: { parsed: entry.parsed ?? null, raw: entry.raw },
+      usage,
+      cost,
+      responseOriginMeta: entry.responseOriginMeta
+    };
+  };
+
+  let stopped = false;
+  let next = 0;
+
+  const worker = async (): Promise<void> => {
+    for (;;) {
+      if (stopped) return;
+      if (ledger.hasExceededCeiling) {
+        stopped = true;
+        summary.stoppedOnCeiling = true;
+        log(`Actual spend has passed the --max-cost ceiling by $${ledger.overshootUsd.toFixed(4)}; ` +
+          "no further requests were dispatched.");
+        return;
+      }
+      const index = next++;
+      if (index >= pending.length) return;
+      const task = pending[index];
+
+      const cached = cache.get(task.requestKey);
+      if (cached) {
+        // A cache hit reserves nothing and costs nothing this run.
+        summary.cacheHits += 1;
+        await writer.write(rowFromResponse(task, cached, "cache", 0));
+        summary.written += 1;
+        continue;
+      }
+
+      let reservation;
+      try {
+        reservation = ledger.reserve(task.worstCaseUsd);
+      } catch (error) {
+        if (error instanceof CostCeilingExceeded) {
+          stopped = true;
+          summary.stoppedOnCeiling = true;
+          log(error.message);
+          return;
+        }
+        throw error;
+      }
+
+      let attempts = 0;
+      let lastError: unknown;
+      let result: CompletionResult | undefined;
+      while (attempts <= retries) {
+        attempts += 1;
+        try {
+          result = await createCompletion({ request: task.request, aiPrompt: task.aiPrompt });
+          break;
+        } catch (error) {
+          lastError = error;
+          if (!isTransientError(error) || attempts > retries) break;
+          await sleep(250 * 2 ** (attempts - 1));
+        }
+      }
+
+      if (!result) {
+        // The request went out, so the provider may have billed for it even though nothing usable
+        // came back. Charging its single-attempt share is honest in the direction that matters: a
+        // long run of failures must not look free. Errors are never cached.
+        ledger.settleFailedAttempt(reservation, attempts, 1 + retries);
+        await writer.write({
+          ...common(task),
+          status: "error",
+          error: {
+            type: (lastError as any)?.name ?? "Error",
+            message: (lastError as Error)?.message ?? String(lastError),
+            attempts
+          }
+        } satisfies ResultRow);
+        summary.written += 1;
+        continue;
+      }
+
+      summary.apiCalls += 1;
+      // The call happened, so the money is spent whatever the response turned out to be.
+      const incurredThisRunUsd = priceTokens(result.usage.promptTokens, result.usage.completionTokens, pricing);
+      ledger.settle(reservation, incurredThisRunUsd);
+
+      if (result.parsed == null && result.refusal == null) {
+        // A response with neither a parsed object nor a refusal is a failure, the same way production
+        // treats it ("No response from AI" in on-analysis-document-imaged.ts). It is not cached: the
+        // usual cause is a truncated or malformed completion, which a rerun may well get past.
+        const reason = result.finish_reason ? `finish_reason: ${result.finish_reason}` : "no finish_reason reported";
+        await writer.write({
+          ...common(task),
+          status: "error",
+          error: {
+            type: "unparsed",
+            message: `The model returned neither a parsed response nor a refusal (${reason}).`,
+            attempts
+          },
+          // The API answered and billed for it, so the row carries what it cost. Without this the
+          // report understates spend by exactly the unparsed responses.
+          usage: { ...result.usage, source: "api" },
+          cost: { modeledUsd: incurredThisRunUsd, incurredThisRunUsd },
+          responseOriginMeta: result.originMeta
+        } satisfies ResultRow);
+        summary.written += 1;
+        continue;
+      }
+
+      const entry: CacheEntry = {
+        schemaVersion: kSchemaVersion,
+        key: task.requestKey,
+        status: result.refusal ? "refusal" : "success",
+        parsed: result.parsed ?? undefined,
+        raw: result.raw,
+        refusal: result.refusal ?? undefined,
+        usage: result.usage,
+        responseOriginMeta: result.originMeta
+      };
+      // Successes *and* refusals are cached, so a rerun does not re-spend on a deterministic refusal.
+      cache.put(entry);
+      await writer.write(rowFromResponse(task, entry, "api", incurredThisRunUsd));
+      summary.written += 1;
+    }
+  };
+
+  // allSettled rather than all: Promise.all rejects on the first worker failure and would skip
+  // writer.close(), abandoning rows already queued. Every worker is drained first, the writer is
+  // closed in the finally, and only then is the first failure rethrown.
+  const outcomes = await Promise.allSettled(
+    Array.from({ length: Math.max(1, concurrency) }, () => worker()));
+  try {
+    const failure = outcomes.find((outcome) => outcome.status === "rejected");
+    if (failure) throw (failure as PromiseRejectedResult).reason;
+  } finally {
+    await writer.close();
+  }
+
+  summary.reservedPeakUsd = ledger.reservedPeakUsd;
+  summary.incurredUsd = ledger.incurredUsd;
+  summary.overshootUsd = ledger.overshootUsd;
+  return summary;
+}

--- a/scripts/ai-harness/src/messages.ts
+++ b/scripts/ai-harness/src/messages.ts
@@ -1,0 +1,97 @@
+/**
+ * Request construction. Every request the harness sends is built by the same functions the deployed
+ * analysis pipeline uses, so a variant can never "win" by being formatted differently.
+ */
+import type { ChatCompletionMessageParam } from "openai/resources/chat/completions";
+import {
+  IAiPrompt, RelatedSummary, buildSummaryMessages, buildZodResponseSchema, categorizationResponseFormat
+} from "../../../shared/ai-analysis-messages.js";
+import { MessageShape, sha256Canonical } from "./schemas.js";
+
+export interface GenerationSettings {
+  /**
+   * Production sets no completion cap. The harness always sets one so the spend ceiling is a real
+   * upper bound rather than an estimate; see the README.
+   */
+  max_completion_tokens: number;
+}
+
+export interface HarnessRequest {
+  model: string;
+  messages: ChatCompletionMessageParam[];
+  /** The serializable projection of the response format — what goes into the cache key. */
+  responseFormat: { type: string; json_schema: { name: string; strict?: boolean; schema: unknown } };
+  generationSettings: GenerationSettings;
+}
+
+export interface BuildRequestOptions {
+  model: string;
+  aiPrompt: IAiPrompt;
+  message: MessageShape;
+  markdown: string;
+  relatedSummaries?: RelatedSummary[];
+  generationSettings: GenerationSettings;
+}
+
+/** The openai helper object, complete with its parsing hooks. Not serializable — do not hash it. */
+export function responseFormatFor(aiPrompt: IAiPrompt) {
+  const responseSchema = buildZodResponseSchema(aiPrompt);
+  if (Object.keys(responseSchema).length === 0) {
+    throw new Error("aiPrompt must specify at least one response field for the schema.");
+  }
+  return categorizationResponseFormat(responseSchema);
+}
+
+/**
+ * Narrows the openai helper's response format to the serializable fields the cache key is built from.
+ *
+ * This is checked rather than cast because canonicalJson drops `undefined`: if a future SDK renamed
+ * `json_schema.schema`, the projection would silently produce `{type, json_schema: {name}}` for every
+ * prompt, and two genuinely different schemas would collide on one cache key — returning another
+ * prompt's cached answer. Failing loudly here is the only safe behavior.
+ */
+export function projectResponseFormat(parseable: unknown): HarnessRequest["responseFormat"] {
+  const format = parseable as { type?: unknown; json_schema?: { name?: unknown; strict?: unknown; schema?: unknown } };
+  const jsonSchema = format?.json_schema;
+  if (format?.type !== "json_schema" || typeof jsonSchema?.name !== "string" || jsonSchema.schema === undefined) {
+    throw new Error("Unexpected response-format shape from openai's zodResponseFormat helper " +
+      `(type: ${JSON.stringify(format?.type)}, json_schema keys: ` +
+      `${JSON.stringify(jsonSchema ? Object.keys(jsonSchema) : null)}). The cache key is derived from ` +
+      "these fields, so the harness stops rather than risk colliding keys across different schemas.");
+  }
+  return {
+    type: format.type,
+    json_schema: {
+      name: jsonSchema.name,
+      strict: typeof jsonSchema.strict === "boolean" ? jsonSchema.strict : undefined,
+      schema: jsonSchema.schema
+    }
+  };
+}
+
+export function buildRequest(options: BuildRequestOptions): HarnessRequest {
+  const { model, aiPrompt, message, markdown, relatedSummaries = [], generationSettings } = options;
+  if (message !== "text-only") {
+    throw new Error(`Message shape "${message}" is not supported in milestone 1.`);
+  }
+  return {
+    model,
+    messages: buildSummaryMessages(aiPrompt, markdown, relatedSummaries),
+    responseFormat: projectResponseFormat(responseFormatFor(aiPrompt)),
+    generationSettings
+  };
+}
+
+/**
+ * The cache key, which is also resume identity: it embeds the model, the fully built messages (so the
+ * document, its representation and the prompt are all in there), the response schema, and the
+ * generation settings.
+ */
+export function requestKeyFor(request: HarnessRequest): string {
+  return sha256Canonical({
+    model: request.model,
+    messages: request.messages,
+    responseFormat: request.responseFormat,
+    generationSettings: request.generationSettings
+  });
+}

--- a/scripts/ai-harness/src/pricing.json
+++ b/scripts/ai-harness/src/pricing.json
@@ -1,0 +1,11 @@
+{
+  "schemaVersion": 1,
+  "effectiveDate": "2026-08-11",
+  "models": {
+    "gpt-4o-mini": {
+      "inputPerMTokUsd": 0.15,
+      "outputPerMTokUsd": 0.6,
+      "maxOutputTokens": 1024
+    }
+  }
+}

--- a/scripts/ai-harness/src/report.ts
+++ b/scripts/ai-harness/src/report.ts
@@ -36,12 +36,49 @@ export interface GroupSummary {
   categories: Record<string, number>;
 }
 
+export interface SupersededSummary {
+  /** Rows in the file that a later re-run replaced. */
+  rows: number;
+  /** What those rows cost. Real money, so it is reported rather than dropped. */
+  incurredUsd: number;
+}
+
 export interface ReportSummary {
   schemaVersion: number;
   results: string;
   generatedAt: string;
+  /** Every row in the file, superseded ones included. */
   rows: number;
+  /** Rows the groups below are computed from: the latest outcome per (document, run). */
+  currentRows: number;
+  superseded: SupersededSummary;
   groups: GroupSummary[];
+}
+
+/**
+ * Splits a results file into the outcomes that still stand and the ones a later run replaced.
+ *
+ * Resume deliberately appends rather than rewrites: a changed document, prompt, representation or
+ * generation setting produces a new request key, so it re-runs and lands beside the old row. Summing
+ * both would double-count tokens and cost and split the category distribution between a superseded
+ * answer and the current one — so aggregation uses the last row per (document, run), which is the
+ * most recent because the writer only ever appends. An error row followed by a successful retry is
+ * the same case: the success is the outcome, the error is history.
+ */
+export function partitionSuperseded(rows: ResultRow[]): { current: ResultRow[]; superseded: ResultRow[] } {
+  const lastIndexForPair = new Map<string, number>();
+  rows.forEach((row, index) => lastIndexForPair.set(`${row.docId} ${row.runId}`, index));
+  const current: ResultRow[] = [];
+  const superseded: ResultRow[] = [];
+  rows.forEach((row, index) => {
+    if (lastIndexForPair.get(`${row.docId} ${row.runId}`) === index) current.push(row);
+    else superseded.push(row);
+  });
+  return { current, superseded };
+}
+
+function incurredUsdOf(rows: ResultRow[]): number {
+  return rows.reduce((total, row) => total + (("cost" in row && row.cost) ? row.cost.incurredThisRunUsd : 0), 0);
 }
 
 function mean(values: number[]): number {
@@ -178,6 +215,7 @@ export function assertSingleCorpusAndExperiment(rows: ResultRow[], resultsFile: 
 
 export function summarizeResults(rows: ResultRow[], resultsFile: string, now: Date = new Date()): ReportSummary {
   assertSingleCorpusAndExperiment(rows, resultsFile);
+  const { current, superseded } = partitionSuperseded(rows);
   // The cross-run aggregate is kept out of the keyed map rather than stored under its display label,
   // so an experiment that happens to define a run called "(all runs)" cannot merge into it.
   const groups = new Map<string, Accumulator>();
@@ -192,7 +230,7 @@ export function summarizeResults(rows: ResultRow[], resultsFile: string, now: Da
     return accumulator;
   };
 
-  for (const row of rows) {
+  for (const row of current) {
     accumulate(get(row.runId, row.modality), row);
     accumulate(get(row.runId, "all"), row);
     accumulate(overall, row);
@@ -203,6 +241,8 @@ export function summarizeResults(rows: ResultRow[], resultsFile: string, now: Da
     results: resultsFile,
     generatedAt: now.toISOString(),
     rows: rows.length,
+    currentRows: current.length,
+    superseded: { rows: superseded.length, incurredUsd: incurredUsdOf(superseded) },
     groups: [...groups.values(), overall].map(finish)
   };
 }
@@ -237,7 +277,13 @@ export function formatSummaryTable(summary: ReportSummary): string {
   for (const group of summary.groups) rows.push(kColumns.map((column) => column.value(group)));
   const widths = kColumns.map((_, index) => Math.max(...rows.map((row) => row[index].length)));
   const line = (row: string[]) => row.map((cell, index) => cell.padEnd(widths[index])).join("  ").trimEnd();
-  return [line(rows[0]), widths.map((width) => "-".repeat(width)).join("  "), ...rows.slice(1).map(line)].join("\n");
+  const table = [line(rows[0]), widths.map((width) => "-".repeat(width)).join("  "),
+    ...rows.slice(1).map(line)].join("\n");
+  if (summary.superseded.rows === 0) return table;
+  // Stated rather than silently dropped: the spend was real, and a reader should know the file holds
+  // outcomes that a later run replaced.
+  return `${table}\n\n${summary.superseded.rows} superseded row(s) excluded from the totals above ` +
+    `(replaced by a later re-run); they cost $${summary.superseded.incurredUsd.toFixed(4)}.`;
 }
 
 export function summaryPathFor(resultsFile: string): string {

--- a/scripts/ai-harness/src/report.ts
+++ b/scripts/ai-harness/src/report.ts
@@ -1,0 +1,261 @@
+/**
+ * Reports as data: a stdout table plus a summary.json next to the results file.
+ *
+ * Every result status is handled explicitly — a new status would fail to compile rather than being
+ * silently dropped from the counts.
+ */
+import path from "node:path";
+import { ManifestDocument, Modality, ResultRow, kSchemaVersion } from "./schemas.js";
+import { writeJsonFile } from "./corpus.js";
+
+/**
+ * Key for the cross-run aggregate. It is a sentinel rather than the display label because an
+ * experiment could legitimately define a run whose id is the label, and that run's rows would then be
+ * merged into the aggregate.
+ */
+export const kAllRunsKey = Symbol.for("clue-harness.all-runs");
+export const kAllRunsLabel = "(all runs)";
+
+export interface GroupSummary {
+  runId: string;
+  /** "all" aggregates every modality for that run. */
+  modality: Modality | "all";
+  docs: number;
+  cacheHits: number;
+  statuses: { success: number; refusal: number; error: number; skipped: number };
+  tokens: {
+    promptTotal: number;
+    completionTotal: number;
+    total: number;
+    promptMean: number;
+    promptMedian: number;
+    completionMean: number;
+    completionMedian: number;
+  };
+  cost: { modeledUsd: number; incurredUsd: number };
+  categories: Record<string, number>;
+}
+
+export interface ReportSummary {
+  schemaVersion: number;
+  results: string;
+  generatedAt: string;
+  rows: number;
+  groups: GroupSummary[];
+}
+
+function mean(values: number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((total, value) => total + value, 0) / values.length;
+}
+
+function median(values: number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[middle - 1] + sorted[middle]) / 2 : sorted[middle];
+}
+
+interface Accumulator {
+  runId: string | typeof kAllRunsKey;
+  modality: Modality | "all";
+  docs: Set<string>;
+  cacheHits: number;
+  statuses: GroupSummary["statuses"];
+  promptTokens: number[];
+  completionTokens: number[];
+  modeledUsd: number;
+  incurredUsd: number;
+  categories: Record<string, number>;
+}
+
+function newAccumulator(runId: string | typeof kAllRunsKey, modality: Modality | "all"): Accumulator {
+  return {
+    runId,
+    modality,
+    docs: new Set(),
+    cacheHits: 0,
+    statuses: { success: 0, refusal: 0, error: 0, skipped: 0 },
+    promptTokens: [],
+    completionTokens: [],
+    modeledUsd: 0,
+    incurredUsd: 0,
+    categories: {}
+  };
+}
+
+function accumulate(accumulator: Accumulator, row: ResultRow): void {
+  accumulator.docs.add(row.docId);
+  switch (row.status) {
+    case "success": {
+      accumulator.statuses.success += 1;
+      if (row.usage.source === "cache") accumulator.cacheHits += 1;
+      accumulator.promptTokens.push(row.usage.promptTokens);
+      accumulator.completionTokens.push(row.usage.completionTokens);
+      accumulator.modeledUsd += row.cost.modeledUsd;
+      accumulator.incurredUsd += row.cost.incurredThisRunUsd;
+      const category = (row.response.parsed as any)?.category;
+      const label = typeof category === "string" ? category : "(none)";
+      accumulator.categories[label] = (accumulator.categories[label] ?? 0) + 1;
+      break;
+    }
+    case "refusal": {
+      accumulator.statuses.refusal += 1;
+      if (row.usage.source === "cache") accumulator.cacheHits += 1;
+      accumulator.promptTokens.push(row.usage.promptTokens);
+      accumulator.completionTokens.push(row.usage.completionTokens);
+      accumulator.modeledUsd += row.cost.modeledUsd;
+      accumulator.incurredUsd += row.cost.incurredThisRunUsd;
+      break;
+    }
+    case "error": {
+      accumulator.statuses.error += 1;
+      // An error row that carries usage was answered and billed (the "unparsed" case). Its money and
+      // tokens belong in the totals even though it is not a usable result; leaving them out would
+      // understate spend by exactly those responses. It stays counted as an error, not a success.
+      if (row.usage && row.cost) {
+        if (row.usage.source === "cache") accumulator.cacheHits += 1;
+        accumulator.promptTokens.push(row.usage.promptTokens);
+        accumulator.completionTokens.push(row.usage.completionTokens);
+        accumulator.modeledUsd += row.cost.modeledUsd;
+        accumulator.incurredUsd += row.cost.incurredThisRunUsd;
+      }
+      break;
+    }
+    case "skipped": {
+      accumulator.statuses.skipped += 1;
+      break;
+    }
+    default: {
+      const unhandled: never = row;
+      throw new Error(`Unhandled result status: ${JSON.stringify(unhandled)}`);
+    }
+  }
+}
+
+function finish(accumulator: Accumulator): GroupSummary {
+  const promptTotal = accumulator.promptTokens.reduce((total, value) => total + value, 0);
+  const completionTotal = accumulator.completionTokens.reduce((total, value) => total + value, 0);
+  return {
+    runId: accumulator.runId === kAllRunsKey ? kAllRunsLabel : accumulator.runId,
+    modality: accumulator.modality,
+    docs: accumulator.docs.size,
+    cacheHits: accumulator.cacheHits,
+    statuses: accumulator.statuses,
+    tokens: {
+      promptTotal,
+      completionTotal,
+      total: promptTotal + completionTotal,
+      promptMean: mean(accumulator.promptTokens),
+      promptMedian: median(accumulator.promptTokens),
+      completionMean: mean(accumulator.completionTokens),
+      completionMedian: median(accumulator.completionTokens)
+    },
+    cost: { modeledUsd: accumulator.modeledUsd, incurredUsd: accumulator.incurredUsd },
+    categories: accumulator.categories
+  };
+}
+
+/**
+ * A results file is expected to describe one corpus and one experiment definition. Summing across two
+ * would produce a table that looks fine and means nothing — different documents, or the same
+ * documents under a silently edited experiment.
+ */
+export function assertSingleCorpusAndExperiment(rows: ResultRow[], resultsFile: string): void {
+  const corpora = new Set(rows.map((row) => row.corpus));
+  if (corpora.size > 1) {
+    throw new Error(`${resultsFile}: mixes ${corpora.size} corpora (${[...corpora].sort().join(", ")}). ` +
+      "Report one corpus at a time — use a separate --output per corpus.");
+  }
+  const hashes = new Set(rows.map((row) => row.experimentSha256));
+  if (hashes.size > 1) {
+    const names = [...new Set(rows.map((row) => row.experiment))].sort().join(", ");
+    throw new Error(`${resultsFile}: mixes ${hashes.size} experiment definitions (name(s): ${names}). ` +
+      "The experiment file changed between runs, so these rows are not comparable. Re-run into a " +
+      "fresh --output.");
+  }
+}
+
+export function summarizeResults(rows: ResultRow[], resultsFile: string, now: Date = new Date()): ReportSummary {
+  assertSingleCorpusAndExperiment(rows, resultsFile);
+  // The cross-run aggregate is kept out of the keyed map rather than stored under its display label,
+  // so an experiment that happens to define a run called "(all runs)" cannot merge into it.
+  const groups = new Map<string, Accumulator>();
+  const overall = newAccumulator(kAllRunsKey, "all");
+  const get = (runId: string, modality: Modality | "all") => {
+    const key = `${runId} ${modality}`;
+    let accumulator = groups.get(key);
+    if (!accumulator) {
+      accumulator = newAccumulator(runId, modality);
+      groups.set(key, accumulator);
+    }
+    return accumulator;
+  };
+
+  for (const row of rows) {
+    accumulate(get(row.runId, row.modality), row);
+    accumulate(get(row.runId, "all"), row);
+    accumulate(overall, row);
+  }
+
+  return {
+    schemaVersion: kSchemaVersion,
+    results: resultsFile,
+    generatedAt: now.toISOString(),
+    rows: rows.length,
+    groups: [...groups.values(), overall].map(finish)
+  };
+}
+
+const kColumns: { header: string; value: (group: GroupSummary) => string }[] = [
+  { header: "run", value: (group) => group.runId },
+  { header: "modality", value: (group) => group.modality },
+  { header: "docs", value: (group) => String(group.docs) },
+  { header: "ok", value: (group) => String(group.statuses.success) },
+  { header: "refused", value: (group) => String(group.statuses.refusal) },
+  { header: "errors", value: (group) => String(group.statuses.error) },
+  { header: "skipped", value: (group) => String(group.statuses.skipped) },
+  { header: "cached", value: (group) => String(group.cacheHits) },
+  { header: "tok in", value: (group) => String(group.tokens.promptTotal) },
+  { header: "tok out", value: (group) => String(group.tokens.completionTotal) },
+  { header: "in mean", value: (group) => group.tokens.promptMean.toFixed(0) },
+  { header: "in med", value: (group) => group.tokens.promptMedian.toFixed(0) },
+  { header: "out mean", value: (group) => group.tokens.completionMean.toFixed(0) },
+  { header: "out med", value: (group) => group.tokens.completionMedian.toFixed(0) },
+  { header: "modeled $", value: (group) => group.cost.modeledUsd.toFixed(4) },
+  { header: "incurred $", value: (group) => group.cost.incurredUsd.toFixed(4) },
+  { header: "categories", value: (group) => formatCategories(group.categories) }
+];
+
+function formatCategories(categories: Record<string, number>): string {
+  const entries = Object.entries(categories).sort(([a], [b]) => a.localeCompare(b));
+  return entries.length === 0 ? "-" : entries.map(([name, count]) => `${name}:${count}`).join(" ");
+}
+
+export function formatSummaryTable(summary: ReportSummary): string {
+  const rows = [kColumns.map((column) => column.header)];
+  for (const group of summary.groups) rows.push(kColumns.map((column) => column.value(group)));
+  const widths = kColumns.map((_, index) => Math.max(...rows.map((row) => row[index].length)));
+  const line = (row: string[]) => row.map((cell, index) => cell.padEnd(widths[index])).join("  ").trimEnd();
+  return [line(rows[0]), widths.map((width) => "-".repeat(width)).join("  "), ...rows.slice(1).map(line)].join("\n");
+}
+
+export function summaryPathFor(resultsFile: string): string {
+  return path.join(path.dirname(resultsFile), "summary.json");
+}
+
+export function writeSummary(summary: ReportSummary, summaryFile: string): string {
+  writeJsonFile(summaryFile, summary);
+  return summaryFile;
+}
+
+/**
+ * A `done`-queue record describes an analysis of whatever the document looked like *then*. It may
+ * only be lined up against a fresh run when the content hash proves the input is identical; a
+ * historical record that does not carry the hash it ran against can never clear that bar.
+ */
+export function historicalIsComparable(document: ManifestDocument): boolean {
+  const historical = document.historical;
+  if (!historical) return false;
+  return typeof historical.contentSha256 === "string" && historical.contentSha256 === document.contentSha256;
+}

--- a/scripts/ai-harness/src/represent-text.ts
+++ b/scripts/ai-harness/src/represent-text.ts
@@ -1,0 +1,41 @@
+/**
+ * Text representations of a document.
+ *
+ * Each variant wraps `documentSummarizer` from shared/ai-summarizer so the harness measures exactly
+ * what production produces. `variantVersion` is bumped whenever a variant's output would change for
+ * the same input; the representation envelope records it so stale caches are detected.
+ *
+ * The `svg-drawings` variant (documentSummarizerWithDrawings) is deliberately absent — see the
+ * README. It pulls in src/plugins/drawing, which imports .svg assets that only a bundler can load.
+ */
+import { documentSummarizer } from "../../../shared/ai-summarizer/ai-summarizer.js";
+
+export interface TextVariant {
+  id: string;
+  /** Bump when this variant's output would change for the same input. */
+  variantVersion: number;
+  render(content: unknown): string;
+}
+
+export const textVariants: Record<string, TextVariant> = {
+  default: {
+    id: "default",
+    variantVersion: 1,
+    render: (content) => documentSummarizer(content, {})
+  },
+  minimal: {
+    id: "minimal",
+    variantVersion: 1,
+    render: (content) => documentSummarizer(content, { minimal: true })
+  }
+};
+
+export const textVariantIds: readonly string[] = Object.keys(textVariants);
+
+export function getTextVariant(id: string): TextVariant {
+  const variant = textVariants[id];
+  if (!variant) {
+    throw new Error(`Unknown text variant "${id}". Known variants: ${textVariantIds.join(", ")}`);
+  }
+  return variant;
+}

--- a/scripts/ai-harness/src/schemas.ts
+++ b/scripts/ai-harness/src/schemas.ts
@@ -1,0 +1,756 @@
+/**
+ * Types, runtime validators and the canonical serialization used by every hash in the harness.
+ *
+ * Every on-disk format carries `schemaVersion: 1`. Validators run on every read and throw a
+ * `ValidationError` naming the file and the offending field.
+ */
+import { createHash } from "node:crypto";
+
+export const kSchemaVersion = 1;
+
+// ---------------------------------------------------------------------------
+// Canonical serialization
+// ---------------------------------------------------------------------------
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value !== null && typeof value === "object") {
+    const source = value as Record<string, unknown>;
+    const result: Record<string, unknown> = {};
+    for (const key of Object.keys(source).sort()) {
+      if (source[key] !== undefined) result[key] = canonicalize(source[key]);
+    }
+    return result;
+  }
+  return value;
+}
+
+/** Deterministic JSON: object keys sorted recursively, no whitespace, `undefined` members dropped. */
+export function canonicalJson(value: unknown): string {
+  return JSON.stringify(canonicalize(value)) ?? "null";
+}
+
+/** The one hash function the harness uses. "sha256 of X" always means this unless it says "file bytes". */
+export function sha256Canonical(value: unknown): string {
+  return createHash("sha256").update(canonicalJson(value), "utf8").digest("hex");
+}
+
+// ---------------------------------------------------------------------------
+// Validation helpers
+// ---------------------------------------------------------------------------
+
+export class ValidationError extends Error {
+  constructor(public readonly file: string, public readonly field: string, detail: string) {
+    super(`${file}: ${field} ${detail}`);
+    this.name = "ValidationError";
+  }
+}
+
+function fail(file: string, field: string, detail: string): never {
+  throw new ValidationError(file, field, detail);
+}
+
+function asObject(value: unknown, file: string, field: string): Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    fail(file, field, `must be an object, got ${describe(value)}`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function asArray(value: unknown, file: string, field: string): unknown[] {
+  if (!Array.isArray(value)) fail(file, field, `must be an array, got ${describe(value)}`);
+  return value;
+}
+
+function asString(value: unknown, file: string, field: string): string {
+  if (typeof value !== "string") fail(file, field, `must be a string, got ${describe(value)}`);
+  return value;
+}
+
+function asOptionalString(value: unknown, file: string, field: string): string | null {
+  if (value === undefined || value === null) return null;
+  return asString(value, file, field);
+}
+
+function asBoolean(value: unknown, file: string, field: string): boolean {
+  if (typeof value !== "boolean") fail(file, field, `must be a boolean, got ${describe(value)}`);
+  return value;
+}
+
+function asNumber(value: unknown, file: string, field: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    fail(file, field, `must be a finite number, got ${describe(value)}`);
+  }
+  return value;
+}
+
+/** A negative price would make the reservation ledger under-count instead of over-count. */
+function asNonNegativeNumber(value: unknown, file: string, field: string): number {
+  const parsed = asNumber(value, file, field);
+  if (parsed < 0) fail(file, field, `must not be negative, got ${parsed}`);
+  return parsed;
+}
+
+/** The completion cap is what turns the reservation into a real bound, so it has to be a real cap. */
+function asPositiveInteger(value: unknown, file: string, field: string): number {
+  const parsed = asNumber(value, file, field);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    fail(file, field, `must be a positive integer, got ${describe(value)}`);
+  }
+  return parsed;
+}
+
+function asEnum<T extends string>(value: unknown, allowed: readonly T[], file: string, field: string): T {
+  const text = asString(value, file, field);
+  if (!allowed.includes(text as T)) {
+    fail(file, field, `must be one of ${allowed.join(", ")}, got "${text}"`);
+  }
+  return text as T;
+}
+
+function checkSchemaVersion(record: Record<string, unknown>, file: string): void {
+  if (record.schemaVersion !== kSchemaVersion) {
+    fail(file, "schemaVersion", `must be ${kSchemaVersion}, got ${describe(record.schemaVersion)}`);
+  }
+}
+
+function describe(value: unknown): string {
+  if (value === undefined) return "undefined";
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "an array";
+  return typeof value === "object" ? "an object" : JSON.stringify(value);
+}
+
+// ---------------------------------------------------------------------------
+// Corpus manifest
+// ---------------------------------------------------------------------------
+
+export const modalities = ["text-only", "visual-only", "mixed", "empty"] as const;
+export type Modality = typeof modalities[number];
+
+export const corpusSources = ["synthetic", "demo", "qa", "production"] as const;
+export type CorpusSource = typeof corpusSources[number];
+
+/** Recorded when a production document is pulled (milestone 6). Always `null` in milestone 1. */
+export interface HistoricalAnalysis {
+  summarizer: string;
+  promptTokens: number;
+  completionTokens: number;
+  response: unknown;
+  analyzedAt: string;
+  /** The document hash the historical analysis actually ran against, when it is known. */
+  contentSha256?: string;
+}
+
+export interface RelatedSummaryEntry {
+  summary: string;
+  agreements: Record<string, { content: string; tags: string[] }[]>;
+}
+
+export interface ManifestDocument {
+  id: string;
+  file: string;
+  source: CorpusSource;
+  contentSha256: string;
+  retrievedAt: string | null;
+  unit: string | null;
+  investigation: string | null;
+  problem: string | null;
+  contextId: string | null;
+  /** Always recomputed by `import` from the current content. */
+  computedModality: Modality;
+  /** Only ever set by a human; tooling never writes it. */
+  modalityOverride: Modality | null;
+  labels: Record<string, unknown>;
+  relatedSummaries: RelatedSummaryEntry[];
+  historical: HistoricalAnalysis | null;
+}
+
+export interface CorpusManifest {
+  schemaVersion: number;
+  name: string;
+  createdAt: string;
+  documents: ManifestDocument[];
+}
+
+export const kDocumentIdPattern = /^[a-z0-9-]+$/;
+
+export function validateCorpusManifest(value: unknown, file: string): CorpusManifest {
+  const record = asObject(value, file, "manifest");
+  checkSchemaVersion(record, file);
+  const documents = asArray(record.documents, file, "documents").map((entry, index) =>
+    validateManifestDocument(entry, file, `documents[${index}]`));
+  const seen = new Set<string>();
+  for (const document of documents) {
+    if (seen.has(document.id)) fail(file, "documents", `contains duplicate document id "${document.id}"`);
+    seen.add(document.id);
+  }
+  return {
+    schemaVersion: kSchemaVersion,
+    name: asString(record.name, file, "name"),
+    createdAt: asString(record.createdAt, file, "createdAt"),
+    documents
+  };
+}
+
+function validateManifestDocument(value: unknown, file: string, field: string): ManifestDocument {
+  const record = asObject(value, file, field);
+  const id = asString(record.id, file, `${field}.id`);
+  if (!kDocumentIdPattern.test(id)) {
+    fail(file, `${field}.id`, `must match ${kDocumentIdPattern}, got "${id}"`);
+  }
+  return {
+    id,
+    file: asString(record.file, file, `${field}.file`),
+    source: asEnum(record.source, corpusSources, file, `${field}.source`),
+    contentSha256: asString(record.contentSha256, file, `${field}.contentSha256`),
+    retrievedAt: asOptionalString(record.retrievedAt, file, `${field}.retrievedAt`),
+    unit: asOptionalString(record.unit, file, `${field}.unit`),
+    investigation: asOptionalString(record.investigation, file, `${field}.investigation`),
+    problem: asOptionalString(record.problem, file, `${field}.problem`),
+    contextId: asOptionalString(record.contextId, file, `${field}.contextId`),
+    computedModality: asEnum(record.computedModality, modalities, file, `${field}.computedModality`),
+    modalityOverride: record.modalityOverride == null
+      ? null
+      : asEnum(record.modalityOverride, modalities, file, `${field}.modalityOverride`),
+    labels: record.labels == null ? {} : asObject(record.labels, file, `${field}.labels`),
+    relatedSummaries: record.relatedSummaries == null
+      ? []
+      : asArray(record.relatedSummaries, file, `${field}.relatedSummaries`)
+        .map((entry, index) => validateRelatedSummary(entry, file, `${field}.relatedSummaries[${index}]`)),
+    historical: record.historical == null
+      ? null
+      : validateHistoricalAnalysis(record.historical, file, `${field}.historical`)
+  };
+}
+
+/**
+ * Related summaries are injected into request construction from milestone 3 on, and the manifest is
+ * exactly the file a human hand-edits, so these are checked rather than cast.
+ */
+function validateRelatedSummary(value: unknown, file: string, field: string): RelatedSummaryEntry {
+  const record = asObject(value, file, field);
+  const agreements = asObject(record.agreements, file, `${field}.agreements`);
+  const validated: RelatedSummaryEntry["agreements"] = {};
+  for (const [agreementValue, entries] of Object.entries(agreements)) {
+    const agreementField = `${field}.agreements.${agreementValue}`;
+    validated[agreementValue] = asArray(entries, file, agreementField).map((entry, index) => {
+      const info = asObject(entry, file, `${agreementField}[${index}]`);
+      return {
+        content: asString(info.content, file, `${agreementField}[${index}].content`),
+        tags: asArray(info.tags, file, `${agreementField}[${index}].tags`)
+          .map((tag, tagIndex) => asString(tag, file, `${agreementField}[${index}].tags[${tagIndex}]`))
+      };
+    });
+  }
+  return { summary: asString(record.summary, file, `${field}.summary`), agreements: validated };
+}
+
+function validateHistoricalAnalysis(value: unknown, file: string, field: string): HistoricalAnalysis {
+  const record = asObject(value, file, field);
+  const historical: HistoricalAnalysis = {
+    summarizer: asString(record.summarizer, file, `${field}.summarizer`),
+    promptTokens: asNumber(record.promptTokens, file, `${field}.promptTokens`),
+    completionTokens: asNumber(record.completionTokens, file, `${field}.completionTokens`),
+    response: record.response,
+    analyzedAt: asString(record.analyzedAt, file, `${field}.analyzedAt`)
+  };
+  if (record.contentSha256 !== undefined) {
+    historical.contentSha256 = asString(record.contentSha256, file, `${field}.contentSha256`);
+  }
+  return historical;
+}
+
+/** The modality reports and result rows use: the human override when present, otherwise the computed one. */
+export function effectiveModality(document: ManifestDocument): Modality {
+  return document.modalityOverride ?? document.computedModality;
+}
+
+// ---------------------------------------------------------------------------
+// Prompt file
+// ---------------------------------------------------------------------------
+
+export interface AiPromptData {
+  systemPrompt: string;
+  mainPrompt: string;
+  categorizationDescription?: string;
+  categories?: string[];
+  keyIndicatorsPrompt?: string;
+  discussionPrompt?: string;
+}
+
+export interface PromptFile {
+  schemaVersion: number;
+  name: string;
+  aiPrompt: AiPromptData;
+  provenance: {
+    source: string;
+    retrievedAt: string;
+    aiPromptSha256: string;
+  };
+}
+
+/**
+ * Every field is checked, not just the two required ones. `categories` matters most: a *string* there
+ * passes a loose check and then gets spread character-by-character into the Zod enum, producing a
+ * schema that looks valid and asks the model for entirely the wrong categories.
+ */
+export function validateAiPrompt(value: unknown, file: string, field: string): AiPromptData {
+  const record = asObject(value, file, field);
+  const prompt: AiPromptData = {
+    systemPrompt: asString(record.systemPrompt, file, `${field}.systemPrompt`),
+    mainPrompt: asString(record.mainPrompt, file, `${field}.mainPrompt`)
+  };
+  for (const optional of ["categorizationDescription", "keyIndicatorsPrompt", "discussionPrompt"] as const) {
+    if (record[optional] !== undefined) {
+      prompt[optional] = asString(record[optional], file, `${field}.${optional}`);
+    }
+  }
+  if (record.categories !== undefined) {
+    const categories = asArray(record.categories, file, `${field}.categories`)
+      .map((category, index) => {
+        const text = asString(category, file, `${field}.categories[${index}]`);
+        if (text.trim().length === 0) fail(file, `${field}.categories[${index}]`, "must not be empty");
+        return text;
+      });
+    const seen = new Set<string>();
+    for (const category of categories) {
+      if (seen.has(category)) fail(file, `${field}.categories`, `contains the duplicate entry "${category}"`);
+      seen.add(category);
+      // buildZodResponseSchema prepends "unknown" itself; a second one makes an invalid enum.
+      if (category === "unknown") {
+        fail(file, `${field}.categories`, 'must not list "unknown" — the schema builder adds it');
+      }
+    }
+    prompt.categories = categories;
+  }
+  return prompt;
+}
+
+export function validatePromptFile(value: unknown, file: string): PromptFile {
+  const record = asObject(value, file, "prompt");
+  checkSchemaVersion(record, file);
+  const aiPrompt = validateAiPrompt(record.aiPrompt, file, "aiPrompt");
+  const provenance = asObject(record.provenance, file, "provenance");
+  const declaredHash = asString(provenance.aiPromptSha256, file, "provenance.aiPromptSha256");
+  const actualHash = sha256Canonical(aiPrompt);
+  if (declaredHash !== actualHash) {
+    fail(file, "provenance.aiPromptSha256",
+      `does not match sha256Canonical(aiPrompt): declared ${declaredHash}, actual ${actualHash}`);
+  }
+  return {
+    schemaVersion: kSchemaVersion,
+    name: asString(record.name, file, "name"),
+    aiPrompt,
+    provenance: {
+      source: asString(provenance.source, file, "provenance.source"),
+      retrievedAt: asString(provenance.retrievedAt, file, "provenance.retrievedAt"),
+      aiPromptSha256: declaredHash
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Experiment file
+// ---------------------------------------------------------------------------
+
+/** Milestone 1 runs text-only messages. `image-only` and `mixed` arrive in milestones 2 and 3. */
+export const messageShapes = ["text-only"] as const;
+export type MessageShape = typeof messageShapes[number];
+
+export interface ExperimentRun {
+  id: string;
+  message: MessageShape;
+  textVariant: string;
+  prompt: string;
+}
+
+export interface ExperimentFile {
+  schemaVersion: number;
+  name: string;
+  runs: ExperimentRun[];
+}
+
+export interface ExperimentValidationContext {
+  /** Text representation variants this build knows how to produce. */
+  knownTextVariants: readonly string[];
+  /** Returns true when `prompts/<name>.json` exists. */
+  promptExists: (name: string) => boolean;
+}
+
+export function validateExperimentFile(
+  value: unknown, file: string, context: ExperimentValidationContext
+): ExperimentFile {
+  const record = asObject(value, file, "experiment");
+  checkSchemaVersion(record, file);
+  // The name becomes a path segment in the default results file, so it is constrained the same way a
+  // document id is: a name like "../../escaped" would otherwise steer that file out of data/.
+  const name = asString(record.name, file, "name");
+  if (!kDocumentIdPattern.test(name)) {
+    fail(file, "name", `must match ${kDocumentIdPattern}, got "${name}"`);
+  }
+  const runs = asArray(record.runs, file, "runs");
+  if (runs.length === 0) fail(file, "runs", "must contain at least one run");
+  const seen = new Set<string>();
+  const validated = runs.map((entry, index) => {
+    const field = `runs[${index}]`;
+    const run = asObject(entry, file, field);
+    const id = asString(run.id, file, `${field}.id`);
+    if (seen.has(id)) fail(file, `${field}.id`, `duplicates an earlier run id "${id}"`);
+    seen.add(id);
+    const textVariant = asString(run.textVariant, file, `${field}.textVariant`);
+    if (!context.knownTextVariants.includes(textVariant)) {
+      fail(file, `${field}.textVariant`,
+        `must be one of ${context.knownTextVariants.join(", ")}, got "${textVariant}"`);
+    }
+    const prompt = asString(run.prompt, file, `${field}.prompt`);
+    if (!context.promptExists(prompt)) {
+      fail(file, `${field}.prompt`, `names a prompt file that does not exist: prompts/${prompt}.json`);
+    }
+    return {
+      id,
+      message: asEnum(run.message, messageShapes, file, `${field}.message`),
+      textVariant,
+      prompt
+    };
+  });
+  return { schemaVersion: kSchemaVersion, name, runs: validated };
+}
+
+// ---------------------------------------------------------------------------
+// Representation envelope
+// ---------------------------------------------------------------------------
+
+export interface RepresentationEnvelope {
+  schemaVersion: number;
+  docId: string;
+  variantId: string;
+  variantVersion: number;
+  sourceContentSha256: string;
+  generatedAt: string;
+  markdown: string;
+}
+
+export function validateRepresentationEnvelope(value: unknown, file: string): RepresentationEnvelope {
+  const record = asObject(value, file, "representation");
+  checkSchemaVersion(record, file);
+  return {
+    schemaVersion: kSchemaVersion,
+    docId: asString(record.docId, file, "docId"),
+    variantId: asString(record.variantId, file, "variantId"),
+    variantVersion: asNumber(record.variantVersion, file, "variantVersion"),
+    sourceContentSha256: asString(record.sourceContentSha256, file, "sourceContentSha256"),
+    generatedAt: asString(record.generatedAt, file, "generatedAt"),
+    markdown: asString(record.markdown, file, "markdown")
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Pricing config
+// ---------------------------------------------------------------------------
+
+export interface ModelPricing {
+  inputPerMTokUsd: number;
+  outputPerMTokUsd: number;
+  maxOutputTokens: number;
+}
+
+export interface PricingConfig {
+  schemaVersion: number;
+  effectiveDate: string;
+  models: Record<string, ModelPricing>;
+}
+
+export function validatePricingConfig(value: unknown, file: string): PricingConfig {
+  const record = asObject(value, file, "pricing");
+  checkSchemaVersion(record, file);
+  const models = asObject(record.models, file, "models");
+  const validated: Record<string, ModelPricing> = {};
+  for (const [model, entry] of Object.entries(models)) {
+    const field = `models.${model}`;
+    const pricing = asObject(entry, file, field);
+    validated[model] = {
+      inputPerMTokUsd: asNonNegativeNumber(pricing.inputPerMTokUsd, file, `${field}.inputPerMTokUsd`),
+      outputPerMTokUsd: asNonNegativeNumber(pricing.outputPerMTokUsd, file, `${field}.outputPerMTokUsd`),
+      maxOutputTokens: asPositiveInteger(pricing.maxOutputTokens, file, `${field}.maxOutputTokens`)
+    };
+  }
+  return {
+    schemaVersion: kSchemaVersion,
+    effectiveDate: asString(record.effectiveDate, file, "effectiveDate"),
+    models: validated
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Result rows
+// ---------------------------------------------------------------------------
+
+export const resultStatuses = ["success", "refusal", "error", "skipped"] as const;
+export type ResultStatus = typeof resultStatuses[number];
+
+export interface RunMeta {
+  date: string;
+  openaiSdkVersion: string;
+  gitCommit: string | null;
+  gitDirty: boolean;
+}
+
+export interface ResponseOriginMeta {
+  /** When the originating API call happened — for a cache hit this is the *original* call's date. */
+  date: string;
+  modelReturned: string | null;
+  systemFingerprint: string | null;
+}
+
+export interface ResultUsage {
+  promptTokens: number;
+  completionTokens: number;
+  source: "api" | "cache";
+}
+
+export interface ResultCost {
+  /** What the response's token usage costs at the configured prices. */
+  modeledUsd: number;
+  /** What this particular run actually spent — always 0 for a cache hit. */
+  incurredThisRunUsd: number;
+}
+
+export interface ResultRowCommon {
+  schemaVersion: number;
+  experiment: string;
+  experimentSha256: string;
+  runId: string;
+  corpus: string;
+  docId: string;
+  modality: Modality;
+  message: MessageShape;
+  textVariant: string;
+  prompt: { name: string; sha256: string };
+  /** The cache key, which doubles as resume identity. `null` on skipped rows: they build no request. */
+  requestKey: string | null;
+  runMeta: RunMeta;
+}
+
+export interface SuccessResultRow extends ResultRowCommon {
+  status: "success";
+  requestKey: string;
+  response: { parsed: unknown; raw: unknown };
+  usage: ResultUsage;
+  cost: ResultCost;
+  responseOriginMeta: ResponseOriginMeta;
+}
+
+export interface RefusalResultRow extends ResultRowCommon {
+  status: "refusal";
+  requestKey: string;
+  refusal: string;
+  usage: ResultUsage;
+  cost: ResultCost;
+  responseOriginMeta: ResponseOriginMeta;
+}
+
+export interface ErrorResultRow extends ResultRowCommon {
+  status: "error";
+  requestKey: string;
+  error: { type: string; message: string; attempts: number };
+  /**
+   * Present when the API actually answered and billed for it — the "unparsed" case, where a
+   * completion came back with usage but neither parsed content nor a refusal. Absent when the call
+   * never produced a response (network failure, timeout), which is billed by nobody we can observe.
+   * Reports add these into the cost totals while still counting the row as an error.
+   */
+  usage?: ResultUsage;
+  cost?: ResultCost;
+  responseOriginMeta?: ResponseOriginMeta;
+}
+
+export interface SkippedResultRow extends ResultRowCommon {
+  status: "skipped";
+  requestKey: null;
+  skipReasons: string[];
+}
+
+export type ResultRow = SuccessResultRow | RefusalResultRow | ErrorResultRow | SkippedResultRow;
+
+function validateResultCommon(record: Record<string, unknown>, file: string): ResultRowCommon {
+  checkSchemaVersion(record, file);
+  const prompt = asObject(record.prompt, file, "prompt");
+  const runMeta = asObject(record.runMeta, file, "runMeta");
+  return {
+    schemaVersion: kSchemaVersion,
+    experiment: asString(record.experiment, file, "experiment"),
+    experimentSha256: asString(record.experimentSha256, file, "experimentSha256"),
+    runId: asString(record.runId, file, "runId"),
+    corpus: asString(record.corpus, file, "corpus"),
+    docId: asString(record.docId, file, "docId"),
+    modality: asEnum(record.modality, modalities, file, "modality"),
+    message: asEnum(record.message, messageShapes, file, "message"),
+    textVariant: asString(record.textVariant, file, "textVariant"),
+    prompt: { name: asString(prompt.name, file, "prompt.name"), sha256: asString(prompt.sha256, file, "prompt.sha256") },
+    requestKey: null,
+    runMeta: {
+      date: asString(runMeta.date, file, "runMeta.date"),
+      openaiSdkVersion: asString(runMeta.openaiSdkVersion, file, "runMeta.openaiSdkVersion"),
+      gitCommit: asOptionalString(runMeta.gitCommit, file, "runMeta.gitCommit"),
+      gitDirty: asBoolean(runMeta.gitDirty, file, "runMeta.gitDirty")
+    }
+  };
+}
+
+function validateUsage(value: unknown, file: string): ResultUsage {
+  const usage = asObject(value, file, "usage");
+  return {
+    promptTokens: asNumber(usage.promptTokens, file, "usage.promptTokens"),
+    completionTokens: asNumber(usage.completionTokens, file, "usage.completionTokens"),
+    source: asEnum(usage.source, ["api", "cache"] as const, file, "usage.source")
+  };
+}
+
+function validateCost(value: unknown, file: string): ResultCost {
+  const cost = asObject(value, file, "cost");
+  return {
+    modeledUsd: asNumber(cost.modeledUsd, file, "cost.modeledUsd"),
+    incurredThisRunUsd: asNumber(cost.incurredThisRunUsd, file, "cost.incurredThisRunUsd")
+  };
+}
+
+function validateOriginMeta(value: unknown, file: string): ResponseOriginMeta {
+  const meta = asObject(value, file, "responseOriginMeta");
+  return {
+    date: asString(meta.date, file, "responseOriginMeta.date"),
+    modelReturned: asOptionalString(meta.modelReturned, file, "responseOriginMeta.modelReturned"),
+    systemFingerprint: asOptionalString(meta.systemFingerprint, file, "responseOriginMeta.systemFingerprint")
+  };
+}
+
+/** Validates one result row against the schema its `status` selects. */
+export function validateResultRow(value: unknown, file: string): ResultRow {
+  const record = asObject(value, file, "result");
+  const status = asEnum(record.status, resultStatuses, file, "status");
+  const common = validateResultCommon(record, file);
+
+  if (status === "skipped") {
+    if (record.requestKey != null) {
+      fail(file, "requestKey", `must be null on a skipped row, got ${describe(record.requestKey)}`);
+    }
+    return {
+      ...common,
+      status,
+      requestKey: null,
+      skipReasons: asArray(record.skipReasons, file, "skipReasons")
+        .map((reason, index) => asString(reason, file, `skipReasons[${index}]`))
+    };
+  }
+
+  const requestKey = asString(record.requestKey, file, "requestKey");
+
+  if (status === "error") {
+    const error = asObject(record.error, file, "error");
+    const row: ErrorResultRow = {
+      ...common,
+      status,
+      requestKey,
+      error: {
+        type: asString(error.type, file, "error.type"),
+        message: asString(error.message, file, "error.message"),
+        attempts: asNumber(error.attempts, file, "error.attempts")
+      }
+    };
+    // A billed error carries all three or none: a row with cost but no usage would let a report
+    // double-count or under-count without any way to tell which.
+    const billed = ["usage", "cost", "responseOriginMeta"].filter((key) => record[key] != null);
+    if (billed.length > 0 && billed.length < 3) {
+      fail(file, billed[0], "is set on an error row without usage, cost and responseOriginMeta together");
+    }
+    if (billed.length === 3) {
+      row.usage = validateUsage(record.usage, file);
+      row.cost = validateCost(record.cost, file);
+      row.responseOriginMeta = validateOriginMeta(record.responseOriginMeta, file);
+    }
+    return row;
+  }
+
+  if (status === "refusal") {
+    return {
+      ...common,
+      status,
+      requestKey,
+      refusal: asString(record.refusal, file, "refusal"),
+      usage: validateUsage(record.usage, file),
+      cost: validateCost(record.cost, file),
+      responseOriginMeta: validateOriginMeta(record.responseOriginMeta, file)
+    };
+  }
+
+  const response = asObject(record.response, file, "response");
+  if (!("parsed" in response)) fail(file, "response.parsed", "is missing");
+  if (!("raw" in response)) fail(file, "response.raw", "is missing");
+  return {
+    ...common,
+    status,
+    requestKey,
+    response: { parsed: response.parsed, raw: response.raw },
+    usage: validateUsage(record.usage, file),
+    cost: validateCost(record.cost, file),
+    responseOriginMeta: validateOriginMeta(record.responseOriginMeta, file)
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fixture expectations (the committed synthetic corpus)
+// ---------------------------------------------------------------------------
+
+export const handlerTiers = ["full", "partial", "stub", "fallback"] as const;
+export type HandlerTier = typeof handlerTiers[number];
+
+export interface FixtureExpectation {
+  computedModality: Modality;
+  tileTypes: string[];
+  capability: { containsStudentText: boolean; requiresVisualRepresentation: boolean };
+  handlerTier: HandlerTier;
+  distinctiveString: string;
+  /** Defaults to `handlerTier` being full or partial; set explicitly where a handler emits nothing. */
+  expectDistinctiveInDefaultSummary: boolean;
+  defaultSummaryMustSucceed: boolean;
+  minimalSummaryMustSucceed: boolean;
+  notes?: string;
+}
+
+export interface ExpectationsFile {
+  schemaVersion: number;
+  corpus: string;
+  documents: Record<string, FixtureExpectation>;
+}
+
+export function validateExpectationsFile(value: unknown, file: string): ExpectationsFile {
+  const record = asObject(value, file, "expectations");
+  checkSchemaVersion(record, file);
+  const documents = asObject(record.documents, file, "documents");
+  const validated: Record<string, FixtureExpectation> = {};
+  for (const [docId, entry] of Object.entries(documents)) {
+    const field = `documents.${docId}`;
+    const expectation = asObject(entry, file, field);
+    const capability = asObject(expectation.capability, file, `${field}.capability`);
+    validated[docId] = {
+      computedModality: asEnum(expectation.computedModality, modalities, file, `${field}.computedModality`),
+      tileTypes: asArray(expectation.tileTypes, file, `${field}.tileTypes`)
+        .map((type, index) => asString(type, file, `${field}.tileTypes[${index}]`)),
+      capability: {
+        containsStudentText: asBoolean(capability.containsStudentText, file, `${field}.capability.containsStudentText`),
+        requiresVisualRepresentation: asBoolean(
+          capability.requiresVisualRepresentation, file, `${field}.capability.requiresVisualRepresentation`)
+      },
+      handlerTier: asEnum(expectation.handlerTier, handlerTiers, file, `${field}.handlerTier`),
+      distinctiveString: asString(expectation.distinctiveString, file, `${field}.distinctiveString`),
+      expectDistinctiveInDefaultSummary: asBoolean(
+        expectation.expectDistinctiveInDefaultSummary, file, `${field}.expectDistinctiveInDefaultSummary`),
+      defaultSummaryMustSucceed: asBoolean(
+        expectation.defaultSummaryMustSucceed, file, `${field}.defaultSummaryMustSucceed`),
+      minimalSummaryMustSucceed: asBoolean(
+        expectation.minimalSummaryMustSucceed, file, `${field}.minimalSummaryMustSucceed`),
+      notes: expectation.notes === undefined ? undefined : asString(expectation.notes, file, `${field}.notes`)
+    };
+  }
+  return { schemaVersion: kSchemaVersion, corpus: asString(record.corpus, file, "corpus"), documents: validated };
+}

--- a/scripts/ai-harness/test/cache.test.ts
+++ b/scripts/ai-harness/test/cache.test.ts
@@ -228,12 +228,36 @@ describe("a damaged cache entry is a miss, not a crash", () => {
     ["missing origin meta", { ...good, responseOriginMeta: undefined }],
     ["origin meta without a date", { ...good, responseOriginMeta: { modelReturned: "m" } }],
     ["a success without parsed", { ...good, parsed: undefined }],
+    // The run loop calls a response with no parsed content an "unparsed" error and never caches it,
+    // so an entry in that shape cannot be replayed as a success.
+    ["a success whose parsed is null", { ...good, parsed: null }],
     ["a refusal without refusal text", { ...good, status: "refusal", refusal: undefined }],
+    ["a refusal whose text is empty", { ...good, status: "refusal", refusal: "" }],
     ["missing raw", { ...good, raw: undefined }],
     ["a bare array", []],
     ["null", null]
   ])("treats %s as a miss", (_label, value) => {
     expect(validateCacheEntry(value, "abc")).toBeUndefined();
+  });
+
+  it("retries a null-parsed entry rather than replaying it as a success", async () => {
+    const dataRoot = makeTestDataRoot("cache-null-parsed");
+    const tasks = [makeTask("text", "text-default", "a summary")];
+    const cache = new ResponseCache(path.join(dataRoot, "cache"));
+
+    // Hand-written or left by an older build: a status the run loop would never produce.
+    const file = cache.pathFor(tasks[0].requestKey);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, JSON.stringify({
+      schemaVersion: 1, key: tasks[0].requestKey, status: "success", parsed: null, raw: {},
+      usage: { promptTokens: 10, completionTokens: 5 }, responseOriginMeta: originalOrigin
+    }));
+
+    let calls = 0;
+    const result = await run(dataRoot, tasks, async () => { calls += 1; return completion(); }, { cache });
+    expect(calls).toBe(1);
+    expect(result.rows[0].status).toBe("success");
+    expect((result.rows[0] as SuccessResultRow).response.parsed).not.toBeNull();
   });
 
   it("does not hand a truncated entry to the run loop", async () => {

--- a/scripts/ai-harness/test/cache.test.ts
+++ b/scripts/ai-harness/test/cache.test.ts
@@ -1,0 +1,256 @@
+import fs from "node:fs";
+import path from "node:path";
+import { CacheEntry, ResponseCache, cacheOptionsFor, validateCacheEntry } from "../src/cache.js";
+import { CostLedger } from "../src/cost.js";
+import { CompletionResult, RunTask, runTasks } from "../src/execute.js";
+import { SuccessResultRow, RefusalResultRow, ResultRow } from "../src/schemas.js";
+import { makeTask, makeTestDataRoot, readLines, testPricing, testRunMeta } from "./helpers.js";
+
+const experiment = { schemaVersion: 1, name: "cache-tests", runs: [] as any[] };
+
+const originalOrigin = {
+  date: "2026-01-01T00:00:00.000Z",
+  modelReturned: "gpt-4o-mini-2024-07-18",
+  systemFingerprint: "fp_original"
+};
+
+function completion(overrides: Partial<CompletionResult> = {}): CompletionResult {
+  return {
+    parsed: { category: "form", keyIndicators: ["a sketch"], discussion: "Looks like form." },
+    refusal: null,
+    raw: { id: "chatcmpl-1" },
+    usage: { promptTokens: 120, completionTokens: 40 },
+    originMeta: originalOrigin,
+    ...overrides
+  };
+}
+
+async function run(dataRoot: string, tasks: RunTask[], createCompletion: () => Promise<CompletionResult>,
+  options: { cache?: ResponseCache; runMeta?: typeof testRunMeta; output?: string } = {}) {
+  const outputFile = options.output ?? path.join(dataRoot, "results.jsonl");
+  const summary = await runTasks({
+    corpus: "synthetic-corpus",
+    experiment: experiment as any,
+    experimentSha256: "hash",
+    tasks,
+    outputFile,
+    ledger: new CostLedger(10),
+    cache: options.cache ?? new ResponseCache(path.join(dataRoot, "cache")),
+    pricing: testPricing,
+    runMeta: options.runMeta ?? testRunMeta,
+    createCompletion
+  });
+  return { summary, rows: readLines(outputFile) as ResultRow[], outputFile };
+}
+
+describe("cache flags", () => {
+  it("maps --no-cache and --refresh-cache onto read/write", () => {
+    expect(cacheOptionsFor(false, false)).toEqual({ read: true, write: true });
+    expect(cacheOptionsFor(true, false)).toEqual({ read: false, write: false });
+    expect(cacheOptionsFor(false, true)).toEqual({ read: false, write: true });
+    expect(() => cacheOptionsFor(true, true)).toThrow(/cannot be combined/);
+  });
+
+  it("shards entries by the first two characters of the key", () => {
+    const cache = new ResponseCache("/tmp/never-written");
+    expect(cache.pathFor("abcdef")).toBe(path.join("/tmp/never-written", "ab", "abcdef.json"));
+  });
+});
+
+describe("a cache hit", () => {
+  it("reports its source, spends nothing, and keeps the original call's provenance", async () => {
+    const dataRoot = makeTestDataRoot("cache-hit");
+    const tasks = [makeTask("text", "text-default", "a summary")];
+
+    const first = await run(dataRoot, tasks, async () => completion());
+    expect(first.summary.apiCalls).toBe(1);
+    const firstRow = first.rows[0] as SuccessResultRow;
+    expect(firstRow.usage.source).toBe("api");
+    expect(firstRow.cost.incurredThisRunUsd).toBeGreaterThan(0);
+
+    // A second run against a fresh output file, with a different runMeta, must hit the cache.
+    const laterRunMeta = { ...testRunMeta, date: "2026-09-01T00:00:00.000Z", gitCommit: "beefbeef", gitDirty: true };
+    const second = await run(dataRoot, tasks, async () => {
+      throw new Error("the API must not be called on a cache hit");
+    }, { runMeta: laterRunMeta, output: path.join(dataRoot, "second.jsonl") });
+
+    expect(second.summary.cacheHits).toBe(1);
+    expect(second.summary.apiCalls).toBe(0);
+    const row = second.rows[0] as SuccessResultRow;
+    expect(row.usage.source).toBe("cache");
+    expect(row.usage.promptTokens).toBe(120);
+    expect(row.cost.incurredThisRunUsd).toBe(0);
+    expect(row.cost.modeledUsd).toBeGreaterThan(0);
+    // runMeta describes *this* run...
+    expect(row.runMeta).toEqual(laterRunMeta);
+    // ...while responseOriginMeta still describes the call that produced the response.
+    expect(row.responseOriginMeta).toEqual(originalOrigin);
+  });
+
+  it("does not read the cache under --no-cache, and writes nothing either", async () => {
+    const dataRoot = makeTestDataRoot("cache-disabled");
+    const tasks = [makeTask("text", "text-default", "a summary")];
+    const cacheDir = path.join(dataRoot, "cache");
+    let calls = 0;
+    const cache = new ResponseCache(cacheDir, { read: false, write: false });
+
+    await run(dataRoot, tasks, async () => { calls += 1; return completion(); }, { cache });
+    await run(dataRoot, tasks, async () => { calls += 1; return completion(); },
+      { cache, output: path.join(dataRoot, "second.jsonl") });
+
+    expect(calls).toBe(2);
+    expect(fs.existsSync(cacheDir)).toBe(false);
+  });
+
+  it("bypasses reads but refreshes writes under --refresh-cache", async () => {
+    const dataRoot = makeTestDataRoot("cache-refresh");
+    const tasks = [makeTask("text", "text-default", "a summary")];
+    const cacheDir = path.join(dataRoot, "cache");
+
+    await run(dataRoot, tasks, async () => completion());
+    const refreshed = { ...originalOrigin, systemFingerprint: "fp_refreshed" };
+    const second = await run(dataRoot, tasks, async () => completion({ originMeta: refreshed }), {
+      cache: new ResponseCache(cacheDir, { read: false, write: true }),
+      output: path.join(dataRoot, "second.jsonl")
+    });
+
+    expect(second.summary.apiCalls).toBe(1);
+    const stored = JSON.parse(
+      fs.readFileSync(new ResponseCache(cacheDir).pathFor(tasks[0].requestKey), "utf8")) as CacheEntry;
+    expect(stored.responseOriginMeta.systemFingerprint).toBe("fp_refreshed");
+  });
+});
+
+describe("refusals", () => {
+  it("are cached, so a rerun does not spend money on the same refusal again", async () => {
+    const dataRoot = makeTestDataRoot("cache-refusal");
+    const tasks = [makeTask("text", "text-default", "a summary")];
+    const refusal = completion({ parsed: null, refusal: "I can't help with that." });
+
+    const first = await run(dataRoot, tasks, async () => refusal);
+    expect((first.rows[0] as RefusalResultRow).status).toBe("refusal");
+    expect((first.rows[0] as RefusalResultRow).refusal).toBe("I can't help with that.");
+    expect((first.rows[0] as RefusalResultRow).cost.incurredThisRunUsd).toBeGreaterThan(0);
+
+    const second = await run(dataRoot, tasks, async () => {
+      throw new Error("a cached refusal must not be re-requested");
+    }, { output: path.join(dataRoot, "second.jsonl") });
+
+    const row = second.rows[0] as RefusalResultRow;
+    expect(row.status).toBe("refusal");
+    expect(row.usage.source).toBe("cache");
+    expect(row.cost.incurredThisRunUsd).toBe(0);
+    expect(second.summary.apiCalls).toBe(0);
+  });
+});
+
+describe("errors", () => {
+  it("are never cached, and the next run tries again", async () => {
+    const dataRoot = makeTestDataRoot("cache-error");
+    const tasks = [makeTask("text", "text-default", "a summary")];
+
+    const first = await runTasks({
+      corpus: "synthetic-corpus",
+      experiment: experiment as any,
+      experimentSha256: "hash",
+      tasks,
+      outputFile: path.join(dataRoot, "results.jsonl"),
+      ledger: new CostLedger(10),
+      cache: new ResponseCache(path.join(dataRoot, "cache")),
+      pricing: testPricing,
+      runMeta: testRunMeta,
+      createCompletion: async () => { throw new Error("connection reset"); },
+      sleep: async () => undefined
+    });
+    expect(first.written).toBe(1);
+    const rows = readLines(path.join(dataRoot, "results.jsonl")) as ResultRow[];
+    expect(rows[0].status).toBe("error");
+    expect(fs.existsSync(new ResponseCache(path.join(dataRoot, "cache")).pathFor(tasks[0].requestKey))).toBe(false);
+
+    let calls = 0;
+    const second = await run(dataRoot, tasks, async () => { calls += 1; return completion(); });
+    expect(calls).toBe(1);
+    expect(second.summary.resumed).toBe(0);
+  });
+
+  it("treats a response with neither parsed nor refusal as an error, uncached and retryable", async () => {
+    const dataRoot = makeTestDataRoot("cache-unparsed");
+    const tasks = [makeTask("text", "text-default", "a summary")];
+
+    const first = await run(dataRoot, tasks,
+      async () => completion({ parsed: null, refusal: null, finish_reason: "length" }));
+
+    const row = first.rows[0];
+    expect(row.status).toBe("error");
+    if (row.status === "error") {
+      expect(row.error.type).toBe("unparsed");
+      expect(row.error.message).toContain("length");
+      expect(row.error.attempts).toBe(1);
+    }
+    // The call still happened, so it still cost money even though the response was unusable.
+    expect(first.summary.apiCalls).toBe(1);
+    expect(first.summary.incurredUsd).toBeGreaterThan(0);
+
+    // Nothing is cached, so a rerun really re-requests it rather than replaying the failure.
+    expect(fs.existsSync(new ResponseCache(path.join(dataRoot, "cache")).pathFor(tasks[0].requestKey)))
+      .toBe(false);
+
+    let calls = 0;
+    const second = await run(dataRoot, tasks, async () => { calls += 1; return completion(); });
+    expect(calls).toBe(1);
+    expect(second.summary.resumed).toBe(0);
+    expect((readLines(path.join(dataRoot, "results.jsonl")) as ResultRow[]).map((r) => r.status))
+      .toEqual(["error", "success"]);
+  });
+});
+
+describe("a damaged cache entry is a miss, not a crash", () => {
+  const good: CacheEntry = {
+    schemaVersion: 1,
+    key: "abc",
+    status: "success",
+    parsed: { category: "form" },
+    raw: { id: "chatcmpl-1" },
+    usage: { promptTokens: 10, completionTokens: 5 },
+    responseOriginMeta: originalOrigin
+  };
+
+  it("accepts a complete entry", () => {
+    expect(validateCacheEntry(good, "abc")).toEqual(good);
+  });
+
+  it.each([
+    ["a mismatched key", { ...good, key: "other" }],
+    ["a wrong schema version", { ...good, schemaVersion: 2 }],
+    ["an unknown status", { ...good, status: "degraded" }],
+    ["missing usage", { ...good, usage: undefined }],
+    ["non-numeric usage", { ...good, usage: { promptTokens: "10", completionTokens: 5 } }],
+    ["missing origin meta", { ...good, responseOriginMeta: undefined }],
+    ["origin meta without a date", { ...good, responseOriginMeta: { modelReturned: "m" } }],
+    ["a success without parsed", { ...good, parsed: undefined }],
+    ["a refusal without refusal text", { ...good, status: "refusal", refusal: undefined }],
+    ["missing raw", { ...good, raw: undefined }],
+    ["a bare array", []],
+    ["null", null]
+  ])("treats %s as a miss", (_label, value) => {
+    expect(validateCacheEntry(value, "abc")).toBeUndefined();
+  });
+
+  it("does not hand a truncated entry to the run loop", async () => {
+    const dataRoot = makeTestDataRoot("cache-truncated");
+    const tasks = [makeTask("text", "text-default", "a summary")];
+    const cache = new ResponseCache(path.join(dataRoot, "cache"));
+
+    // Truncated at a record boundary: still valid JSON, so JSON.parse alone would let it through and
+    // rowFromResponse would then crash on the missing usage.
+    const file = cache.pathFor(tasks[0].requestKey);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, JSON.stringify({ schemaVersion: 1, key: tasks[0].requestKey, status: "success" }));
+
+    expect(cache.get(tasks[0].requestKey)).toBeUndefined();
+    let calls = 0;
+    const result = await run(dataRoot, tasks, async () => { calls += 1; return completion(); }, { cache });
+    expect(calls).toBe(1);
+    expect(result.rows[0].status).toBe("success");
+  });
+});

--- a/scripts/ai-harness/test/capability.test.ts
+++ b/scripts/ai-harness/test/capability.test.ts
@@ -158,6 +158,42 @@ describe("Question traversal", () => {
     expect(result.tiles.find((tile) => tile.tileId === "inner-prompt")).toMatchObject({ hasStudentText: false });
   });
 
+  it("keeps a Question nested inside a prompt authored all the way down", () => {
+    // The whole subtree is curriculum content. Recomputing role from row position let the nested
+    // question's own later rows count as student work and flipped the document's modality.
+    const content = doc([[{ tileId: "outer" }]], {
+      outer: questionTile([["inner"], ["response"]], "outer"),
+      inner: questionTile([["inner-prompt"], ["inner-image"]], "inner"),
+      "inner-prompt": textTile("Look at this diagram:"),
+      "inner-image": { content: { type: "Image" } },
+      response: textTile("   ")
+    });
+
+    const result = classifyDocument(content);
+    expect(result.tiles.find((tile) => tile.tileId === "inner-image")).toMatchObject({
+      role: "prompt", hasStudentText: false, requiresVisualRepresentation: false
+    });
+    // The student wrote nothing and the image is the author's, so there is no student work here.
+    expect(result.computedModality).toBe("empty");
+  });
+
+  it("still classifies a Question nested in a response by its own rows", () => {
+    const content = doc([[{ tileId: "outer" }]], {
+      outer: questionTile([["outer-prompt"], ["inner"]], "outer"),
+      "outer-prompt": textTile("Outer prompt"),
+      inner: questionTile([["inner-prompt"], ["inner-image"]], "inner"),
+      "inner-prompt": textTile("Inner prompt"),
+      "inner-image": { content: { type: "Image" } }
+    });
+
+    const result = classifyDocument(content);
+    expect(result.tiles.find((tile) => tile.tileId === "inner-prompt")).toMatchObject({ role: "prompt" });
+    expect(result.tiles.find((tile) => tile.tileId === "inner-image")).toMatchObject({
+      role: "student", requiresVisualRepresentation: true
+    });
+    expect(result.computedModality).toBe("visual-only");
+  });
+
   it("stops recursing at the depth cap instead of looping forever", () => {
     const tileMap: Record<string, any> = {};
     const depth = kMaxQuestionDepth + 4;

--- a/scripts/ai-harness/test/capability.test.ts
+++ b/scripts/ai-harness/test/capability.test.ts
@@ -1,0 +1,178 @@
+import { classifyDocument, drawingTileHasText, kMaxQuestionDepth, textTileHasContent } from "../src/capability.js";
+
+function doc(rows: { tileId: string }[][], tileMap: Record<string, any>) {
+  const rowOrder: string[] = [];
+  const rowMap: Record<string, any> = {};
+  rows.forEach((tiles, index) => {
+    const rowId = `row-${index + 1}`;
+    rowOrder.push(rowId);
+    rowMap[rowId] = { id: rowId, isSectionHeader: false, tiles };
+  });
+  return { rowOrder, rowMap, tileMap };
+}
+
+function textTile(text: string, format = "markdown") {
+  return { content: { type: "Text", format, text } };
+}
+
+function questionTile(rows: string[][], questionId = "q1") {
+  const rowOrder: string[] = [];
+  const rowMap: Record<string, any> = {};
+  rows.forEach((tileIds, index) => {
+    const rowId = `q-row-${index + 1}`;
+    rowOrder.push(rowId);
+    rowMap[rowId] = { id: rowId, tiles: tileIds.map((tileId) => ({ tileId })) };
+  });
+  return { content: { type: "Question", questionId, rowOrder, rowMap } };
+}
+
+describe("instance-level checks", () => {
+  it("counts a Text tile only when it has content after trimming", () => {
+    expect(textTileHasContent({ type: "Text", format: "markdown", text: "hello" })).toBe(true);
+    expect(textTileHasContent({ type: "Text", format: "markdown", text: "   \n  " })).toBe(false);
+    expect(textTileHasContent({ type: "Text", format: "markdown" })).toBe(false);
+  });
+
+  it("reads slate content through the markdown converter before deciding", () => {
+    const empty = JSON.stringify({ object: "value", document: { children: [{ type: "paragraph", children: [{ text: "" }] }] } });
+    const filled = JSON.stringify({ object: "value", document: { children: [{ type: "paragraph", children: [{ text: "hi" }] }] } });
+    expect(textTileHasContent({ type: "Text", format: "slate", text: empty })).toBe(false);
+    expect(textTileHasContent({ type: "Text", format: "slate", text: filled })).toBe(true);
+  });
+
+  it("counts a Drawing tile only when it has text objects that say something", () => {
+    expect(drawingTileHasText({ objects: [{ type: "rectangle" }] })).toBe(false);
+    expect(drawingTileHasText({ objects: [{ type: "text", text: "  " }] })).toBe(false);
+    expect(drawingTileHasText({ objects: [{ type: "text", text: "hinge" }] })).toBe(true);
+    expect(drawingTileHasText({})).toBe(false);
+  });
+
+  it("classifies an empty Text tile as an empty document, not a text-only one", () => {
+    const result = classifyDocument(doc([[{ tileId: "t1" }]], { t1: textTile("   ") }));
+    expect(result.computedModality).toBe("empty");
+  });
+});
+
+describe("document modality", () => {
+  it("is text-only when there is student text and nothing visual", () => {
+    expect(classifyDocument(doc([[{ tileId: "t1" }]], { t1: textTile("hi") })).computedModality).toBe("text-only");
+  });
+
+  it("is visual-only when there is something visual and no student text", () => {
+    const content = doc([[{ tileId: "t1" }]], { t1: { content: { type: "Image" } } });
+    expect(classifyDocument(content).computedModality).toBe("visual-only");
+  });
+
+  it("is mixed when both are present", () => {
+    const content = doc([[{ tileId: "t1" }, { tileId: "t2" }]],
+      { t1: textTile("hi"), t2: { content: { type: "Drawing", objects: [] } } });
+    expect(classifyDocument(content).computedModality).toBe("mixed");
+  });
+
+  it("is empty when there is neither", () => {
+    expect(classifyDocument({}).computedModality).toBe("empty");
+    const content = doc([[{ tileId: "t1" }]], { t1: { content: { type: "Placeholder" } } });
+    expect(classifyDocument(content).computedModality).toBe("empty");
+  });
+
+  it("skips section header rows", () => {
+    const content = {
+      rowOrder: ["header", "row-1"],
+      rowMap: { header: { isSectionHeader: true, sectionId: "s1" }, "row-1": { tiles: [{ tileId: "t1" }] } },
+      tileMap: { t1: textTile("hi") }
+    };
+    expect(classifyDocument(content).computedModality).toBe("text-only");
+  });
+});
+
+describe("Question traversal", () => {
+  it("does not count the authored prompt as student text", () => {
+    const content = doc([[{ tileId: "q" }]], {
+      q: questionTile([["prompt"]]),
+      prompt: textTile("What problem does your design solve?")
+    });
+    const result = classifyDocument(content);
+    expect(result.computedModality).toBe("empty");
+    expect(result.tiles.find((tile) => tile.tileId === "prompt")).toMatchObject({
+      role: "prompt", hasStudentText: false, requiresVisualRepresentation: false
+    });
+  });
+
+  it("classifies response tiles individually by their own types", () => {
+    const content = doc([[{ tileId: "q" }]], {
+      q: questionTile([["prompt"], ["response-text", "response-image"]]),
+      prompt: textTile("Describe your design."),
+      "response-text": textTile("It latches shut."),
+      "response-image": { content: { type: "Image" } }
+    });
+    const result = classifyDocument(content);
+    expect(result.computedModality).toBe("mixed");
+    expect(result.tiles.find((tile) => tile.tileId === "response-text")).toMatchObject({
+      role: "student", hasStudentText: true
+    });
+    expect(result.tiles.find((tile) => tile.tileId === "response-image")).toMatchObject({
+      role: "student", requiresVisualRepresentation: true
+    });
+  });
+
+  it("does not let an authored prompt make the document visual", () => {
+    const content = doc([[{ tileId: "q" }]], {
+      q: questionTile([["prompt-image"], ["response"]]),
+      "prompt-image": { content: { type: "Image" } },
+      response: textTile("Because it is stiff.")
+    });
+    expect(classifyDocument(content).computedModality).toBe("text-only");
+  });
+
+  it("skips a missing tile reference and records a warning", () => {
+    const content = doc([[{ tileId: "q" }]], {
+      q: questionTile([["prompt"], ["gone"]]),
+      prompt: textTile("Describe your design.")
+    });
+    const result = classifyDocument(content);
+    expect(result.warnings).toEqual([expect.stringContaining('tile reference "gone"')]);
+    expect(result.tiles.map((tile) => tile.tileId)).toEqual(["q", "prompt"]);
+  });
+
+  it("counts a tile referenced twice only once", () => {
+    const content = doc([[{ tileId: "q" }, { tileId: "shared" }]], {
+      q: questionTile([["prompt"], ["shared"]]),
+      prompt: textTile("Describe your design."),
+      shared: textTile("It latches shut.")
+    });
+    const result = classifyDocument(content);
+    expect(result.tiles.filter((tile) => tile.tileId === "shared")).toHaveLength(1);
+  });
+
+  it("recurses into nested Questions", () => {
+    const content = doc([[{ tileId: "outer" }]], {
+      outer: questionTile([["outer-prompt"], ["inner"]], "outer"),
+      "outer-prompt": textTile("Outer prompt"),
+      inner: questionTile([["inner-prompt"], ["inner-response"]], "inner"),
+      "inner-prompt": textTile("Inner prompt"),
+      "inner-response": textTile("Inner response")
+    });
+    const result = classifyDocument(content);
+    expect(result.computedModality).toBe("text-only");
+    expect(result.tiles.find((tile) => tile.tileId === "inner-response")).toMatchObject({ hasStudentText: true });
+    expect(result.tiles.find((tile) => tile.tileId === "inner-prompt")).toMatchObject({ hasStudentText: false });
+  });
+
+  it("stops recursing at the depth cap instead of looping forever", () => {
+    const tileMap: Record<string, any> = {};
+    const depth = kMaxQuestionDepth + 4;
+    for (let level = 0; level < depth; level += 1) {
+      tileMap[`q${level}`] = questionTile([[`p${level}`], [`q${level + 1}`]], `q${level}`);
+      tileMap[`p${level}`] = textTile(`prompt ${level}`);
+    }
+    tileMap[`q${depth}`] = textTile("the deepest response");
+    const result = classifyDocument(doc([[{ tileId: "q0" }]], tileMap));
+    expect(result.warnings.some((warning) => warning.includes("nesting depth cap"))).toBe(true);
+    expect(result.tiles.some((tile) => tile.tileId === `q${depth}`)).toBe(false);
+  });
+
+  it("survives a Question tile that references itself", () => {
+    const content = doc([[{ tileId: "q" }]], { q: questionTile([["prompt"], ["q"]]), prompt: textTile("Prompt") });
+    expect(() => classifyDocument(content)).not.toThrow();
+  });
+});

--- a/scripts/ai-harness/test/cli.test.ts
+++ b/scripts/ai-harness/test/cli.test.ts
@@ -1,0 +1,86 @@
+import path from "node:path";
+import { harnessRoot } from "../src/corpus.js";
+import { parseArgs, resolveDataPath } from "../harness.js";
+
+const known = {
+  import: ["from", "corpus", "source", "prune"],
+  run: ["corpus", "experiment", "max-cost", "output", "no-cache", "refresh-cache"]
+};
+
+describe("argv parsing", () => {
+  it("reads --name value pairs", () => {
+    expect(parseArgs(["import", "--from", "examples/synthetic-corpus", "--corpus", "demo1"], known))
+      .toEqual({ command: "import", flags: { from: "examples/synthetic-corpus", corpus: "demo1" } });
+  });
+
+  it("reads boolean flags", () => {
+    expect(parseArgs(["import", "--corpus", "demo1", "--prune"], known).flags)
+      .toEqual({ corpus: "demo1", prune: true });
+  });
+
+  it("rejects an unknown command", () => {
+    expect(() => parseArgs(["explode"], known)).toThrow(/Unknown command "explode"/);
+  });
+
+  it("rejects an unknown flag", () => {
+    expect(() => parseArgs(["import", "--corpuss", "demo1"], known))
+      .toThrow(/Unknown flag "--corpuss" for command "import"/);
+  });
+
+  it("rejects a flag that belongs to another command", () => {
+    expect(() => parseArgs(["import", "--max-cost", "1"], known)).toThrow(/Unknown flag "--max-cost"/);
+  });
+
+  it("rejects a value-taking flag with no value", () => {
+    expect(() => parseArgs(["import", "--corpus"], known)).toThrow(/Flag "--corpus" needs a value/);
+    expect(() => parseArgs(["import", "--corpus", "--prune"], known)).toThrow(/Flag "--corpus" needs a value/);
+  });
+
+  it("rejects a repeated flag", () => {
+    expect(() => parseArgs(["import", "--corpus", "a", "--corpus", "b"], known))
+      .toThrow(/was given more than once/);
+  });
+
+  it("rejects a bare positional argument", () => {
+    expect(() => parseArgs(["import", "demo1"], known)).toThrow(/Unexpected argument "demo1"/);
+  });
+
+  it("rejects no command at all", () => {
+    expect(() => parseArgs([], known)).toThrow(/Usage: harness\.ts/);
+  });
+});
+
+describe("results-path containment", () => {
+  const dataRoot = path.join(harnessRoot, "data");
+  const resolve = (value: string) => resolveDataPath(value, "--output", dataRoot);
+
+  it("resolves a relative path against the harness directory, as the README writes them", () => {
+    // Same base as --from and --experiment, so `data/results/x.jsonl` means what it looks like.
+    expect(resolve("data/results/text-baselines.jsonl"))
+      .toBe(path.join(dataRoot, "results", "text-baselines.jsonl"));
+  });
+
+  it("accepts an absolute path that is already inside the data root", () => {
+    const inside = path.join(dataRoot, "results", "run.jsonl");
+    expect(resolve(inside)).toBe(inside);
+  });
+
+  it.each([
+    ["../escape.jsonl"],
+    ["data/results/../../../escape.jsonl"],
+    ["/tmp/escape.jsonl"],
+    [".."],
+    ["results/not-under-data.jsonl"]
+  ])("refuses %s, which would write student work outside data/", (output) => {
+    expect(() => resolve(output)).toThrow(/must name a file inside the harness data directory/);
+  });
+
+  it("refuses the data root itself", () => {
+    expect(() => resolve(dataRoot)).toThrow(/must name a file inside/);
+  });
+
+  it("names the flag it is complaining about and suggests a valid path", () => {
+    expect(() => resolveDataPath("../x.jsonl", "--results", dataRoot))
+      .toThrow(/--results must name a file inside .*Try a path like "data\/results\/my-run\.jsonl"/s);
+  });
+});

--- a/scripts/ai-harness/test/corpus.test.ts
+++ b/scripts/ai-harness/test/corpus.test.ts
@@ -42,7 +42,7 @@ describe("corpus names cannot escape the artifact root", () => {
     ["../results"],
     ["nested/name"],
     ["/absolute"],
-    ["Capitalised"],
+    ["Capitalized"],
     ["has space"],
     [""]
   ])("refuses %s", (corpus) => {
@@ -93,7 +93,7 @@ describe("import", () => {
       .toThrow(/document id "Not Valid" must match/);
   });
 
-  it("rejects a traversal attempt at the id pattern, the first line of defence", () => {
+  it("rejects a traversal attempt at the id pattern, the first line of defense", () => {
     const dataRoot = makeTestDataRoot("import-escape");
     const from = sourceDir(dataRoot, { "a-text.json": textDoc });
     fs.renameSync(path.join(from, "a-text.json"), path.join(from, "..-escape.json"));

--- a/scripts/ai-harness/test/corpus.test.ts
+++ b/scripts/ai-harness/test/corpus.test.ts
@@ -1,0 +1,198 @@
+import fs from "node:fs";
+import path from "node:path";
+import {
+  corpusPaths, importCorpus, readCorpusDocument, readManifest, representationIsFresh, representationPath,
+  resolveCorpusFile, writeJsonFile
+} from "../src/corpus.js";
+import { makeTestDataRoot } from "./helpers.js";
+
+const now = () => new Date("2026-08-11T00:00:00.000Z");
+
+function sourceDir(root: string, documents: Record<string, unknown>): string {
+  const directory = path.join(root, "source");
+  fs.mkdirSync(directory, { recursive: true });
+  for (const [name, content] of Object.entries(documents)) {
+    fs.writeFileSync(path.join(directory, name), JSON.stringify(content, null, 2));
+  }
+  return directory;
+}
+
+const textDoc = {
+  rowOrder: ["row-1"],
+  rowMap: { "row-1": { tiles: [{ tileId: "t1" }] } },
+  tileMap: { t1: { id: "t1", content: { type: "Text", format: "markdown", text: "Our latch." } } }
+};
+const imageDoc = {
+  rowOrder: ["row-1"],
+  rowMap: { "row-1": { tiles: [{ tileId: "t1" }] } },
+  tileMap: { t1: { id: "t1", content: { type: "Image" } } }
+};
+
+describe("import", () => {
+  it("writes a manifest with content hashes and computed modalities", () => {
+    const dataRoot = makeTestDataRoot("import-basic");
+    const from = sourceDir(dataRoot, { "a-text.json": textDoc, "b-image.json": imageDoc });
+    const result = importCorpus({ from, corpus: "demo1", source: "synthetic", prune: false, dataRoot, now });
+
+    expect(result.imported).toEqual(["a-text", "b-image"]);
+    expect(result.manifest.documents.map((entry) => entry.computedModality)).toEqual(["text-only", "visual-only"]);
+    expect(result.manifest.documents[0].contentSha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(result.manifest.documents[0].retrievedAt).toBeNull();
+
+    const paths = corpusPaths(dataRoot, "demo1");
+    expect(fs.existsSync(path.join(paths.documents, "a-text.json"))).toBe(true);
+    expect(readManifest(paths).documents).toHaveLength(2);
+  });
+
+  it("stamps a retrieval time on documents that came from somewhere", () => {
+    const dataRoot = makeTestDataRoot("import-retrieved");
+    const from = sourceDir(dataRoot, { "a-text.json": textDoc });
+    const result = importCorpus({ from, corpus: "demo1", source: "demo", prune: false, dataRoot, now });
+    expect(result.manifest.documents[0].retrievedAt).toBe("2026-08-11T00:00:00.000Z");
+  });
+
+  it("refuses to set the production source", () => {
+    const dataRoot = makeTestDataRoot("import-production");
+    const from = sourceDir(dataRoot, { "a-text.json": textDoc });
+    expect(() => importCorpus({ from, corpus: "demo1", source: "production", prune: false, dataRoot, now }))
+      .toThrow(/only produced by the \(gated\) pull command/);
+  });
+
+  it("rejects a document id that is not kebab-case", () => {
+    const dataRoot = makeTestDataRoot("import-bad-id");
+    const from = sourceDir(dataRoot, { "Not Valid.json": textDoc });
+    expect(() => importCorpus({ from, corpus: "demo1", source: "synthetic", prune: false, dataRoot, now }))
+      .toThrow(/document id "Not Valid" must match/);
+  });
+
+  it("rejects a traversal attempt at the id pattern, the first line of defence", () => {
+    const dataRoot = makeTestDataRoot("import-escape");
+    const from = sourceDir(dataRoot, { "a-text.json": textDoc });
+    fs.renameSync(path.join(from, "a-text.json"), path.join(from, "..-escape.json"));
+    expect(() => importCorpus({ from, corpus: "demo1", source: "synthetic", prune: false, dataRoot, now }))
+      .toThrow(/must match/);
+  });
+
+  it("refreshes computedModality but never touches modalityOverride or labels", () => {
+    const dataRoot = makeTestDataRoot("import-override");
+    const from = sourceDir(dataRoot, { "a-text.json": textDoc });
+    importCorpus({ from, corpus: "demo1", source: "synthetic", prune: false, dataRoot, now });
+
+    const paths = corpusPaths(dataRoot, "demo1");
+    const manifest = readManifest(paths);
+    manifest.documents[0].modalityOverride = "mixed";
+    manifest.documents[0].labels = { category: "form" };
+    manifest.documents[0].unit = "mods";
+    writeJsonFile(paths.manifest, manifest);
+
+    // The document changes to a visual one; the human override must survive untouched.
+    fs.writeFileSync(path.join(from, "a-text.json"), JSON.stringify(imageDoc));
+    const result = importCorpus({ from, corpus: "demo1", source: "synthetic", prune: false, dataRoot, now });
+    expect(result.manifest.documents[0].computedModality).toBe("visual-only");
+    expect(result.manifest.documents[0].modalityOverride).toBe("mixed");
+    expect(result.manifest.documents[0].labels).toEqual({ category: "form" });
+    expect(result.manifest.documents[0].unit).toBe("mods");
+  });
+
+  it("keeps an entry whose source file has disappeared, with a warning", () => {
+    const dataRoot = makeTestDataRoot("import-missing");
+    const from = sourceDir(dataRoot, { "a-text.json": textDoc, "b-image.json": imageDoc });
+    importCorpus({ from, corpus: "demo1", source: "synthetic", prune: false, dataRoot, now });
+
+    fs.rmSync(path.join(from, "b-image.json"));
+    const result = importCorpus({ from, corpus: "demo1", source: "synthetic", prune: false, dataRoot, now });
+    expect(result.missing).toEqual(["b-image"]);
+    expect(result.manifest.documents).toHaveLength(2);
+    expect(result.warnings.join("\n")).toContain("source file has disappeared");
+  });
+
+  it("removes it under --prune, along with its copied content and representations", () => {
+    const dataRoot = makeTestDataRoot("import-prune");
+    const from = sourceDir(dataRoot, { "a-text.json": textDoc, "b-image.json": imageDoc });
+    importCorpus({ from, corpus: "demo1", source: "synthetic", prune: false, dataRoot, now });
+
+    const paths = corpusPaths(dataRoot, "demo1");
+    // Stand in for `represent` having run: envelopes for both variants.
+    for (const variant of ["default", "minimal"]) {
+      for (const id of ["a-text", "b-image"]) {
+        writeJsonFile(representationPath(paths, variant, id), { schemaVersion: 1, docId: id });
+      }
+    }
+
+    fs.rmSync(path.join(from, "b-image.json"));
+    const result = importCorpus({ from, corpus: "demo1", source: "synthetic", prune: true, dataRoot, now });
+    expect(result.pruned).toEqual(["b-image"]);
+    expect(result.manifest.documents.map((entry) => entry.id)).toEqual(["a-text"]);
+
+    // No unreachable copy of the document may linger once it has left the manifest.
+    expect(fs.existsSync(path.join(paths.documents, "b-image.json"))).toBe(false);
+    for (const variant of ["default", "minimal"]) {
+      expect(fs.existsSync(representationPath(paths, variant, "b-image"))).toBe(false);
+      expect(fs.existsSync(representationPath(paths, variant, "a-text"))).toBe(true);
+    }
+    expect(fs.existsSync(path.join(paths.documents, "a-text.json"))).toBe(true);
+  });
+
+  it("keeps the corpus createdAt across re-imports", () => {
+    const dataRoot = makeTestDataRoot("import-created-at");
+    const from = sourceDir(dataRoot, { "a-text.json": textDoc });
+    const first = importCorpus({ from, corpus: "demo1", source: "synthetic", prune: false, dataRoot, now });
+    const second = importCorpus({
+      from, corpus: "demo1", source: "synthetic", prune: false, dataRoot, now: () => new Date("2027-01-01")
+    });
+    expect(second.manifest.createdAt).toBe(first.manifest.createdAt);
+  });
+});
+
+describe("reading a document the manifest points at", () => {
+  const dataRoot = makeTestDataRoot("corpus-file-escape");
+  const from = sourceDir(dataRoot, { "a-text.json": textDoc });
+  importCorpus({ from, corpus: "demo1", source: "synthetic", prune: false, dataRoot, now });
+  const paths = corpusPaths(dataRoot, "demo1");
+  const entry = readManifest(paths).documents[0];
+
+  it("reads a document that sits inside the corpus", () => {
+    expect(readCorpusDocument(paths, entry)).toEqual(textDoc);
+  });
+
+  it.each([
+    ["../../escape.json"],
+    ["documents/../../../escape.json"],
+    ["/etc/passwd"]
+  ])("refuses a hand-edited file field of %s", (file) => {
+    expect(() => readCorpusDocument(paths, { ...entry, file }))
+      .toThrow(/resolves outside the corpus directory/);
+  });
+
+  it("refuses the corpus root itself", () => {
+    expect(() => resolveCorpusFile(paths, { ...entry, file: "." }))
+      .toThrow(/resolves outside the corpus directory/);
+  });
+});
+
+describe("representation staleness", () => {
+  const envelope = {
+    schemaVersion: 1,
+    docId: "a-text",
+    variantId: "default",
+    variantVersion: 1,
+    sourceContentSha256: "abc",
+    generatedAt: "2026-08-11T00:00:00.000Z",
+    markdown: "# CLUE Document Summary"
+  };
+
+  const identity = { docId: "a-text", variantId: "default", contentSha256: "abc", variantVersion: 1 };
+
+  it("is decided by the envelope, not by the file existing", () => {
+    expect(representationIsFresh(envelope, identity)).toBe(true);
+    expect(representationIsFresh(envelope, { ...identity, contentSha256: "different" })).toBe(false);
+    expect(representationIsFresh(envelope, { ...identity, variantVersion: 2 })).toBe(false);
+  });
+
+  it("checks identity too, so an envelope on the wrong path is not reused", () => {
+    // A `default` envelope copied onto a `minimal` path would otherwise pass and make the two
+    // variants identical.
+    expect(representationIsFresh(envelope, { ...identity, variantId: "minimal" })).toBe(false);
+    expect(representationIsFresh(envelope, { ...identity, docId: "b-image" })).toBe(false);
+  });
+});

--- a/scripts/ai-harness/test/corpus.test.ts
+++ b/scripts/ai-harness/test/corpus.test.ts
@@ -28,6 +28,34 @@ const imageDoc = {
   tileMap: { t1: { id: "t1", content: { type: "Image" } } }
 };
 
+describe("corpus names cannot escape the artifact root", () => {
+  const dataRoot = "/repo/scripts/ai-harness/data";
+
+  it("builds paths under data/corpus for a valid name", () => {
+    expect(corpusPaths(dataRoot, "synthetic-corpus").root)
+      .toBe(path.join(dataRoot, "corpus", "synthetic-corpus"));
+  });
+
+  it.each([
+    ["../../escaped"],
+    [".."],
+    ["../results"],
+    ["nested/name"],
+    ["/absolute"],
+    ["Capitalised"],
+    ["has space"],
+    [""]
+  ])("refuses %s", (corpus) => {
+    expect(() => corpusPaths(dataRoot, corpus)).toThrow(/--corpus must match/);
+  });
+
+  it("is enforced for every command, not only import", () => {
+    expect(() => importCorpus({
+      from: ".", corpus: "../../escaped", source: "synthetic", prune: false, dataRoot, now
+    })).toThrow(/--corpus must match/);
+  });
+});
+
 describe("import", () => {
   it("writes a manifest with content hashes and computed modalities", () => {
     const dataRoot = makeTestDataRoot("import-basic");

--- a/scripts/ai-harness/test/cost.test.ts
+++ b/scripts/ai-harness/test/cost.test.ts
@@ -1,0 +1,217 @@
+import {
+  CostCeilingExceeded, CostLedger, estimateInputTokens, estimateTokensForText, kCharsPerToken, kRetries,
+  loadPricingConfig, pricingFor, priceTokens, worstCaseUsd
+} from "../src/cost.js";
+import { canonicalJson } from "../src/schemas.js";
+import { ResponseCache } from "../src/cache.js";
+import { CompletionResult, RunTask, runTasks } from "../src/execute.js";
+import { buildRequest, requestKeyFor } from "../src/messages.js";
+import { defaultAiPrompt } from "../../../shared/ai-analysis-messages.js";
+import { makeRequest, makeTask, makeTestDataRoot, testPricing, testRunMeta } from "./helpers.js";
+import path from "node:path";
+
+const experiment = { schemaVersion: 1, name: "ceiling", runs: [] as any[] };
+
+describe("pricing config", () => {
+  it("loads and prices gpt-4o-mini", () => {
+    const config = loadPricingConfig();
+    const pricing = pricingFor(config, "gpt-4o-mini");
+    expect(pricing.inputPerMTokUsd).toBeGreaterThan(0);
+    expect(pricing.outputPerMTokUsd).toBeGreaterThan(0);
+    expect(pricing.maxOutputTokens).toBeGreaterThan(0);
+    expect(config.effectiveDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("refuses a model it has no price for", () => {
+    expect(() => pricingFor(loadPricingConfig(), "gpt-5-imaginary")).toThrow(/no pricing for model/);
+  });
+});
+
+describe("every request carries a completion cap", () => {
+  it("puts the pricing config's maxOutputTokens into the request", () => {
+    const pricing = pricingFor(loadPricingConfig(), "gpt-4o-mini");
+    const request = buildRequest({
+      model: "gpt-4o-mini",
+      aiPrompt: defaultAiPrompt,
+      message: "text-only",
+      markdown: "# CLUE Document Summary",
+      generationSettings: { max_completion_tokens: pricing.maxOutputTokens }
+    });
+    expect(request.generationSettings.max_completion_tokens).toBe(pricing.maxOutputTokens);
+  });
+
+  it("makes the cap part of the request key, so changing it re-runs", () => {
+    expect(requestKeyFor(makeRequest("hello", 1024))).not.toBe(requestKeyFor(makeRequest("hello", 512)));
+  });
+});
+
+describe("the reservation formula", () => {
+  it("prices the input estimate plus a completion that runs all the way to the cap, times the retries", () => {
+    const request = makeRequest("a".repeat(300));
+    const estimate = estimateInputTokens(request);
+    const expected = priceTokens(estimate, 1024, testPricing) * (1 + kRetries);
+    expect(worstCaseUsd(request, testPricing)).toBeCloseTo(expected, 12);
+  });
+
+  it("never estimates fewer tokens than the message text divided by the chars-per-token divisor", () => {
+    const request = makeRequest("a".repeat(3000));
+    const messageChars = canonicalJson(request.messages).length;
+    const schemaChars = canonicalJson(request.responseFormat).length;
+    expect(estimateInputTokens(request))
+      .toBeGreaterThanOrEqual(Math.ceil((messageChars + schemaChars) / kCharsPerToken));
+  });
+
+  it("counts non-ASCII characters as a whole token each, so CJK cannot undercut the reservation", () => {
+    // 300 ASCII characters cost about 100 tokens; 300 CJK characters cost about 300.
+    const ascii = estimateInputTokens(makeRequest("a".repeat(300)));
+    const cjk = estimateInputTokens(makeRequest("学".repeat(300)));
+    expect(cjk).toBeGreaterThan(ascii + 190);
+    expect(estimateTokensForText("学".repeat(50))).toBe(50);
+    expect(estimateTokensForText("a".repeat(300))).toBe(100);
+    expect(estimateTokensForText("学a学a")).toBe(2 + Math.ceil(2 / kCharsPerToken));
+  });
+
+  it("prices emoji conservatively too", () => {
+    expect(estimateTokensForText("🙂🙂🙂")).toBe(3);
+  });
+});
+
+describe("the ledger", () => {
+  it("refuses a reservation that would cross the ceiling", () => {
+    const ledger = new CostLedger(1);
+    ledger.reserve(0.6);
+    expect(() => ledger.reserve(0.6)).toThrow(CostCeilingExceeded);
+    expect(ledger.committedUsd).toBeCloseTo(0.6, 12);
+  });
+
+  it("replaces a reservation with the actual cost when the call completes", () => {
+    const ledger = new CostLedger(1);
+    const reservation = ledger.reserve(0.5);
+    ledger.settle(reservation, 0.01);
+    expect(ledger.incurredUsd).toBeCloseTo(0.01, 12);
+    expect(ledger.remainingUsd).toBeCloseTo(0.99, 12);
+  });
+
+  it("releases a reservation for a call that never happened", () => {
+    const ledger = new CostLedger(1);
+    ledger.release(ledger.reserve(0.9));
+    expect(ledger.committedUsd).toBe(0);
+  });
+
+  it("rejects a non-positive ceiling", () => {
+    expect(() => new CostLedger(0)).toThrow(/--max-cost must be a positive number/);
+  });
+});
+
+describe("an actual-cost overshoot is detected and reported", () => {
+  it("flags the ledger when settled cost passes the ceiling", () => {
+    const ledger = new CostLedger(1);
+    expect(ledger.hasExceededCeiling).toBe(false);
+    const reservation = ledger.reserve(0.9);
+    // Reservations are conservative, but the input estimate is a character heuristic rather than a
+    // tokenizer, so an actual cost can land above what was reserved.
+    ledger.settle(reservation, 1.5);
+    expect(ledger.hasExceededCeiling).toBe(true);
+    expect(ledger.overshootUsd).toBeCloseTo(0.5, 10);
+  });
+
+  it("stays clear when actuals come in under the reservation", () => {
+    const ledger = new CostLedger(1);
+    ledger.settle(ledger.reserve(0.9), 0.1);
+    expect(ledger.hasExceededCeiling).toBe(false);
+    expect(ledger.overshootUsd).toBe(0);
+  });
+
+  it("stops the run and reports the overshoot in the summary", async () => {
+    const dataRoot = makeTestDataRoot("cost-overshoot");
+    const tasks: RunTask[] = Array.from({ length: 8 }, (_, index) =>
+      makeTask(`doc-${index}`, "text-default", `document ${index}`, 0.02));
+    const ledger = new CostLedger(0.05);
+    const messages: string[] = [];
+    const summary = await runTasks({
+      corpus: "synthetic-corpus",
+      experiment: experiment as any,
+      experimentSha256: "hash",
+      tasks,
+      outputFile: path.join(dataRoot, "results.jsonl"),
+      ledger,
+      cache: new ResponseCache(path.join(dataRoot, "cache")),
+      pricing: testPricing,
+      runMeta: testRunMeta,
+      // Each response really costs far more than the estimate reserved for it.
+      createCompletion: async () => ({
+        parsed: { category: "form" },
+        refusal: null,
+        raw: {},
+        usage: { promptTokens: 400_000, completionTokens: 1024 },
+        originMeta: { date: "2026-08-12T00:00:00.000Z", modelReturned: "gpt-4o-mini", systemFingerprint: null }
+      }),
+      concurrency: 1,
+      log: (message) => messages.push(message)
+    });
+
+    expect(summary.stoppedOnCeiling).toBe(true);
+    expect(summary.overshootUsd).toBeGreaterThan(0);
+    expect(summary.apiCalls).toBeLessThan(tasks.length);
+    expect(messages.join("\n")).toMatch(/passed the --max-cost ceiling by \$/);
+  });
+});
+
+describe("concurrent runs cannot overshoot --max-cost", () => {
+  it("stops dispatching once reservations reach the ceiling", async () => {
+    const dataRoot = makeTestDataRoot("cost-ceiling");
+    // 20 calls, each reserving a worst case of $0.02 and really costing about $0.0156. The ceiling
+    // pays for a handful of them, so the run has to stop partway through.
+    const tasks: RunTask[] = Array.from({ length: 20 }, (_, index) =>
+      makeTask(`doc-${index}`, "text-default", `document ${index}`, 0.02));
+    const ceiling = 0.085;
+    const ledger = new CostLedger(ceiling);
+
+    let inFlight = 0;
+    let peakInFlight = 0;
+    // Recorded rather than asserted in place: an expect() that throws inside createCompletion is
+    // caught by runTasks' own retry handling and turned into an error row, so the failure would be
+    // swallowed. The peak is checked after runTasks returns.
+    let peakCommittedUsd = 0;
+    const createCompletion = async (): Promise<CompletionResult> => {
+      inFlight += 1;
+      peakInFlight = Math.max(peakInFlight, inFlight);
+      // Yield so every worker is mid-call at once — the moment a naive ledger would overshoot.
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      peakCommittedUsd = Math.max(peakCommittedUsd, ledger.committedUsd);
+      inFlight -= 1;
+      return {
+        parsed: { category: "form" },
+        refusal: null,
+        raw: {},
+        usage: { promptTokens: 100_000, completionTokens: 1024 },
+        originMeta: { date: "2026-08-11T00:00:00.000Z", modelReturned: "gpt-4o-mini", systemFingerprint: null }
+      };
+    };
+
+    const messages: string[] = [];
+    const summary = await runTasks({
+      corpus: "synthetic-corpus",
+      experiment: experiment as any,
+      experimentSha256: "hash",
+      tasks,
+      outputFile: path.join(dataRoot, "results.jsonl"),
+      ledger,
+      cache: new ResponseCache(path.join(dataRoot, "cache")),
+      pricing: testPricing,
+      runMeta: testRunMeta,
+      createCompletion,
+      log: (message) => messages.push(message)
+    });
+
+    expect(peakInFlight).toBeGreaterThan(1);
+    expect(peakCommittedUsd).toBeGreaterThan(0);
+    expect(peakCommittedUsd).toBeLessThanOrEqual(ceiling);
+    expect(summary.stoppedOnCeiling).toBe(true);
+    expect(summary.apiCalls).toBeGreaterThan(0);
+    expect(summary.apiCalls).toBeLessThan(tasks.length);
+    expect(summary.reservedPeakUsd).toBeLessThanOrEqual(ceiling);
+    expect(ledger.incurredUsd).toBeLessThanOrEqual(ceiling);
+    expect(messages.join("\n")).toContain("No further requests were dispatched");
+  });
+});

--- a/scripts/ai-harness/test/execute.test.ts
+++ b/scripts/ai-harness/test/execute.test.ts
@@ -1,0 +1,328 @@
+import { jest } from "@jest/globals";
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import path from "node:path";
+import { ResponseCache } from "../src/cache.js";
+import { CostLedger } from "../src/cost.js";
+import {
+  CompletionResult, JsonlWriter, RunTask, currentRunMeta, isTransientError, readResultRows, runTasks
+} from "../src/execute.js";
+import { ResultRow } from "../src/schemas.js";
+import { makeTask, makeTestDataRoot, readLines, testPricing, testRunMeta } from "./helpers.js";
+
+const experiment = { schemaVersion: 1, name: "resume-tests", runs: [] as any[] };
+
+function completion(): CompletionResult {
+  return {
+    parsed: { category: "form" },
+    refusal: null,
+    raw: { id: "chatcmpl-1" },
+    usage: { promptTokens: 100, completionTokens: 20 },
+    originMeta: { date: "2026-08-11T00:00:00.000Z", modelReturned: "gpt-4o-mini", systemFingerprint: null }
+  };
+}
+
+async function run(dataRoot: string, tasks: RunTask[], createCompletion: () => Promise<CompletionResult>,
+  outputFile = path.join(dataRoot, "results.jsonl")) {
+  return {
+    summary: await runTasks({
+      corpus: "synthetic-corpus",
+      experiment: experiment as any,
+      experimentSha256: "hash",
+      tasks,
+      outputFile,
+      ledger: new CostLedger(10),
+      // The cache is disabled so these tests exercise resume, not caching.
+      cache: new ResponseCache(path.join(dataRoot, "cache"), { read: false, write: false }),
+      pricing: testPricing,
+      runMeta: testRunMeta,
+      createCompletion,
+      sleep: async () => undefined
+    }),
+    outputFile
+  };
+}
+
+describe("resume", () => {
+  it("skips a (document, run) pair whose requestKey already has a row", async () => {
+    const dataRoot = makeTestDataRoot("resume-basic");
+    const tasks = [
+      makeTask("text", "text-default", "summary of text"),
+      makeTask("table", "text-default", "summary of table")
+    ];
+
+    const first = await run(dataRoot, tasks, async () => completion());
+    expect(first.summary.written).toBe(2);
+
+    const second = await run(dataRoot, tasks, async () => {
+      throw new Error("a completed pair must not be re-requested");
+    });
+    expect(second.summary.resumed).toBe(2);
+    expect(second.summary.written).toBe(0);
+    expect(readLines(first.outputFile)).toHaveLength(2);
+  });
+
+  it("resumes an interrupted run and finishes the rest", async () => {
+    const dataRoot = makeTestDataRoot("resume-interrupted");
+    const tasks = Array.from({ length: 6 }, (_, index) =>
+      makeTask(`doc-${index}`, "text-default", `summary ${index}`));
+
+    // Simulate a crash: only the first three tasks got a row.
+    await run(dataRoot, tasks.slice(0, 3), async () => completion());
+    const second = await run(dataRoot, tasks, async () => completion());
+
+    expect(second.summary.resumed).toBe(3);
+    expect(second.summary.written).toBe(3);
+    const rows = readLines(second.outputFile) as ResultRow[];
+    expect(new Set(rows.map((row) => row.docId)).size).toBe(6);
+  });
+
+  it("re-runs when the representation, prompt or generation settings change the requestKey", async () => {
+    const dataRoot = makeTestDataRoot("resume-changed");
+    const original = makeTask("text", "text-default", "summary of text");
+    await run(dataRoot, [original], async () => completion());
+
+    // Same document id and run id, different markdown — a changed representation.
+    const changed = makeTask("text", "text-default", "a DIFFERENT summary of text");
+    expect(changed.requestKey).not.toBe(original.requestKey);
+
+    let calls = 0;
+    const second = await run(dataRoot, [changed], async () => { calls += 1; return completion(); });
+    expect(second.summary.resumed).toBe(0);
+    expect(calls).toBe(1);
+  });
+
+  it("lets an error row be retried on the next run", async () => {
+    const dataRoot = makeTestDataRoot("resume-error");
+    const tasks = [makeTask("text", "text-default", "summary of text")];
+    await run(dataRoot, tasks, async () => { throw new Error("boom"); });
+
+    let calls = 0;
+    const second = await run(dataRoot, tasks, async () => { calls += 1; return completion(); });
+    expect(second.summary.resumed).toBe(0);
+    expect(calls).toBe(1);
+    const rows = readResultRows(path.join(dataRoot, "results.jsonl"));
+    expect(rows.map((row) => row.status)).toEqual(["error", "success"]);
+  });
+});
+
+describe("resume identity spans the corpus and the experiment", () => {
+  const runWith = async (dataRoot: string, overrides: { corpus?: string; experimentSha256?: string },
+    tasks: RunTask[], createCompletion: () => Promise<CompletionResult>) =>
+    runTasks({
+      corpus: overrides.corpus ?? "synthetic-corpus",
+      experiment: experiment as any,
+      experimentSha256: overrides.experimentSha256 ?? "hash",
+      tasks,
+      outputFile: path.join(dataRoot, "results.jsonl"),
+      ledger: new CostLedger(10),
+      cache: new ResponseCache(path.join(dataRoot, "cache"), { read: false, write: false }),
+      pricing: testPricing,
+      runMeta: testRunMeta,
+      createCompletion,
+      sleep: async () => undefined
+    });
+
+  it("does not resume a row written for a different corpus", async () => {
+    const dataRoot = makeTestDataRoot("resume-corpus");
+    const tasks = [makeTask("text", "text-default", "a summary")];
+    await runWith(dataRoot, { corpus: "corpus-a" }, tasks, async () => completion());
+
+    let calls = 0;
+    const second = await runWith(dataRoot, { corpus: "corpus-b" }, tasks,
+      async () => { calls += 1; return completion(); });
+    expect(second.resumed).toBe(0);
+    expect(calls).toBe(1);
+  });
+
+  it("does not resume a row written under a different experiment definition", async () => {
+    const dataRoot = makeTestDataRoot("resume-experiment");
+    const tasks = [makeTask("text", "text-default", "a summary")];
+    await runWith(dataRoot, { experimentSha256: "before-edit" }, tasks, async () => completion());
+
+    let calls = 0;
+    const second = await runWith(dataRoot, { experimentSha256: "after-edit" }, tasks,
+      async () => { calls += 1; return completion(); });
+    expect(second.resumed).toBe(0);
+    expect(calls).toBe(1);
+  });
+
+  it("still resumes when corpus and experiment both match", async () => {
+    const dataRoot = makeTestDataRoot("resume-same");
+    const tasks = [makeTask("text", "text-default", "a summary")];
+    await runWith(dataRoot, {}, tasks, async () => completion());
+    const second = await runWith(dataRoot, {}, tasks, async () => {
+      throw new Error("must not be re-requested");
+    });
+    expect(second.resumed).toBe(1);
+  });
+});
+
+describe("a dispatched request that fails is not treated as free", () => {
+  it("settles its single-attempt share instead of releasing the whole reservation", async () => {
+    const dataRoot = makeTestDataRoot("failed-attempt-cost");
+    const tasks = [makeTask("text", "text-default", "a summary", 0.03)];
+    const ledger = new CostLedger(10);
+    await runTasks({
+      corpus: "synthetic-corpus",
+      experiment: experiment as any,
+      experimentSha256: "hash",
+      tasks,
+      outputFile: path.join(dataRoot, "results.jsonl"),
+      ledger,
+      cache: new ResponseCache(path.join(dataRoot, "cache"), { read: false, write: false }),
+      pricing: testPricing,
+      runMeta: testRunMeta,
+      createCompletion: async () => { throw Object.assign(new Error("gone"), { status: 500 }); },
+      sleep: async () => undefined
+    });
+    // Three attempts of a reservation that covered three: the whole reservation is charged.
+    expect(ledger.incurredUsd).toBeCloseTo(0.03, 10);
+    expect(ledger.incurredUsd).toBeGreaterThan(0);
+  });
+
+  it("charges only the attempts it made when it gives up early", async () => {
+    const dataRoot = makeTestDataRoot("failed-attempt-partial");
+    const tasks = [makeTask("text", "text-default", "a summary", 0.03)];
+    const ledger = new CostLedger(10);
+    await runTasks({
+      corpus: "synthetic-corpus",
+      experiment: experiment as any,
+      experimentSha256: "hash",
+      tasks,
+      outputFile: path.join(dataRoot, "results.jsonl"),
+      ledger,
+      cache: new ResponseCache(path.join(dataRoot, "cache"), { read: false, write: false }),
+      pricing: testPricing,
+      runMeta: testRunMeta,
+      // Not transient, so it is attempted once and not retried.
+      createCompletion: async () => { throw new Error("bad request"); },
+      sleep: async () => undefined
+    });
+    expect(ledger.incurredUsd).toBeCloseTo(0.01, 10);
+  });
+});
+
+describe("retries", () => {
+  it("retries a transient failure and gives up after the configured number of attempts", async () => {
+    expect(isTransientError({ status: 429 })).toBe(true);
+    expect(isTransientError({ status: 503 })).toBe(true);
+    expect(isTransientError({ code: "ECONNRESET" })).toBe(true);
+    expect(isTransientError({ status: 400 })).toBe(false);
+    expect(isTransientError(new Error("bad prompt"))).toBe(false);
+
+    const dataRoot = makeTestDataRoot("retries");
+    const tasks = [makeTask("text", "text-default", "summary of text")];
+    let attempts = 0;
+    const { outputFile } = await run(dataRoot, tasks, async () => {
+      attempts += 1;
+      if (attempts < 3) throw Object.assign(new Error("rate limited"), { status: 429 });
+      return completion();
+    });
+    expect(attempts).toBe(3);
+    expect((readLines(outputFile)[0] as ResultRow).status).toBe("success");
+  });
+
+  it("records the attempt count on an error row", async () => {
+    const dataRoot = makeTestDataRoot("retries-exhausted");
+    const tasks = [makeTask("text", "text-default", "summary of text")];
+    const { outputFile } = await run(dataRoot, tasks, async () => {
+      throw Object.assign(new Error("still rate limited"), { status: 429 });
+    });
+    const row = readLines(outputFile)[0] as ResultRow;
+    expect(row.status).toBe("error");
+    if (row.status === "error") expect(row.error.attempts).toBe(3);
+  });
+
+  it("does not retry a non-transient failure", async () => {
+    const dataRoot = makeTestDataRoot("retries-none");
+    const tasks = [makeTask("text", "text-default", "summary of text")];
+    let attempts = 0;
+    await run(dataRoot, tasks, async () => { attempts += 1; throw new Error("invalid request"); });
+    expect(attempts).toBe(1);
+  });
+});
+
+describe("the JSONL writer", () => {
+  it("produces whole, non-interleaved rows under concurrency", async () => {
+    const dataRoot = makeTestDataRoot("writer-queue");
+    const file = path.join(dataRoot, "concurrent.jsonl");
+    const writer = new JsonlWriter(file);
+
+    // Large payloads so a naive appender really would interleave.
+    const rows = Array.from({ length: 200 }, (_, index) => ({ index, filler: "x".repeat(4000) }));
+    await Promise.all(rows.map((row) => writer.write(row)));
+    await writer.close();
+
+    const lines = fs.readFileSync(file, "utf8").split("\n").filter((line) => line.length > 0);
+    expect(lines).toHaveLength(200);
+    const parsed = lines.map((line) => JSON.parse(line));
+    expect(parsed.map((row) => row.index)).toEqual(rows.map((row) => row.index));
+    for (const row of parsed) expect(row.filler).toHaveLength(4000);
+  });
+
+  it("writes whole rows from concurrent completions", async () => {
+    const dataRoot = makeTestDataRoot("writer-run");
+    const tasks: RunTask[] = Array.from({ length: 24 }, (_, index) =>
+      makeTask(`doc-${index}`, "text-default", "x".repeat(2000) + index));
+    const { outputFile } = await run(dataRoot, tasks, async () => {
+      await new Promise((resolve) => setTimeout(resolve, Math.random() * 4));
+      return completion();
+    });
+    const rows = readResultRows(outputFile);
+    expect(rows).toHaveLength(24);
+    expect(new Set(rows.map((row) => row.docId)).size).toBe(24);
+  });
+});
+
+describe("the writer survives a failing append", () => {
+  // Not asked for by the review, but B1/B2 changed behaviour that nothing else covers.
+  it("keeps writing after one append fails, and reports the failure once from close()", async () => {
+    const dataRoot = makeTestDataRoot("writer-poison");
+    const writer = new JsonlWriter(path.join(dataRoot, "rows.jsonl"));
+    const failure = new Error("disk full");
+    const appendFile = jest.spyOn(fsp, "appendFile")
+      .mockRejectedValueOnce(failure as never);
+
+    await expect(writer.write({ row: 1 })).rejects.toThrow("disk full");
+    // The queue must not be poisoned: later rows still land, including the error row that would
+    // explain the failure.
+    await expect(writer.write({ row: 2 })).resolves.toBeUndefined();
+    await expect(writer.write({ row: 3 })).resolves.toBeUndefined();
+    await expect(writer.close()).rejects.toThrow("disk full");
+
+    appendFile.mockRestore();
+    expect(readLines(path.join(dataRoot, "rows.jsonl"))).toEqual([{ row: 2 }, { row: 3 }]);
+  });
+
+  it("closes the writer even when a worker throws, so queued rows are not lost", async () => {
+    const dataRoot = makeTestDataRoot("writer-worker-throws");
+    const tasks = [makeTask("a", "text-default", "one"), makeTask("b", "text-default", "two")];
+    // A non-Error throw from the ledger is not something runTasks catches, so it escapes the worker.
+    const exploding = { reserve: () => { throw new Error("ledger exploded"); } } as any;
+
+    await expect(runTasks({
+      corpus: "synthetic-corpus",
+      experiment: { schemaVersion: 1, name: "boom", runs: [] } as any,
+      experimentSha256: "hash",
+      tasks,
+      outputFile: path.join(dataRoot, "results.jsonl"),
+      ledger: exploding,
+      cache: new ResponseCache(path.join(dataRoot, "cache"), { read: false, write: false }),
+      pricing: testPricing,
+      runMeta: testRunMeta,
+      createCompletion: async () => completion(),
+      sleep: async () => undefined
+    })).rejects.toThrow("ledger exploded");
+  });
+});
+
+describe("run metadata", () => {
+  it("records the SDK version, the date, and the git state", () => {
+    const meta = currentRunMeta(new Date("2026-08-11T12:00:00.000Z"));
+    expect(meta.date).toBe("2026-08-11T12:00:00.000Z");
+    expect(meta.openaiSdkVersion).toMatch(/^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$/);
+    expect(typeof meta.gitDirty).toBe("boolean");
+    expect(meta.gitCommit === null || /^[0-9a-f]{40}$/.test(meta.gitCommit)).toBe(true);
+  });
+});

--- a/scripts/ai-harness/test/execute.test.ts
+++ b/scripts/ai-harness/test/execute.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import fsp from "node:fs/promises";
 import path from "node:path";
 import { ResponseCache } from "../src/cache.js";
-import { CostLedger } from "../src/cost.js";
+import { CostLedger, priceTokens } from "../src/cost.js";
 import {
   CompletionResult, JsonlWriter, RunTask, currentRunMeta, isTransientError, readResultRows, runTasks
 } from "../src/execute.js";
@@ -240,6 +240,110 @@ describe("retries", () => {
     let attempts = 0;
     await run(dataRoot, tasks, async () => { attempts += 1; throw new Error("invalid request"); });
     expect(attempts).toBe(1);
+  });
+});
+
+describe("a request that succeeds after failed attempts", () => {
+  const runOnce = async (dataRoot: string, ledger: CostLedger, createCompletion: () => Promise<CompletionResult>) =>
+    runTasks({
+      corpus: "synthetic-corpus",
+      experiment: experiment as any,
+      experimentSha256: "hash",
+      tasks: [makeTask("text", "text-default", "a summary", 0.03)],
+      outputFile: path.join(dataRoot, "results.jsonl"),
+      ledger,
+      cache: new ResponseCache(path.join(dataRoot, "cache"), { read: false, write: false }),
+      pricing: testPricing,
+      runMeta: testRunMeta,
+      createCompletion,
+      sleep: async () => undefined
+    });
+
+  it("charges the earlier dispatched attempts, not only the response that came back", async () => {
+    const dataRoot = makeTestDataRoot("retry-cost");
+    const ledger = new CostLedger(10);
+    let attempts = 0;
+    const summary = await runOnce(dataRoot, ledger, async () => {
+      attempts += 1;
+      if (attempts < 3) throw Object.assign(new Error("rate limited"), { status: 429 });
+      return completion();
+    });
+
+    // The response itself is tiny; the two failed attempts are two thirds of a $0.03 reservation.
+    const responseOnly = priceTokens(100, 20, testPricing);
+    expect(summary.written).toBe(1);
+    expect(ledger.incurredUsd).toBeCloseTo(responseOnly + 0.02, 10);
+    expect(ledger.incurredUsd).toBeGreaterThan(responseOnly);
+  });
+
+  it("charges nothing extra when the first attempt succeeds", async () => {
+    const dataRoot = makeTestDataRoot("retry-cost-clean");
+    const ledger = new CostLedger(10);
+    await runOnce(dataRoot, ledger, async () => completion());
+    expect(ledger.incurredUsd).toBeCloseTo(priceTokens(100, 20, testPricing), 10);
+  });
+
+  it("accounts the same way whether the request eventually succeeds or not", async () => {
+    // The two paths must agree about the identical event: an attempt that went out and came back
+    // with nothing.
+    const failedOnly = new CostLedger(10);
+    await runOnce(makeTestDataRoot("retry-cost-allfail"), failedOnly, async () => {
+      throw Object.assign(new Error("gone"), { status: 500 });
+    });
+
+    const succeeded = new CostLedger(10);
+    let attempts = 0;
+    await runOnce(makeTestDataRoot("retry-cost-mixed"), succeeded, async () => {
+      attempts += 1;
+      if (attempts < 3) throw Object.assign(new Error("gone"), { status: 500 });
+      return completion();
+    });
+
+    // Three failed attempts cost the whole reservation; two failed plus a response cost two thirds
+    // of it plus the response.
+    expect(failedOnly.incurredUsd).toBeCloseTo(0.03, 10);
+    expect(succeeded.incurredUsd).toBeCloseTo(0.02 + priceTokens(100, 20, testPricing), 10);
+  });
+});
+
+describe("apiCalls counts dispatches, which is what the CLI reports", () => {
+  const runWith = async (name: string, createCompletion: () => Promise<CompletionResult>) => {
+    const dataRoot = makeTestDataRoot(name);
+    return runTasks({
+      corpus: "synthetic-corpus",
+      experiment: experiment as any,
+      experimentSha256: "hash",
+      tasks: [makeTask("text", "text-default", "a summary")],
+      outputFile: path.join(dataRoot, "results.jsonl"),
+      ledger: new CostLedger(10),
+      cache: new ResponseCache(path.join(dataRoot, "cache"), { read: false, write: false }),
+      pricing: testPricing,
+      runMeta: testRunMeta,
+      createCompletion,
+      sleep: async () => undefined
+    });
+  };
+
+  it("counts every attempt when a request succeeds on its third", async () => {
+    let attempts = 0;
+    const summary = await runWith("apicalls-retry", async () => {
+      attempts += 1;
+      if (attempts < 3) throw Object.assign(new Error("rate limited"), { status: 429 });
+      return completion();
+    });
+    expect(summary.apiCalls).toBe(3);
+  });
+
+  it("counts the attempts of a request that exhausts its retries, rather than reporting none", async () => {
+    const summary = await runWith("apicalls-exhausted", async () => {
+      throw Object.assign(new Error("rate limited"), { status: 429 });
+    });
+    expect(summary.apiCalls).toBe(3);
+    expect(summary.written).toBe(1);
+  });
+
+  it("counts one for a request that succeeds immediately, and none for a cache hit", async () => {
+    expect((await runWith("apicalls-clean", async () => completion())).apiCalls).toBe(1);
   });
 });
 

--- a/scripts/ai-harness/test/execute.test.ts
+++ b/scripts/ai-harness/test/execute.test.ts
@@ -159,7 +159,7 @@ describe("resume identity spans the corpus and the experiment", () => {
 });
 
 describe("a dispatched request that fails is not treated as free", () => {
-  it("settles its single-attempt share instead of releasing the whole reservation", async () => {
+  it("charges the whole reservation when every attempt it paid for was dispatched", async () => {
     const dataRoot = makeTestDataRoot("failed-attempt-cost");
     const tasks = [makeTask("text", "text-default", "a summary", 0.03)];
     const ledger = new CostLedger(10);
@@ -380,7 +380,7 @@ describe("the JSONL writer", () => {
 });
 
 describe("the writer survives a failing append", () => {
-  // Not asked for by the review, but B1/B2 changed behaviour that nothing else covers.
+  // The writer's queue-poisoning and shutdown behavior is not covered anywhere else.
   it("keeps writing after one append fails, and reports the failure once from close()", async () => {
     const dataRoot = makeTestDataRoot("writer-poison");
     const writer = new JsonlWriter(path.join(dataRoot, "rows.jsonl"));

--- a/scripts/ai-harness/test/fixtures.test.ts
+++ b/scripts/ai-harness/test/fixtures.test.ts
@@ -1,0 +1,86 @@
+import fs from "node:fs";
+import path from "node:path";
+import { tileTypes } from "../../../shared/tile-types.js";
+import { classifyDocument } from "../src/capability.js";
+import { harnessRoot } from "../src/corpus.js";
+import { textVariants } from "../src/represent-text.js";
+import { validateExpectationsFile } from "../src/schemas.js";
+
+const corpusDir = path.join(harnessRoot, "examples", "synthetic-corpus");
+const documentsDir = path.join(corpusDir, "documents");
+const expectationsFile = path.join(corpusDir, "expectations.json");
+const expectations = validateExpectationsFile(
+  JSON.parse(fs.readFileSync(expectationsFile, "utf8")), expectationsFile);
+
+const docIds = Object.keys(expectations.documents);
+
+function readDocument(docId: string): unknown {
+  return JSON.parse(fs.readFileSync(path.join(documentsDir, `${docId}.json`), "utf8"));
+}
+
+describe("the committed synthetic corpus", () => {
+  it("has one document per file and one expectation per document", () => {
+    const files = fs.readdirSync(documentsDir).filter((name) => name.endsWith(".json"))
+      .map((name) => path.basename(name, ".json")).sort();
+    expect(files).toEqual([...docIds].sort());
+  });
+
+  it("has no committed manifest — `import` generates that", () => {
+    expect(fs.existsSync(path.join(corpusDir, "manifest.json"))).toBe(false);
+  });
+
+  it("covers every registered tile type, plus a mixed and an empty document", () => {
+    const covered = new Set(Object.values(expectations.documents).flatMap((entry) => entry.tileTypes));
+    // The Unknown fixture stands in for the "Unknown" registration with a made-up type string.
+    covered.add("Unknown");
+    for (const tileType of tileTypes) expect([...covered]).toContain(tileType);
+    expect(Object.values(expectations.documents).map((entry) => entry.computedModality))
+      .toEqual(expect.arrayContaining(["text-only", "visual-only", "mixed", "empty"]));
+  });
+});
+
+describe.each(docIds)("fixture %s", (docId) => {
+  const expectation = expectations.documents[docId];
+  // Read inside beforeAll rather than while jest collects the suite: a missing or unparsable fixture
+  // would otherwise take down the whole file with a collection-time crash, hiding the parity test's
+  // far clearer "documents and expectations disagree" diagnostic.
+  let content: unknown;
+  let classification: ReturnType<typeof classifyDocument>;
+
+  beforeAll(() => {
+    content = readDocument(docId);
+    classification = classifyDocument(content);
+  });
+
+  it("classifies as expected", () => {
+    expect(classification.computedModality).toBe(expectation.computedModality);
+    expect(classification.warnings).toEqual([]);
+  });
+
+  it("has the expected document-level capability", () => {
+    expect({
+      containsStudentText: classification.tiles.some((tile) => tile.hasStudentText),
+      requiresVisualRepresentation: classification.tiles.some((tile) => tile.requiresVisualRepresentation)
+    }).toEqual(expectation.capability);
+  });
+
+  it("contains the expected tile types", () => {
+    const types = [...new Set(classification.tiles.map((tile) => tile.tileType))].sort();
+    expect(types).toEqual([...expectation.tileTypes].sort());
+  });
+
+  it("summarizes with the default variant", () => {
+    if (!expectation.defaultSummaryMustSucceed) return;
+    const summary = textVariants.default.render(content);
+    expect(summary.length).toBeGreaterThan(0);
+    if (expectation.expectDistinctiveInDefaultSummary) {
+      // Full- and partial-fidelity handlers must carry the fixture's own content through.
+      expect(summary).toContain(expectation.distinctiveString);
+    }
+  });
+
+  it("summarizes with the minimal variant", () => {
+    if (!expectation.minimalSummaryMustSucceed) return;
+    expect(textVariants.minimal.render(content).length).toBeGreaterThan(0);
+  });
+});

--- a/scripts/ai-harness/test/fixtures.test.ts
+++ b/scripts/ai-harness/test/fixtures.test.ts
@@ -31,11 +31,22 @@ describe("the committed synthetic corpus", () => {
 
   it("covers every registered tile type, plus a mixed and an empty document", () => {
     const covered = new Set(Object.values(expectations.documents).flatMap((entry) => entry.tileTypes));
-    // The Unknown fixture stands in for the "Unknown" registration with a made-up type string.
-    covered.add("Unknown");
-    for (const tileType of tileTypes) expect([...covered]).toContain(tileType);
+    // "Unknown" is deliberately not in `covered`: it is the registration for a type this build does
+    // not know, so the fixture standing in for it declares a made-up type instead. Asserting that is
+    // what the old `covered.add("Unknown")` gave away — adding the string made this unfailable.
+    for (const tileType of tileTypes) {
+      if (tileType === "Unknown") continue;
+      expect([...covered]).toContain(tileType);
+    }
     expect(Object.values(expectations.documents).map((entry) => entry.computedModality))
       .toEqual(expect.arrayContaining(["text-only", "visual-only", "mixed", "empty"]));
+  });
+
+  it("stands in for the Unknown registration with a type this build does not register", () => {
+    const unknownFixture = expectations.documents.unknown;
+    expect(unknownFixture).toBeDefined();
+    const registered = tileTypes as readonly string[];
+    expect(unknownFixture.tileTypes.filter((type) => !registered.includes(type))).not.toEqual([]);
   });
 });
 
@@ -69,8 +80,12 @@ describe.each(docIds)("fixture %s", (docId) => {
     expect(types).toEqual([...expectation.tileTypes].sort());
   });
 
-  it("summarizes with the default variant", () => {
-    if (!expectation.defaultSummaryMustSucceed) return;
+  // Skipped rather than silently passing when a fixture declares it cannot summarize: an early
+  // `return` inside the test made a `false` flag indistinguishable from a passing assertion.
+  const itDefault = expectation.defaultSummaryMustSucceed ? it : it.skip;
+  const itMinimal = expectation.minimalSummaryMustSucceed ? it : it.skip;
+
+  itDefault("summarizes with the default variant", () => {
     const summary = textVariants.default.render(content);
     expect(summary.length).toBeGreaterThan(0);
     if (expectation.expectDistinctiveInDefaultSummary) {
@@ -79,8 +94,7 @@ describe.each(docIds)("fixture %s", (docId) => {
     }
   });
 
-  it("summarizes with the minimal variant", () => {
-    if (!expectation.minimalSummaryMustSucceed) return;
+  itMinimal("summarizes with the minimal variant", () => {
     expect(textVariants.minimal.render(content).length).toBeGreaterThan(0);
   });
 });

--- a/scripts/ai-harness/test/helpers.ts
+++ b/scripts/ai-harness/test/helpers.ts
@@ -1,0 +1,69 @@
+import fs from "node:fs";
+import path from "node:path";
+import { harnessRoot } from "../src/corpus.js";
+import type { RunTask } from "../src/execute.js";
+import type { HarnessRequest } from "../src/messages.js";
+import { requestKeyFor } from "../src/messages.js";
+import type { ModelPricing, RunMeta } from "../src/schemas.js";
+
+/** The repository root — two levels up from scripts/ai-harness. */
+export const repoRoot = path.resolve(harnessRoot, "..", "..");
+
+/**
+ * Scratch space for tests. It lives inside `data/` because nothing the harness generates is ever
+ * written outside that (gitignored) tree.
+ */
+export function makeTestDataRoot(name: string): string {
+  const directory = path.join(harnessRoot, "data", "test-runs", name);
+  fs.rmSync(directory, { recursive: true, force: true });
+  fs.mkdirSync(directory, { recursive: true });
+  return directory;
+}
+
+export const testPricing: ModelPricing = {
+  inputPerMTokUsd: 0.15,
+  outputPerMTokUsd: 0.6,
+  maxOutputTokens: 1024
+};
+
+export const testRunMeta: RunMeta = {
+  date: "2026-08-11T00:00:00.000Z",
+  openaiSdkVersion: "6.45.0",
+  gitCommit: "0000000000000000000000000000000000000000",
+  gitDirty: false
+};
+
+export function makeRequest(text: string, maxCompletionTokens = 1024): HarnessRequest {
+  return {
+    model: "gpt-4o-mini",
+    messages: [
+      { role: "system", content: "You are a teaching assistant." },
+      { role: "user", content: [{ type: "text", text }] }
+    ],
+    responseFormat: {
+      type: "json_schema",
+      json_schema: { name: "categorization-response", strict: true, schema: { type: "object" } }
+    },
+    generationSettings: { max_completion_tokens: maxCompletionTokens }
+  };
+}
+
+export function makeTask(docId: string, runId: string, text: string, worstCase = 0.01): RunTask {
+  const request = makeRequest(text);
+  return {
+    docId,
+    runId,
+    run: { id: runId, message: "text-only", textVariant: "default", prompt: "categorize-design-default" },
+    modality: "text-only",
+    promptName: "categorize-design-default",
+    promptSha256: "prompt-hash",
+    aiPrompt: { systemPrompt: "You are a teaching assistant.", mainPrompt: "Evaluate this.", discussionPrompt: "?" },
+    request,
+    requestKey: requestKeyFor(request),
+    worstCaseUsd: worstCase
+  };
+}
+
+export function readLines(file: string): unknown[] {
+  return fs.readFileSync(file, "utf8").split("\n").filter((line) => line.length > 0).map((line) => JSON.parse(line));
+}

--- a/scripts/ai-harness/test/prompt.test.ts
+++ b/scripts/ai-harness/test/prompt.test.ts
@@ -7,7 +7,7 @@ import { sha256Canonical, validatePromptFile } from "../src/schemas.js";
 const promptFile = path.join(harnessRoot, "prompts", "categorize-design-default.json");
 
 /**
- * Acceptance criterion 11. The committed prompt is a copy of production's built-in default, and this
+ * The committed prompt is a copy of production's built-in default, and this
  * is what stops the copy drifting away from it unnoticed.
  */
 describe("the committed default prompt", () => {

--- a/scripts/ai-harness/test/prompt.test.ts
+++ b/scripts/ai-harness/test/prompt.test.ts
@@ -1,0 +1,37 @@
+import fs from "node:fs";
+import path from "node:path";
+import { defaultAiPrompt } from "../../../shared/ai-analysis-messages.js";
+import { harnessRoot } from "../src/corpus.js";
+import { sha256Canonical, validatePromptFile } from "../src/schemas.js";
+
+const promptFile = path.join(harnessRoot, "prompts", "categorize-design-default.json");
+
+/**
+ * Acceptance criterion 11. The committed prompt is a copy of production's built-in default, and this
+ * is what stops the copy drifting away from it unnoticed.
+ */
+describe("the committed default prompt", () => {
+  const raw = JSON.parse(fs.readFileSync(promptFile, "utf8"));
+
+  it("validates, which also checks its own declared hash", () => {
+    const prompt = validatePromptFile(raw, promptFile);
+    expect(prompt.name).toBe("categorize-design-default");
+    expect(prompt.provenance.source).toContain("ai-analysis-messages");
+  });
+
+  it("hashes identically to defaultAiPrompt from the shared module", () => {
+    const productionHash = sha256Canonical(defaultAiPrompt);
+    expect(raw.provenance.aiPromptSha256).toBe(productionHash);
+    expect(sha256Canonical(raw.aiPrompt)).toBe(productionHash);
+  });
+
+  it("is byte-for-byte the same prompt object", () => {
+    expect(raw.aiPrompt).toEqual(defaultAiPrompt);
+  });
+
+  it("rejects a prompt file whose declared hash does not match its content", () => {
+    const tampered = { ...raw, aiPrompt: { ...raw.aiPrompt, systemPrompt: "You are a pirate." } };
+    expect(() => validatePromptFile(tampered, "tampered.json"))
+      .toThrow(/tampered\.json: provenance\.aiPromptSha256 does not match/);
+  });
+});

--- a/scripts/ai-harness/test/report.test.ts
+++ b/scripts/ai-harness/test/report.test.ts
@@ -1,0 +1,171 @@
+import {
+  assertSingleCorpusAndExperiment, formatSummaryTable, historicalIsComparable, summarizeResults
+} from "../src/report.js";
+import { ManifestDocument, ResultRow } from "../src/schemas.js";
+import { testRunMeta } from "./helpers.js";
+
+const base = {
+  schemaVersion: 1 as const,
+  experiment: "text-baselines",
+  experimentSha256: "hash",
+  runId: "text-default",
+  corpus: "synthetic-corpus",
+  message: "text-only" as const,
+  textVariant: "default",
+  prompt: { name: "categorize-design-default", sha256: "p" },
+  runMeta: testRunMeta
+};
+const origin = { date: "2026-08-11T00:00:00.000Z", modelReturned: "gpt-4o-mini", systemFingerprint: null };
+
+const rows: ResultRow[] = [
+  { ...base, docId: "text", modality: "text-only", requestKey: "k1", status: "success",
+    response: { parsed: { category: "form" }, raw: {} },
+    usage: { promptTokens: 100, completionTokens: 10, source: "api" },
+    cost: { modeledUsd: 0.001, incurredThisRunUsd: 0.001 }, responseOriginMeta: origin },
+  { ...base, docId: "table", modality: "text-only", requestKey: "k2", status: "success",
+    response: { parsed: { category: "function" }, raw: {} },
+    usage: { promptTokens: 300, completionTokens: 20, source: "cache" },
+    cost: { modeledUsd: 0.002, incurredThisRunUsd: 0 }, responseOriginMeta: origin },
+  { ...base, docId: "drawing", modality: "visual-only", requestKey: "k3", status: "refusal",
+    refusal: "Not enough content.",
+    usage: { promptTokens: 50, completionTokens: 5, source: "api" },
+    cost: { modeledUsd: 0.0005, incurredThisRunUsd: 0.0005 }, responseOriginMeta: origin },
+  { ...base, docId: "image", modality: "visual-only", requestKey: "k4", status: "error",
+    error: { type: "APIError", message: "boom", attempts: 3 } },
+  { ...base, docId: "empty", modality: "empty", requestKey: null, status: "skipped",
+    skipReasons: ["no student content"] }
+];
+
+describe("summarizeResults", () => {
+  const summary = summarizeResults(rows, "results.jsonl", new Date("2026-08-11T00:00:00.000Z"));
+  const overall = summary.groups.find((group) => group.runId === "(all runs)")!;
+
+  it("counts every status", () => {
+    expect(overall.statuses).toEqual({ success: 2, refusal: 1, error: 1, skipped: 1 });
+  });
+
+  it("counts cache hits separately from API calls", () => {
+    expect(overall.cacheHits).toBe(1);
+  });
+
+  it("splits modeled from incurred cost", () => {
+    expect(overall.cost.modeledUsd).toBeCloseTo(0.0035, 10);
+    expect(overall.cost.incurredUsd).toBeCloseTo(0.0015, 10);
+  });
+
+  it("reports token totals, means and medians", () => {
+    expect(overall.tokens.promptTotal).toBe(450);
+    expect(overall.tokens.completionTotal).toBe(35);
+    expect(overall.tokens.total).toBe(485);
+    expect(overall.tokens.promptMean).toBeCloseTo(150, 10);
+    expect(overall.tokens.promptMedian).toBe(100);
+  });
+
+  it("reports the category distribution from parsed successes", () => {
+    expect(overall.categories).toEqual({ form: 1, function: 1 });
+  });
+
+  it("groups per run configuration and modality", () => {
+    const textOnly = summary.groups.find(
+      (group) => group.runId === "text-default" && group.modality === "text-only")!;
+    expect(textOnly.docs).toBe(2);
+    expect(textOnly.statuses.success).toBe(2);
+    const visualOnly = summary.groups.find(
+      (group) => group.runId === "text-default" && group.modality === "visual-only")!;
+    expect(visualOnly.statuses).toEqual({ success: 0, refusal: 1, error: 1, skipped: 0 });
+  });
+
+  it("renders a table with a header for every column", () => {
+    const table = formatSummaryTable(summary);
+    expect(table.split("\n")[0]).toContain("modality");
+    expect(table).toContain("(all runs)");
+    expect(table.split("\n")).toHaveLength(summary.groups.length + 2);
+  });
+});
+
+describe("historical analyses are never paired with a fresh run on trust", () => {
+  const document = {
+    id: "prod-1", contentSha256: "aaa", historical: null
+  } as unknown as ManifestDocument;
+
+  it("refuses when there is no historical record", () => {
+    expect(historicalIsComparable(document)).toBe(false);
+  });
+
+  it("refuses when the historical record does not say what content it ran against", () => {
+    expect(historicalIsComparable({
+      ...document,
+      historical: { summarizer: "default", promptTokens: 1, completionTokens: 1, response: {}, analyzedAt: "x" }
+    })).toBe(false);
+  });
+
+  it("refuses when the document has changed since", () => {
+    expect(historicalIsComparable({
+      ...document,
+      historical: { summarizer: "default", promptTokens: 1, completionTokens: 1, response: {}, analyzedAt: "x",
+        contentSha256: "bbb" }
+    })).toBe(false);
+  });
+
+  it("allows it only when the content hash proves the input is identical", () => {
+    expect(historicalIsComparable({
+      ...document,
+      historical: { summarizer: "default", promptTokens: 1, completionTokens: 1, response: {}, analyzedAt: "x",
+        contentSha256: "aaa" }
+    })).toBe(true);
+  });
+});
+
+describe("a results file must describe one corpus and one experiment", () => {
+  it("accepts rows that agree", () => {
+    expect(() => assertSingleCorpusAndExperiment(rows, "results.jsonl")).not.toThrow();
+  });
+
+  it("refuses rows from two corpora", () => {
+    const mixed = [...rows, { ...rows[0], corpus: "other-corpus" }] as ResultRow[];
+    expect(() => assertSingleCorpusAndExperiment(mixed, "results.jsonl"))
+      .toThrow(/mixes 2 corpora \(other-corpus, synthetic-corpus\)/);
+  });
+
+  it("refuses rows from two experiment definitions", () => {
+    const mixed = [...rows, { ...rows[0], experimentSha256: "edited" }] as ResultRow[];
+    expect(() => assertSingleCorpusAndExperiment(mixed, "results.jsonl"))
+      .toThrow(/mixes 2 experiment definitions/);
+  });
+
+  it("is enforced by summarizeResults itself", () => {
+    const mixed = [...rows, { ...rows[0], corpus: "other-corpus" }] as ResultRow[];
+    expect(() => summarizeResults(mixed, "results.jsonl")).toThrow(/mixes 2 corpora/);
+  });
+});
+
+describe("a billed error row counts toward the totals", () => {
+  const billed: ResultRow = {
+    ...base, docId: "unparsed-doc", modality: "text-only", requestKey: "k9", status: "error",
+    error: { type: "unparsed", message: "no parsed response (finish_reason: length)", attempts: 1 },
+    usage: { promptTokens: 700, completionTokens: 1024, source: "api" },
+    cost: { modeledUsd: 0.0007, incurredThisRunUsd: 0.0007 }, responseOriginMeta: origin
+  };
+  const summary = summarizeResults([...rows, billed], "results.jsonl");
+  const overall = summary.groups.find((group) => group.runId === "(all runs)")!;
+
+  it("still counts as an error, not a success", () => {
+    expect(overall.statuses).toEqual({ success: 2, refusal: 1, error: 2, skipped: 1 });
+  });
+
+  it("adds its money to the totals, so spend is not understated", () => {
+    expect(overall.cost.incurredUsd).toBeCloseTo(0.0015 + 0.0007, 10);
+    expect(overall.cost.modeledUsd).toBeCloseTo(0.0035 + 0.0007, 10);
+  });
+
+  it("adds its tokens to the totals", () => {
+    expect(overall.tokens.promptTotal).toBe(450 + 700);
+    expect(overall.tokens.completionTotal).toBe(35 + 1024);
+  });
+
+  it("leaves an unbilled error row out of the totals", () => {
+    const unbilled = summarizeResults(rows, "results.jsonl").groups.find((g) => g.runId === "(all runs)")!;
+    expect(unbilled.cost.incurredUsd).toBeCloseTo(0.0015, 10);
+    expect(unbilled.statuses.error).toBe(1);
+  });
+});

--- a/scripts/ai-harness/test/report.test.ts
+++ b/scripts/ai-harness/test/report.test.ts
@@ -1,5 +1,6 @@
 import {
-  assertSingleCorpusAndExperiment, formatSummaryTable, historicalIsComparable, summarizeResults
+  assertSingleCorpusAndExperiment, formatSummaryTable, historicalIsComparable, partitionSuperseded,
+  summarizeResults
 } from "../src/report.js";
 import { ManifestDocument, ResultRow } from "../src/schemas.js";
 import { testRunMeta } from "./helpers.js";
@@ -167,5 +168,73 @@ describe("a billed error row counts toward the totals", () => {
     const unbilled = summarizeResults(rows, "results.jsonl").groups.find((g) => g.runId === "(all runs)")!;
     expect(unbilled.cost.incurredUsd).toBeCloseTo(0.0015, 10);
     expect(unbilled.statuses.error).toBe(1);
+  });
+});
+
+describe("a re-run supersedes the row it replaces", () => {
+  const success = (docId: string, requestKey: string, category: string, tokens: number): ResultRow => ({
+    ...base, docId, modality: "text-only", requestKey, status: "success",
+    response: { parsed: { category }, raw: {} },
+    usage: { promptTokens: tokens, completionTokens: 10, source: "api" },
+    cost: { modeledUsd: 0.001, incurredThisRunUsd: 0.001 }, responseOriginMeta: origin
+  });
+
+  it("keeps the later row and sets the earlier one aside", () => {
+    const { current, superseded } = partitionSuperseded([
+      success("text", "old", "form", 1000), success("text", "new", "function", 1000)
+    ]);
+    expect(current.map((row) => row.requestKey)).toEqual(["new"]);
+    expect(superseded.map((row) => row.requestKey)).toEqual(["old"]);
+  });
+
+  it("counts a re-run document once, not twice", () => {
+    // Editing a prompt and re-running into the same output file used to double every total and split
+    // the category distribution between the old answer and the new one.
+    const summary = summarizeResults(
+      [success("text", "old", "form", 1000), success("text", "new", "function", 1000)], "r.jsonl");
+    const overall = summary.groups.find((group) => group.runId === "(all runs)")!;
+
+    expect(overall.docs).toBe(1);
+    expect(overall.statuses.success).toBe(1);
+    expect(overall.categories).toEqual({ function: 1 });
+    expect(overall.tokens.promptTotal).toBe(1000);
+    expect(overall.cost.incurredUsd).toBeCloseTo(0.001, 10);
+  });
+
+  it("reports the superseded spend rather than losing it", () => {
+    const summary = summarizeResults(
+      [success("text", "old", "form", 1000), success("text", "new", "function", 1000)], "r.jsonl");
+    expect(summary.rows).toBe(2);
+    expect(summary.currentRows).toBe(1);
+    expect(summary.superseded).toEqual({ rows: 1, incurredUsd: 0.001 });
+    expect(formatSummaryTable(summary)).toContain("1 superseded row(s) excluded");
+  });
+
+  it("treats an error followed by a successful retry as one success", () => {
+    const failed: ResultRow = {
+      ...base, docId: "text", modality: "text-only", requestKey: "k", status: "error",
+      error: { type: "APIError", message: "boom", attempts: 3 }
+    };
+    const summary = summarizeResults([failed, success("text", "k", "form", 500)], "r.jsonl");
+    const overall = summary.groups.find((group) => group.runId === "(all runs)")!;
+    expect(overall.statuses).toEqual({ success: 1, refusal: 0, error: 0, skipped: 0 });
+    expect(summary.superseded.rows).toBe(1);
+  });
+
+  it("leaves a file with no re-runs completely unchanged", () => {
+    const summary = summarizeResults(rows, "results.jsonl");
+    expect(summary.superseded).toEqual({ rows: 0, incurredUsd: 0 });
+    expect(summary.currentRows).toBe(rows.length);
+    expect(formatSummaryTable(summary)).not.toContain("superseded");
+  });
+
+  it("keeps distinct documents and runs separate", () => {
+    const summary = summarizeResults([
+      success("text", "a", "form", 100), success("table", "b", "user", 100)
+    ], "r.jsonl");
+    const overall = summary.groups.find((group) => group.runId === "(all runs)")!;
+    expect(overall.docs).toBe(2);
+    expect(overall.statuses.success).toBe(2);
+    expect(summary.superseded.rows).toBe(0);
   });
 });

--- a/scripts/ai-harness/test/schemas.test.ts
+++ b/scripts/ai-harness/test/schemas.test.ts
@@ -1,0 +1,319 @@
+import {
+  ValidationError, canonicalJson, sha256Canonical, validateAiPrompt, validateCorpusManifest,
+  validateExperimentFile, validatePricingConfig, validatePromptFile, validateResultRow
+} from "../src/schemas.js";
+import { projectResponseFormat } from "../src/messages.js";
+import { testRunMeta } from "./helpers.js";
+
+describe("canonical serialization", () => {
+  it("sorts object keys recursively and emits no whitespace", () => {
+    expect(canonicalJson({ b: 1, a: { d: 2, c: [3, { f: 4, e: 5 }] } }))
+      .toBe('{"a":{"c":[3,{"e":5,"f":4}],"d":2},"b":1}');
+  });
+
+  it("hashes values that differ only in key order identically", () => {
+    expect(sha256Canonical({ a: 1, b: 2 })).toBe(sha256Canonical({ b: 2, a: 1 }));
+  });
+
+  it("preserves array order", () => {
+    expect(sha256Canonical([1, 2])).not.toBe(sha256Canonical([2, 1]));
+  });
+
+  it("drops undefined members so they cannot change a hash", () => {
+    expect(canonicalJson({ a: 1, b: undefined })).toBe('{"a":1}');
+  });
+});
+
+describe("validators name the file and the field", () => {
+  it("rejects a manifest with the wrong schema version", () => {
+    expect(() => validateCorpusManifest({ schemaVersion: 2 }, "manifest.json"))
+      .toThrow(/manifest\.json: schemaVersion must be 1/);
+  });
+
+  it("rejects a document id that is not kebab-case", () => {
+    expect(() => validateCorpusManifest({
+      schemaVersion: 1,
+      name: "c",
+      createdAt: "now",
+      documents: [{ id: "Not Valid", file: "documents/x.json", source: "synthetic", contentSha256: "x",
+        computedModality: "empty" }]
+    }, "manifest.json")).toThrow(/manifest\.json: documents\[0\]\.id must match/);
+  });
+
+  it("rejects duplicate document ids", () => {
+    const entry = {
+      id: "a", file: "documents/a.json", source: "synthetic", contentSha256: "x", computedModality: "empty"
+    };
+    expect(() => validateCorpusManifest(
+      { schemaVersion: 1, name: "c", createdAt: "now", documents: [entry, entry] }, "manifest.json"))
+      .toThrow(/duplicate document id "a"/);
+  });
+
+  it("rejects an unknown modality", () => {
+    expect(() => validateCorpusManifest({
+      schemaVersion: 1,
+      name: "c",
+      createdAt: "now",
+      documents: [{ id: "a", file: "documents/a.json", source: "synthetic", contentSha256: "x",
+        computedModality: "mostly-drawn" }]
+    }, "manifest.json")).toThrow(/computedModality must be one of/);
+  });
+
+  it("rejects a pricing config with a non-numeric price", () => {
+    expect(() => validatePricingConfig({
+      schemaVersion: 1,
+      effectiveDate: "2026-08-11",
+      models: { "gpt-4o-mini": { inputPerMTokUsd: "cheap", outputPerMTokUsd: 0.6, maxOutputTokens: 1024 } }
+    }, "pricing.json")).toThrow(/pricing\.json: models\.gpt-4o-mini\.inputPerMTokUsd must be a finite number/);
+  });
+
+  it("throws ValidationError, which carries the file and field", () => {
+    try {
+      validateCorpusManifest({ schemaVersion: 1, name: 1, createdAt: "now", documents: [] }, "manifest.json");
+      throw new Error("expected a ValidationError");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ValidationError);
+      expect((error as ValidationError).field).toBe("name");
+      expect((error as ValidationError).file).toBe("manifest.json");
+    }
+  });
+});
+
+describe("experiment validation", () => {
+  const context = {
+    knownTextVariants: ["default", "minimal"],
+    promptExists: (name: string) => name === "categorize-design-default"
+  };
+  const run = {
+    id: "text-default", message: "text-only", textVariant: "default", prompt: "categorize-design-default"
+  };
+
+  it("accepts the shipped shape", () => {
+    const experiment = validateExperimentFile(
+      { schemaVersion: 1, name: "text-baselines", runs: [run] }, "experiment.json", context);
+    expect(experiment.runs).toHaveLength(1);
+  });
+
+  it("rejects a message shape milestone 1 cannot run", () => {
+    expect(() => validateExperimentFile(
+      { schemaVersion: 1, name: "x", runs: [{ ...run, message: "mixed" }] }, "experiment.json", context))
+      .toThrow(/runs\[0\]\.message must be one of text-only/);
+  });
+
+  it("rejects an unknown text variant", () => {
+    expect(() => validateExperimentFile(
+      { schemaVersion: 1, name: "x", runs: [{ ...run, textVariant: "svg-drawings" }] }, "experiment.json", context))
+      .toThrow(/runs\[0\]\.textVariant must be one of default, minimal/);
+  });
+
+  it("rejects a prompt file that does not exist", () => {
+    expect(() => validateExperimentFile(
+      { schemaVersion: 1, name: "x", runs: [{ ...run, prompt: "nope" }] }, "experiment.json", context))
+      .toThrow(/prompts\/nope\.json/);
+  });
+
+  it("rejects a name that would escape the default results path", () => {
+    // The name becomes a path segment in data/results/<corpus>-<name>.jsonl.
+    for (const name of ["../../escaped", "has spaces", "Capitalised", "with/slash"]) {
+      expect(() => validateExperimentFile(
+        { schemaVersion: 1, name, runs: [run] }, "experiment.json", context))
+        .toThrow(/name must match/);
+    }
+  });
+
+  it("rejects duplicate run ids", () => {
+    expect(() => validateExperimentFile(
+      { schemaVersion: 1, name: "x", runs: [run, run] }, "experiment.json", context))
+      .toThrow(/duplicates an earlier run id/);
+  });
+});
+
+describe("result rows are a discriminated union on status", () => {
+  const common = {
+    schemaVersion: 1,
+    experiment: "text-baselines",
+    experimentSha256: "abc",
+    runId: "text-default",
+    corpus: "synthetic-corpus",
+    docId: "text",
+    modality: "text-only",
+    message: "text-only",
+    textVariant: "default",
+    prompt: { name: "categorize-design-default", sha256: "def" },
+    requestKey: "key",
+    runMeta: testRunMeta
+  };
+  const usage = { promptTokens: 10, completionTokens: 5, source: "api" };
+  const cost = { modeledUsd: 0.0001, incurredThisRunUsd: 0.0001 };
+  const responseOriginMeta = { date: "2026-08-11T00:00:00.000Z", modelReturned: "gpt-4o-mini", systemFingerprint: null };
+
+  it("validates a success row", () => {
+    const row = validateResultRow(
+      { ...common, status: "success", response: { parsed: { category: "form" }, raw: {} }, usage, cost,
+        responseOriginMeta },
+      "results.jsonl");
+    expect(row.status).toBe("success");
+  });
+
+  it("validates a refusal row", () => {
+    const row = validateResultRow(
+      { ...common, status: "refusal", refusal: "no", usage, cost, responseOriginMeta }, "results.jsonl");
+    expect(row.status).toBe("refusal");
+  });
+
+  it("validates an error row", () => {
+    const row = validateResultRow(
+      { ...common, status: "error", error: { type: "APIError", message: "boom", attempts: 3 } }, "results.jsonl");
+    expect(row.status).toBe("error");
+  });
+
+  it("validates a skipped row and requires a null requestKey", () => {
+    const row = validateResultRow(
+      { ...common, status: "skipped", requestKey: null, skipReasons: ["empty document"] }, "results.jsonl");
+    expect(row.status).toBe("skipped");
+    expect(row.requestKey).toBeNull();
+    expect(() => validateResultRow({ ...common, status: "skipped", skipReasons: [] }, "results.jsonl"))
+      .toThrow(/requestKey must be null on a skipped row/);
+  });
+
+  it("rejects a success row that is missing the fields its status requires", () => {
+    expect(() => validateResultRow({ ...common, status: "success", usage, cost, responseOriginMeta }, "results.jsonl"))
+      .toThrow(/response must be an object/);
+    expect(() => validateResultRow(
+      { ...common, status: "refusal", usage, cost, responseOriginMeta }, "results.jsonl"))
+      .toThrow(/refusal must be a string/);
+    expect(() => validateResultRow({ ...common, status: "error" }, "results.jsonl"))
+      .toThrow(/error must be an object/);
+  });
+
+  it("rejects an unknown status", () => {
+    expect(() => validateResultRow({ ...common, status: "degraded" }, "results.jsonl"))
+      .toThrow(/status must be one of success, refusal, error, skipped/);
+  });
+});
+
+describe("the response-format projection", () => {
+  const valid = {
+    type: "json_schema",
+    json_schema: { name: "categorization-response", strict: true, schema: { type: "object" } },
+    $brand: "auto-parseable-response-format",
+    $parseRaw: () => undefined
+  };
+
+  it("keeps only the serializable fields the cache key is built from", () => {
+    expect(projectResponseFormat(valid)).toEqual({
+      type: "json_schema",
+      json_schema: { name: "categorization-response", strict: true, schema: { type: "object" } }
+    });
+  });
+
+  it("accepts a helper that omits strict", () => {
+    const { strict, ...json_schema } = valid.json_schema;
+    expect(projectResponseFormat({ ...valid, json_schema }).json_schema.strict).toBeUndefined();
+  });
+
+  it.each([
+    ["a renamed type", { ...valid, type: "text" }],
+    ["a missing json_schema", { type: "json_schema" }],
+    ["a missing name", { ...valid, json_schema: { schema: {} } }],
+    ["a renamed schema field", { ...valid, json_schema: { name: "x", jsonSchema: {} } }]
+  ])("throws on %s rather than silently dropping it from the key", (_label, shape) => {
+    expect(() => projectResponseFormat(shape)).toThrow(/Unexpected response-format shape/);
+  });
+
+  it("would otherwise collide two different schemas onto one cache key", () => {
+    // Why this is guarded rather than cast: canonicalJson drops undefined, so a renamed schema field
+    // makes every prompt hash to the same key.
+    // The old projection read `.schema`. After a rename that field is undefined for every prompt,
+    // canonicalJson drops it, and the key stops depending on the schema at all.
+    const dropped = (shape: any) => sha256Canonical({
+      type: shape.type, json_schema: { name: shape.json_schema.name, schema: shape.json_schema.schema }
+    });
+    const a = { type: "json_schema", json_schema: { name: "n", jsonSchema: { a: 1 } } };
+    const b = { type: "json_schema", json_schema: { name: "n", jsonSchema: { b: 2 } } };
+    expect(dropped(a)).toBe(dropped(b));
+    expect(() => projectResponseFormat(a)).toThrow();
+  });
+});
+
+describe("aiPrompt validation", () => {
+  const base = { systemPrompt: "You are a teacher.", mainPrompt: "Evaluate this." };
+  const check = (aiPrompt: unknown) => () => validateAiPrompt(aiPrompt, "prompt.json", "aiPrompt");
+
+  it("accepts a full, well-formed prompt", () => {
+    expect(check({ ...base, categories: ["user", "form"], keyIndicatorsPrompt: "k",
+      discussionPrompt: "d", categorizationDescription: "c" })()).toEqual({
+      ...base, categories: ["user", "form"], keyIndicatorsPrompt: "k", discussionPrompt: "d",
+      categorizationDescription: "c"
+    });
+  });
+
+  it("accepts a prompt with only the required fields", () => {
+    expect(check(base)()).toEqual(base);
+  });
+
+  it("rejects a string where categories should be an array", () => {
+    // This is the one that matters: a string passes a loose check and is then spread
+    // character-by-character into the Zod enum, producing a valid-looking but wrong schema.
+    expect(check({ ...base, categories: "user" })).toThrow(/aiPrompt\.categories must be an array/);
+  });
+
+  it("rejects an empty or non-string category", () => {
+    expect(check({ ...base, categories: ["user", "  "] })).toThrow(/categories\[1\] must not be empty/);
+    expect(check({ ...base, categories: ["user", 7] })).toThrow(/categories\[1\] must be a string/);
+  });
+
+  it("rejects duplicate categories", () => {
+    expect(check({ ...base, categories: ["user", "user"] })).toThrow(/duplicate entry "user"/);
+  });
+
+  it('rejects a literal "unknown" category, which the builder adds itself', () => {
+    expect(check({ ...base, categories: ["unknown", "user"] })).toThrow(/must not list "unknown"/);
+  });
+
+  it("rejects non-string optional fields instead of casting them", () => {
+    expect(check({ ...base, discussionPrompt: 42 })).toThrow(/aiPrompt\.discussionPrompt must be a string/);
+    expect(check({ ...base, keyIndicatorsPrompt: {} })).toThrow(/aiPrompt\.keyIndicatorsPrompt must be a string/);
+  });
+
+  it("is what the prompt-file validator uses", () => {
+    expect(() => validatePromptFile({
+      schemaVersion: 1, name: "p", aiPrompt: { ...base, categories: "user" },
+      provenance: { source: "s", retrievedAt: "r", aiPromptSha256: "x" }
+    }, "prompt.json")).toThrow(/aiPrompt\.categories must be an array/);
+  });
+});
+
+describe("error rows may carry what a billed failure cost", () => {
+  const common = {
+    schemaVersion: 1, experiment: "text-baselines", experimentSha256: "abc", runId: "text-default",
+    corpus: "synthetic-corpus", docId: "text", modality: "text-only", message: "text-only",
+    textVariant: "default", prompt: { name: "p", sha256: "d" }, requestKey: "key", runMeta: testRunMeta,
+    status: "error", error: { type: "unparsed", message: "no parsed response", attempts: 1 }
+  };
+  const usage = { promptTokens: 700, completionTokens: 1024, source: "api" };
+  const cost = { modeledUsd: 0.0007, incurredThisRunUsd: 0.0007 };
+  const responseOriginMeta = { date: "2026-08-12T00:00:00.000Z", modelReturned: "gpt-4o-mini", systemFingerprint: null };
+
+  it("validates an error row with all three billing fields", () => {
+    const row = validateResultRow({ ...common, usage, cost, responseOriginMeta }, "results.jsonl");
+    expect(row.status).toBe("error");
+    if (row.status === "error") {
+      expect(row.usage).toEqual(usage);
+      expect(row.cost).toEqual(cost);
+      expect(row.responseOriginMeta).toEqual(responseOriginMeta);
+    }
+  });
+
+  it("validates an error row with none of them", () => {
+    const row = validateResultRow(common, "results.jsonl");
+    if (row.status === "error") expect(row.usage).toBeUndefined();
+  });
+
+  it("rejects a partially billed error row, which a report could not total correctly", () => {
+    expect(() => validateResultRow({ ...common, cost }, "results.jsonl"))
+      .toThrow(/without usage, cost and responseOriginMeta together/);
+    expect(() => validateResultRow({ ...common, usage, responseOriginMeta }, "results.jsonl"))
+      .toThrow(/without usage, cost and responseOriginMeta together/);
+  });
+});

--- a/scripts/ai-harness/test/schemas.test.ts
+++ b/scripts/ai-harness/test/schemas.test.ts
@@ -114,7 +114,7 @@ describe("experiment validation", () => {
 
   it("rejects a name that would escape the default results path", () => {
     // The name becomes a path segment in data/results/<corpus>-<name>.jsonl.
-    for (const name of ["../../escaped", "has spaces", "Capitalised", "with/slash"]) {
+    for (const name of ["../../escaped", "has spaces", "Capitalized", "with/slash"]) {
       expect(() => validateExperimentFile(
         { schemaVersion: 1, name, runs: [run] }, "experiment.json", context))
         .toThrow(/name must match/);

--- a/scripts/ai-harness/test/shared-module.test.ts
+++ b/scripts/ai-harness/test/shared-module.test.ts
@@ -1,0 +1,89 @@
+import fs from "node:fs";
+import path from "node:path";
+import {
+  buildImageMessages, buildSummaryMessages, buildZodResponseSchema, categorizationResponseFormat, defaultAiPrompt
+} from "../../../shared/ai-analysis-messages.js";
+import { repoRoot } from "./helpers.js";
+
+const kForbidden = [/^firebase-functions/, /^firebase-admin/, /^@google-cloud\//, /^firebase$/];
+
+/**
+ * Walks the module graph out from an entry file, following relative imports and collecting the bare
+ * specifiers it reaches. Jest gives no access to its ESM registry, so the "no Firebase in this graph"
+ * assertion is made statically — which also catches a Firebase import added to a transitive
+ * dependency, not only one that happens to execute.
+ */
+/**
+ * Removes line and block comments so a commented-out import is not mistaken for a real one. Without
+ * this, a note like `// we must never import firebase-admin here` fails the check as a false positive.
+ */
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+}
+
+function bareImportsReachableFrom(entry: string): Set<string> {
+  const bare = new Set<string>();
+  const seen = new Set<string>();
+  const queue = [entry];
+
+  while (queue.length > 0) {
+    const file = queue.pop()!;
+    if (seen.has(file)) continue;
+    seen.add(file);
+
+    const source = stripComments(fs.readFileSync(file, "utf8"));
+    const specifiers = [...source.matchAll(/(?:from|import)\s*\(?\s*["']([^"']+)["']/g)].map((match) => match[1]);
+    for (const specifier of specifiers) {
+      if (!specifier.startsWith(".")) {
+        bare.add(specifier);
+        continue;
+      }
+      const base = path.resolve(path.dirname(file), specifier.replace(/\.js$/, ""));
+      const candidate = [base, `${base}.ts`, `${base}.tsx`, path.join(base, "index.ts")]
+        .find((option) => fs.existsSync(option) && fs.statSync(option).isFile());
+      if (candidate) queue.push(candidate);
+    }
+  }
+  return bare;
+}
+
+/**
+ * This is a load-and-run check across the package boundary, not a specification of what the builders
+ * produce — that lives next to the code, in shared/ai-analysis-messages.test.ts. What is being proved
+ * here is that the module resolves and executes from this package's dependency tree, and that pulling
+ * it in drags no Firebase along with it.
+ */
+describe("the shared message builders load and run from the harness", () => {
+  const aiPrompt = defaultAiPrompt;
+
+  it("builds a response schema", () => {
+    expect(Object.keys(buildZodResponseSchema(aiPrompt)).sort())
+      .toEqual(["category", "discussion", "keyIndicators"]);
+  });
+
+  it("builds a response format", () => {
+    const responseFormat = categorizationResponseFormat(buildZodResponseSchema(aiPrompt)) as any;
+    expect(responseFormat.type).toBe("json_schema");
+    expect(responseFormat.json_schema.name).toBe("categorization-response");
+  });
+
+  it("builds image messages", () => {
+    const messages = buildImageMessages(aiPrompt, "https://example.com/doc.png");
+    expect(messages).toHaveLength(2);
+    expect((messages[1].content as any[])[1].type).toBe("image_url");
+  });
+
+  it("builds summary messages", () => {
+    const messages = buildSummaryMessages(aiPrompt, "# CLUE Document Summary", []);
+    expect((messages[1].content as any[])[1].text).toContain("# CLUE Document Summary");
+  });
+
+  it("pulls no Firebase or Firestore module into its graph", () => {
+    const bare = bareImportsReachableFrom(path.join(repoRoot, "shared", "ai-analysis-messages.ts"));
+    const forbidden = [...bare].filter((specifier) => kForbidden.some((pattern) => pattern.test(specifier)));
+    expect(forbidden).toEqual([]);
+    // Sanity check that the walk actually followed the imports, without pinning the complete list:
+    // a legitimate new import in the shared module should not fail this suite.
+    expect([...bare]).toEqual(expect.arrayContaining(["openai/helpers/zod", "zod"]));
+  });
+});

--- a/scripts/ai-harness/test/smoke.test.ts
+++ b/scripts/ai-harness/test/smoke.test.ts
@@ -1,0 +1,179 @@
+import fs from "node:fs";
+import path from "node:path";
+import { main } from "../harness.js";
+import { defaultAiPrompt } from "../../../shared/ai-analysis-messages.js";
+import { buildSummaryMessages } from "../../../shared/ai-analysis-messages.js";
+import { corpusPaths, readRepresentation, representationPath } from "../src/corpus.js";
+import { CompletionRequest, CompletionResult } from "../src/execute.js";
+import { ReportSummary } from "../src/report.js";
+import { ResultRow } from "../src/schemas.js";
+import { makeTestDataRoot, readLines } from "./helpers.js";
+
+/**
+ * Acceptance criterion 12: import -> represent -> plan -> run -> report, driven through the same
+ * argv parsing the CLI uses, with the OpenAI backend replaced by a mock. No network, no API key.
+ */
+describe("end-to-end smoke run against the synthetic corpus", () => {
+  const dataRoot = makeTestDataRoot("smoke");
+  const output: string[] = [];
+  const requests: { model: string; messages: unknown; maxCompletionTokens: number }[] = [];
+  let refusalsRemaining = 1;
+
+  const createCompletion = async ({ request }: CompletionRequest): Promise<CompletionResult> => {
+    requests.push({
+      model: request.model,
+      messages: request.messages,
+      maxCompletionTokens: request.generationSettings.max_completion_tokens
+    });
+    // One refusal so the report exercises more than the success path.
+    if (refusalsRemaining > 0 && String(JSON.stringify(request.messages)).includes("empty CLUE document")) {
+      refusalsRemaining -= 1;
+      return {
+        parsed: null,
+        refusal: "There is not enough here to categorize.",
+        raw: { id: `chatcmpl-${requests.length}` },
+        usage: { promptTokens: 300, completionTokens: 12 },
+        originMeta: { date: "2026-08-11T00:00:00.000Z", modelReturned: "gpt-4o-mini", systemFingerprint: "fp_test" }
+      };
+    }
+    return {
+      parsed: { category: "form", keyIndicators: ["a sketch of the latch"], discussion: "Mostly about form." },
+      raw: { id: `chatcmpl-${requests.length}` },
+      refusal: null,
+      usage: { promptTokens: 900, completionTokens: 60 },
+      originMeta: { date: "2026-08-11T00:00:00.000Z", modelReturned: "gpt-4o-mini", systemFingerprint: "fp_test" }
+    };
+  };
+
+  const deps = {
+    dataRoot,
+    createCompletion,
+    log: (message: string) => output.push(message),
+    now: () => new Date("2026-08-11T00:00:00.000Z")
+  };
+
+  // The default output path names the corpus as well as the experiment (C1), so the same experiment
+  // run against two corpora cannot append into one file.
+  const resultsFile = path.join(dataRoot, "results", "smoke-corpus-text-baselines.jsonl");
+  const paths = corpusPaths(dataRoot, "smoke-corpus");
+
+  it("imports the committed example corpus", async () => {
+    await main(["import", "--from", "examples/synthetic-corpus", "--corpus", "smoke-corpus"], deps);
+    const manifest = JSON.parse(fs.readFileSync(paths.manifest, "utf8"));
+    expect(manifest.schemaVersion).toBe(1);
+    expect(manifest.documents.length).toBe(24);
+    expect(output.join("\n")).toContain("Imported 24 document(s)");
+  });
+
+  it("writes representation envelopes for both text variants", async () => {
+    await main(["represent", "--corpus", "smoke-corpus", "--variants", "default,minimal"], deps);
+    const envelope = readRepresentation(representationPath(paths, "default", "text"));
+    expect(envelope.variantId).toBe("default");
+    expect(envelope.variantVersion).toBe(1);
+    expect(envelope.markdown).toContain("text-fixture-marker");
+    expect(readRepresentation(representationPath(paths, "minimal", "text")).markdown).toContain("text-fixture-marker");
+  });
+
+  it("reuses fresh representations instead of regenerating them", async () => {
+    output.length = 0;
+    await main(["represent", "--corpus", "smoke-corpus", "--variants", "default,minimal"], deps);
+    expect(output.join("\n")).toContain("Wrote 0 representation(s), reused 48");
+  });
+
+  it("plans the run without touching the network", async () => {
+    output.length = 0;
+    await main(["plan", "--corpus", "smoke-corpus", "--experiment", "experiments/text-baselines.json"], deps);
+    const printed = output.join("\n");
+    expect(printed).toContain("2 run(s) × 24 document(s) = 48 call(s)");
+    expect(printed).toContain("max_completion_tokens 1024");
+    expect(printed).toMatch(/Worst-case total \(retries included\): \$\d+\.\d+/);
+    expect(requests).toHaveLength(0);
+  });
+
+  it("runs every pair and writes one JSONL row each", async () => {
+    output.length = 0;
+    await main(["run", "--corpus", "smoke-corpus", "--experiment", "experiments/text-baselines.json",
+      "--max-cost", "1.00"], deps);
+    const rows = readLines(resultsFile) as ResultRow[];
+    expect(rows).toHaveLength(48);
+    expect(new Set(rows.map((row) => `${row.docId} ${row.runId}`)).size).toBe(48);
+
+    // 47, not 48: the image tile contributes nothing to a `minimal` summary, so the image document's
+    // minimal representation is identical to the empty document's — same messages, same request key,
+    // so the second one is served from the cache. That is the cache doing its job.
+    const distinctRequests = new Set(rows.map((row) => row.requestKey));
+    expect(distinctRequests.size).toBe(47);
+    expect(requests.length).toBeGreaterThanOrEqual(distinctRequests.size);
+    expect(requests.length).toBeLessThanOrEqual(48);
+    expect(output.join("\n")).toMatch(/from cache, \d+ API call\(s\)/);
+  });
+
+  it("builds its messages with the shared production builders", () => {
+    const envelope = readRepresentation(representationPath(paths, "default", "text"));
+    const expected = buildSummaryMessages(defaultAiPrompt, envelope.markdown, []);
+    const sent = requests.find((request) => JSON.stringify(request.messages) === JSON.stringify(expected));
+    expect(sent).toBeDefined();
+    expect(sent!.model).toBe("gpt-4o-mini");
+  });
+
+  it("caps every request's completion length", () => {
+    expect(requests.every((request) => request.maxCompletionTokens === 1024)).toBe(true);
+  });
+
+  it("resumes rather than re-running when invoked again", async () => {
+    output.length = 0;
+    const before = requests.length;
+    await main(["run", "--corpus", "smoke-corpus", "--experiment", "experiments/text-baselines.json",
+      "--max-cost", "1.00"], deps);
+    expect(requests).toHaveLength(before);
+    expect(output.join("\n")).toContain("48 already complete");
+  });
+
+  it("refuses --refresh-cache and --no-cache when resume would silently skip everything", async () => {
+    // Resume filtering runs before the cache is consulted, so on a file that already holds completed
+    // rows both flags would otherwise be no-ops — the opposite of what the user asked for.
+    for (const flag of ["--refresh-cache", "--no-cache"]) {
+      await expect(main(["run", "--corpus", "smoke-corpus", "--experiment",
+        "experiments/text-baselines.json", "--max-cost", "1.00", flag], deps))
+        .rejects.toThrow(new RegExp(`\\${flag} asks for fresh API calls`));
+    }
+    // A fresh --output is the way through, and it really does re-execute.
+    const before = requests.length;
+    await main(["run", "--corpus", "smoke-corpus", "--experiment", "experiments/text-baselines.json",
+      "--max-cost", "1.00", "--refresh-cache", "--output",
+      path.join(dataRoot, "results", "refreshed.jsonl")], deps);
+    expect(requests.length).toBeGreaterThan(before);
+  });
+
+  it("reports modality breakdowns, statuses and costs", async () => {
+    output.length = 0;
+    await main(["report", "--results", resultsFile], deps);
+    const table = output[0];
+    expect(table).toContain("text-default");
+    expect(table).toContain("text-minimal");
+    for (const modality of ["text-only", "visual-only", "mixed", "empty"]) expect(table).toContain(modality);
+    expect(table).toContain("(all runs)");
+
+    const summary = JSON.parse(
+      fs.readFileSync(path.join(dataRoot, "results", "summary.json"), "utf8")) as ReportSummary;
+    expect(fs.existsSync(resultsFile)).toBe(true);
+    expect(summary.rows).toBe(48);
+    const overall = summary.groups.find((group) => group.runId === "(all runs)" && group.modality === "all")!;
+    expect(overall.docs).toBe(24);
+    expect(overall.statuses.success + overall.statuses.refusal).toBe(48);
+    expect(overall.statuses.refusal).toBe(1);
+    expect(overall.statuses.error).toBe(0);
+    expect(overall.categories.form).toBe(47);
+    expect(overall.cost.incurredUsd).toBeGreaterThan(0);
+    expect(overall.tokens.total).toBeGreaterThan(0);
+
+    const modalities = new Set(summary.groups.map((group) => group.modality));
+    expect(modalities).toEqual(new Set(["all", "text-only", "visual-only", "mixed", "empty"]));
+  });
+
+  it("keeps everything it generated inside the harness data directory", () => {
+    const relative = path.relative(path.join(dataRoot, "..", ".."), dataRoot);
+    expect(relative.startsWith("..")).toBe(false);
+    expect(fs.existsSync(path.join(dataRoot, "cache"))).toBe(true);
+  });
+});

--- a/scripts/ai-harness/test/smoke.test.ts
+++ b/scripts/ai-harness/test/smoke.test.ts
@@ -145,6 +145,13 @@ describe("end-to-end smoke run against the synthetic corpus", () => {
     expect(requests.length).toBeGreaterThan(before);
   });
 
+  it.each([["represent", ["--variants", "default"]], ["plan", ["--experiment", "experiments/text-baselines.json"]],
+    ["run", ["--experiment", "experiments/text-baselines.json", "--max-cost", "1.00"]]])(
+    "%s refuses a corpus name that escapes the data root", async (command, rest) => {
+      await expect(main([command, "--corpus", "../../escaped", ...rest], deps))
+        .rejects.toThrow(/--corpus must match/);
+    });
+
   it("reports modality breakdowns, statuses and costs", async () => {
     output.length = 0;
     await main(["report", "--results", resultsFile], deps);

--- a/scripts/ai-harness/test/smoke.test.ts
+++ b/scripts/ai-harness/test/smoke.test.ts
@@ -178,6 +178,20 @@ describe("end-to-end smoke run against the synthetic corpus", () => {
     expect(modalities).toEqual(new Set(["all", "text-only", "visual-only", "mixed", "empty"]));
   });
 
+  it("refuses to report on a results file that is not there", async () => {
+    // Silently reporting zero rows turned a mistyped path into an all-zeros table and an empty
+    // summary.json written over the previous one.
+    await expect(main(["report", "--results", path.join(dataRoot, "results", "typo.jsonl")], deps))
+      .rejects.toThrow(/No results file at .*typo\.jsonl/);
+  });
+
+  it("refuses to report on an empty results file", async () => {
+    const empty = path.join(dataRoot, "results", "empty.jsonl");
+    fs.writeFileSync(empty, "");
+    await expect(main(["report", "--results", empty], deps))
+      .rejects.toThrow(/contains no result rows/);
+  });
+
   it("keeps everything it generated inside the harness data directory", () => {
     const relative = path.relative(path.join(dataRoot, "..", ".."), dataRoot);
     expect(relative.startsWith("..")).toBe(false);

--- a/scripts/ai-harness/test/tile-types.test.ts
+++ b/scripts/ai-harness/test/tile-types.test.ts
@@ -1,0 +1,56 @@
+import fs from "node:fs";
+import path from "node:path";
+import { tileTypes } from "../../../shared/tile-types.js";
+import { getTileCapability, missingCapabilityTypes, tileCapabilities } from "../src/capability.js";
+import { repoRoot } from "./helpers.js";
+
+/**
+ * The sync tripwire. `src/register-tile-types.ts` cannot be imported here — it drags in client-side
+ * loading utilities and does not export its registry — so the registration keys are extracted from
+ * the file as text. Registering a new tile type fails this test until shared/tile-types.ts and the
+ * capability registry are both updated.
+ */
+function registeredTileTypes(): string[] {
+  const source = fs.readFileSync(path.join(repoRoot, "src", "register-tile-types.ts"), "utf8");
+  const body = source.slice(source.indexOf("const gTileRegistration"));
+  return [...body.matchAll(/^ {2}"([A-Za-z0-9]+)":\s*loggedLoad\(/gm)].map((match) => match[1]);
+}
+
+/** Registered by top-level imports in register-tile-types.ts rather than through gTileRegistration. */
+const kStaticallyRegistered = ["Placeholder", "Unknown"];
+
+describe("shared/tile-types.ts", () => {
+  it("matches the tile types src/register-tile-types.ts registers", () => {
+    const extracted = registeredTileTypes();
+    expect(extracted.length).toBeGreaterThan(15);
+    expect([...extracted, ...kStaticallyRegistered].sort()).toEqual([...tileTypes].sort());
+  });
+
+  it("lists the two statically registered types", () => {
+    for (const type of kStaticallyRegistered) expect(tileTypes).toContain(type);
+  });
+
+  it("has no duplicates", () => {
+    expect(new Set(tileTypes).size).toBe(tileTypes.length);
+  });
+});
+
+describe("capability registry coverage", () => {
+  it("has a record for every registered tile type", () => {
+    expect(missingCapabilityTypes()).toEqual([]);
+  });
+
+  it.each(tileTypes)("%s has a complete capability record", (tileType) => {
+    const capability = tileCapabilities[tileType];
+    expect(typeof capability.containsStudentText).toBe("boolean");
+    expect(["full", "partial", "stub", "fallback"]).toContain(capability.summaryFidelity);
+    expect(typeof capability.requiresVisualRepresentation).toBe("boolean");
+  });
+
+  it("treats an unregistered type conservatively, as needing an image", () => {
+    const capability = getTileCapability("SomeFutureTile");
+    expect(capability).toEqual({
+      containsStudentText: false, summaryFidelity: "fallback", requiresVisualRepresentation: true
+    });
+  });
+});

--- a/scripts/ai-harness/test/tile-types.test.ts
+++ b/scripts/ai-harness/test/tile-types.test.ts
@@ -10,10 +10,29 @@ import { repoRoot } from "./helpers.js";
  * the file as text. Registering a new tile type fails this test until shared/tile-types.ts and the
  * capability registry are both updated.
  */
-function registeredTileTypes(): string[] {
+function registrationObjectBody(): string {
   const source = fs.readFileSync(path.join(repoRoot, "src", "register-tile-types.ts"), "utf8");
-  const body = source.slice(source.indexOf("const gTileRegistration"));
+  const start = source.indexOf("const gTileRegistration");
+  expect(start).toBeGreaterThan(-1);
+  const end = source.indexOf("\n};", start);
+  expect(end).toBeGreaterThan(start);
+  return source.slice(start, end);
+}
+
+/** Keys registered through the `loggedLoad` helper, which is how every entry is written today. */
+function loggedLoadKeys(body: string): string[] {
   return [...body.matchAll(/^ {2}"([A-Za-z0-9]+)":\s*loggedLoad\(/gm)].map((match) => match[1]);
+}
+
+/**
+ * Every quoted property key in the object, whatever it is assigned. Deliberately permissive about
+ * indentation and about the right-hand side: a registration written with a different loader helper,
+ * or reindented by a reformat, is invisible to `loggedLoadKeys` — and would also be missing from
+ * shared/tile-types.ts, so the two sets would still agree and the tripwire would pass without ever
+ * having looked at the new entry. Comparing the two extractions is what makes that impossible.
+ */
+function quotedKeys(body: string): string[] {
+  return [...body.matchAll(/^\s*"([A-Za-z0-9]+)"\s*:/gm)].map((match) => match[1]);
 }
 
 /** Registered by top-level imports in register-tile-types.ts rather than through gTileRegistration. */
@@ -21,9 +40,16 @@ const kStaticallyRegistered = ["Placeholder", "Unknown"];
 
 describe("shared/tile-types.ts", () => {
   it("matches the tile types src/register-tile-types.ts registers", () => {
-    const extracted = registeredTileTypes();
+    const extracted = loggedLoadKeys(registrationObjectBody());
     expect(extracted.length).toBeGreaterThan(15);
     expect([...extracted, ...kStaticallyRegistered].sort()).toEqual([...tileTypes].sort());
+  });
+
+  it("sees every entry in the registration object, however it is written", () => {
+    // Guards the extractor itself: if these disagree, the loggedLoad pattern has stopped seeing a
+    // registration and the check above would have compared a short list against a short list.
+    const body = registrationObjectBody();
+    expect(quotedKeys(body).sort()).toEqual(loggedLoadKeys(body).sort());
   });
 
   it("lists the two statically registered types", () => {

--- a/scripts/ai-harness/test/versions.test.ts
+++ b/scripts/ai-harness/test/versions.test.ts
@@ -3,9 +3,9 @@ import path from "node:path";
 import { repoRoot } from "./helpers.js";
 
 /**
- * Acceptance criterion 3. `shared/` has its own openai and zod so the harness can import
+ * `shared/` has its own openai and zod so the harness can import
  * shared/ai-analysis-messages.ts directly, while the deployed function resolves both from
- * functions-v2/node_modules. Behaviour parity requires the versions to be identical, and nothing
+ * functions-v2/node_modules. Behavior parity requires the versions to be identical, and nothing
  * else would notice if they drifted.
  */
 const lockfiles = {

--- a/scripts/ai-harness/test/versions.test.ts
+++ b/scripts/ai-harness/test/versions.test.ts
@@ -1,0 +1,48 @@
+import fs from "node:fs";
+import path from "node:path";
+import { repoRoot } from "./helpers.js";
+
+/**
+ * Acceptance criterion 3. `shared/` has its own openai and zod so the harness can import
+ * shared/ai-analysis-messages.ts directly, while the deployed function resolves both from
+ * functions-v2/node_modules. Behaviour parity requires the versions to be identical, and nothing
+ * else would notice if they drifted.
+ */
+const lockfiles = {
+  shared: path.join(repoRoot, "shared", "package-lock.json"),
+  "functions-v2": path.join(repoRoot, "functions-v2", "package-lock.json"),
+  "scripts/ai-harness": path.join(repoRoot, "scripts", "ai-harness", "package-lock.json")
+};
+
+function resolvedVersion(lockfile: string, packageName: string): string {
+  const lock = JSON.parse(fs.readFileSync(lockfile, "utf8"));
+  const entry = lock.packages?.[`node_modules/${packageName}`];
+  if (!entry?.version) {
+    throw new Error(`${lockfile} does not resolve a top-level "${packageName}"`);
+  }
+  return entry.version;
+}
+
+describe("openai and zod versions stay in lockstep", () => {
+  for (const packageName of ["openai", "zod"]) {
+    it(`resolves the same ${packageName} in all three lockfiles`, () => {
+      const versions = Object.fromEntries(
+        Object.entries(lockfiles).map(([name, file]) => [name, resolvedVersion(file, packageName)]));
+      const distinct = new Set(Object.values(versions));
+      expect({ ...versions, distinct: distinct.size }).toEqual({ ...versions, distinct: 1 });
+    });
+  }
+
+  it("pins exact versions in shared/package.json and scripts/ai-harness/package.json", () => {
+    for (const dir of ["shared", path.join("scripts", "ai-harness")]) {
+      const manifest = JSON.parse(fs.readFileSync(path.join(repoRoot, dir, "package.json"), "utf8"));
+      // Merged rather than indexed off `dependencies` directly, so a package.json that moved or
+      // dropped the block fails the assertion instead of throwing a TypeError.
+      const declared = { ...manifest.devDependencies, ...manifest.dependencies };
+      for (const packageName of ["openai", "zod"]) {
+        expect(`${dir}: ${packageName}@${declared[packageName]}`)
+          .toMatch(/@\d+\.\d+\.\d+$/);
+      }
+    }
+  });
+});

--- a/scripts/ai-harness/tsconfig.json
+++ b/scripts/ai-harness/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    // Not "nodenext": shared/ is ESM with extensionless relative imports, which NodeNext rejects
+    // (TS2835). See DEVIATIONS item 1 in README.md.
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+    "lib": ["es2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node", "jest"]
+  },
+  "include": ["harness.ts", "src/**/*", "test/**/*"]
+}

--- a/shared/tile-types.ts
+++ b/shared/tile-types.ts
@@ -1,0 +1,40 @@
+/**
+ * The authoritative list of tile types CLUE registers.
+ *
+ * This module deliberately has no imports: it is loaded by the browser app, by node scripts and by
+ * the evaluation harness (scripts/ai-harness), none of which should have to drag in the client-side
+ * loading utilities that `src/register-tile-types.ts` uses.
+ *
+ * The first 20 entries mirror the keys of `gTileRegistration` in `src/register-tile-types.ts`, in the
+ * same order. `Placeholder` and `Unknown` are registered statically by that file's top-level imports
+ * rather than through `gTileRegistration`, so they are listed last.
+ *
+ * A test in scripts/ai-harness (test/tile-types.test.ts) parses `src/register-tile-types.ts` and fails
+ * if the two lists drift apart, so a newly registered tile type has to be added here as well.
+ */
+export const tileTypes = [
+  "Question",
+  "AI",
+  "BarGraph",
+  "DataCard",
+  "Dataflow",
+  "Diagram",
+  "Drawing",
+  "ErrorTest",
+  "Expression",
+  "Geometry",
+  "Graph",
+  "Image",
+  "IframeInteractive",
+  "Numberline",
+  "Simulator",
+  "Starter",
+  "Table",
+  "Text",
+  "Timeline",
+  "WaveRunner",
+  "Placeholder",
+  "Unknown"
+] as const;
+
+export type TileType = typeof tileTypes[number];


### PR DESCRIPTION
[CLUE-371](https://concord-consortium.atlassian.net/browse/CLUE-371)

Adds `scripts/ai-harness/`, a checked-in tool that runs (representation × prompt × message-shape) experiments against a corpus of CLUE documents and reports quality inputs plus token and cost numbers.

Plan: [docs/plans/CLUE-371-harness-plan.md](docs/plans/CLUE-371-harness-plan.md) · Spec for this milestone: [docs/plans/CLUE-371-harness-implementation-1.md](docs/plans/CLUE-371-harness-implementation-1.md) (added by this PR)

## What's here

Milestone 1 builds the frame and proves it on the text path end to end:

| | |
|---|---|
| **Corpus** | `import` copies documents into `data/corpus/<name>/` and generates a validated manifest. Document ids, content hashes, computed vs. human-overridden modality. |
| **Representation** | `represent` renders text variants (`default`, `minimal`) by wrapping `shared/ai-summarizer`, into envelopes that record what produced them. |
| **Messages** | Every request is built by `shared/ai-analysis-messages` — the same code the deployed function calls. The harness chooses inputs; it never formats a request itself. |
| **Execution** | `run` calls `gpt-4o-mini` with bounded concurrency, retries, a required spend ceiling, a response cache, and JSONL results that resume. |
| **Reporting** | `report` writes a stdout table and `summary.json`, grouped per run configuration × modality. |

Plus `shared/tile-types.ts`: an import-safe list of every registered tile type, because `src/register-tile-types.ts` can't be imported outside the client.

## Design points worth a reviewer's attention

- **`max_completion_tokens` is set on every request** (1024). This is a deliberate deviation from production, which sets no cap — without it the cost reservation bounds nothing. Production should probably adopt the same cap; noted in the README.
- **`--max-cost` is required, with no unlimited mode.** Each call reserves a worst case before dispatch; a reservation that would cross the ceiling stops scheduling. `plan` and `run` share one formula, so a plan's projection is never lower than what a run can reserve. The README is explicit about the two edges where it's an *enforced* bound rather than a mathematical guarantee.
- **Refusals are cached; errors are not.** A refusal is a real API response that cost real money. A response with neither parsed content nor a refusal becomes an `error` row, matching how production treats a missing `parsed`.
- **Resume identity is the request key** plus corpus and experiment hash — so a changed document, prompt, representation or generation setting re-runs automatically, while true duplicates skip.
- **Data safety.** Everything derived from a document lands under `scripts/ai-harness/data/`, which is gitignored; `--output` and `--results` are refused if they resolve outside it. Nothing in this milestone touches production data, credentials or `firebase-admin`.

## Files outside `scripts/ai-harness/`

Six, all small:

- `shared/tile-types.ts` — new, no imports
- `.gitignore` — ignores `scripts/ai-harness/data/`
- `package.json` — root jest skips `scripts/ai-harness` (its tests are ESM and can't run under the root CommonJS runner)
- `.github/workflows/ci.yml` — installs and runs the harness tests in the existing `jest` job
- `functions-v2/test/ai-analysis-messages-integration.test.ts` — corrects one misleading comment
- `docs/plans/CLUE-371-harness-implementation-1.md` — the spec

**Why the harness tests run on every PR rather than behind a path filter:** five of the fourteen suites are tripwires on production code, not tests of the harness. They fail when a tile type is registered without a capability record, when the committed copy of the default AI prompt drifts from `shared/`, when the `openai`/`zod` versions in `shared/`, `functions-v2/` and the harness fall out of lockstep, when a Firebase import appears in the shared message builders, or when a tile summarizer stops carrying content through. Nobody changing that code would think to run these by hand, and the changes they catch land in `src/` and `shared/` — so a path filter on `scripts/ai-harness/**` would exclude exactly the cases the tests exist for. Cost is about 20–40s on a job that already runs 3,600 tests.

## Trying it

```bash
cd scripts/ai-harness
npm ci
npx tsx harness.ts import    --from examples/synthetic-corpus --corpus synthetic-corpus
npx tsx harness.ts represent --corpus synthetic-corpus --variants default,minimal
npx tsx harness.ts plan      --corpus synthetic-corpus --experiment experiments/text-baselines.json
```

`plan` needs no network and no key, and reports a worst case of **$0.1034** for both text baselines across all 24 documents. `run` additionally needs `OPENAI_API_KEY` in `scripts/.env`.

## Testing

- `scripts/ai-harness`: `npm ci`, `npm run typecheck`, **338 tests in 14 suites**, all passing.
- Includes a mocked end-to-end smoke test driving the real CLI through `import → represent → plan → run → report` with no network.
- `functions-v2` and the root suite are unaffected and passing.

The committed synthetic corpus is **24 documents covering all 22 registered tile types**, plus a mixed and an empty document, with `expectations.json` recording what each should classify and summarize as. It's the regression suite for summarizer changes as much as it is input for the harness.

## Not in this milestone

Images (M2); mixed mode, skip-empty execution, extras variants (M3); the HTML review report (M4); rubric scoring and any quality conclusion (M5); the production corpus pull and anything touching real student work (M6). The `findRelatedSummaries` production bug is a separate small PR.

## Review notes

- **Where to start:** `README.md`, then `src/schemas.ts` (all file formats and the canonical hashing), then `harness.ts`. The tests are about half the diff.
- **DEVIATIONS** at the bottom of `scripts/ai-harness/README.md` records the ten places the implementation departs from the spec and why — worth a skim, particularly item 1 (`moduleResolution: "bundler"` rather than `nodenext`, because `shared/` is ESM with extensionless imports).
- **Acceptance criterion 13** (a real run under $0.50) has been verified by hand; the rest are covered by the test suite.


[CLUE-371]: https://concord-consortium.atlassian.net/browse/CLUE-371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ