### PR TITLE
fix: `findRelatedSummaries` returns student's own summary instead of related summaries (CLUE-630)

### DIFF
--- a/functions-v2/lib/src/ai-categorize-document.ts
+++ b/functions-v2/lib/src/ai-categorize-document.ts
@@ -22,15 +22,21 @@ interface IAiPrompt {
   discussionPrompt?: string;
 }
 
-interface AgreementInfo {
+export interface AgreementInfo {
   content: string,
   tags: string[],
 }
-type Agreements = Record<AgreementValue, AgreementInfo[]>
+export type Agreements = Partial<Record<AgreementValue, AgreementInfo[]>>
 
-interface RelatedSummary {
+export interface RelatedSummary {
   summary: string;
   agreements: Agreements;
+}
+
+/** The fields `mapRelatedSummaries` reads off a document returned by the related-summaries search. */
+export interface RelatedSummarySource {
+  summary?: unknown;
+  aiAgreements?: Record<string, AiAgreement>;
 }
 
 const defaultAiPrompt: IAiPrompt = {
@@ -202,32 +208,24 @@ async function findRelatedSummaries(summary: string, apiKey: string, firestoreDo
       distanceMeasure: "EUCLIDEAN",
     });
   const snapshot = await query.get();
-  const docs: RelatedSummarySource[] = [];
-  snapshot.forEach((doc) => docs.push(doc.data() as RelatedSummarySource));
-  return mapRelatedSummaries(docs);
-}
-
-export interface RelatedSummarySource {
-  summary?: unknown;
-  aiAgreements?: Record<string, AiAgreement>;
+  return mapRelatedSummaries(snapshot.docs.map((doc) => doc.data() as RelatedSummarySource));
 }
 
 /**
  * Maps the documents found by the related-summaries search into the entries injected into the AI
- * prompt. Documents missing `aiAgreements` (null/undefined)  or a usable summary are skipped.
- * Exported for unit testing.
+ * prompt. A document with an empty `aiAgreements` map still yields an entry; only a missing map is
+ * skipped. Exported for unit testing.
  */
 export function mapRelatedSummaries(docs: RelatedSummarySource[]): RelatedSummary[] {
   const relatedSummaries: RelatedSummary[] = [];
   for (const data of docs) {
-    const aiAgreements = data.aiAgreements || undefined;
-    if (aiAgreements && typeof data.summary === "string" && data.summary.length > 0) {
-      const agreements = Object.values(aiAgreements).reduce<Agreements>((acc, cur) => {
+    if (data.aiAgreements && typeof data.summary === "string" && data.summary.length > 0) {
+      const agreements = Object.values(data.aiAgreements).reduce<Agreements>((acc, cur) => {
         const value = cur.value as AgreementValue;
         acc[value] = acc[value] || [];
         acc[value].push({content: cur.content, tags: cur.tags});
         return acc;
-      }, {} as Agreements);
+      }, {});
       relatedSummaries.push({
         summary: data.summary,
         agreements,

--- a/functions-v2/lib/src/ai-categorize-document.ts
+++ b/functions-v2/lib/src/ai-categorize-document.ts
@@ -202,10 +202,26 @@ async function findRelatedSummaries(summary: string, apiKey: string, firestoreDo
       distanceMeasure: "EUCLIDEAN",
     });
   const snapshot = await query.get();
+  const docs: RelatedSummarySource[] = [];
+  snapshot.forEach((doc) => docs.push(doc.data() as RelatedSummarySource));
+  return mapRelatedSummaries(docs);
+}
+
+/** The relevant fields of a document found by the related-summaries search. */
+export interface RelatedSummarySource {
+  summary?: unknown;
+  aiAgreements?: Record<string, AiAgreement>;
+}
+
+/**
+ * Maps the documents found by the related-summaries search into the entries injected into the AI
+ * prompt. Documents without agreements or a usable summary are skipped. Exported for unit testing.
+ */
+export function mapRelatedSummaries(docs: RelatedSummarySource[]): RelatedSummary[] {
   const relatedSummaries: RelatedSummary[] = [];
-  snapshot.forEach((doc) => {
-    const aiAgreements: Record<AgreementValue, AiAgreement> = doc.data().aiAgreements || undefined;
-    if (aiAgreements) {
+  for (const data of docs) {
+    const aiAgreements = data.aiAgreements || undefined;
+    if (aiAgreements && typeof data.summary === "string" && data.summary.length > 0) {
       const agreements = Object.values(aiAgreements).reduce<Agreements>((acc, cur) => {
         const value = cur.value as AgreementValue;
         acc[value] = acc[value] || [];
@@ -213,11 +229,11 @@ async function findRelatedSummaries(summary: string, apiKey: string, firestoreDo
         return acc;
       }, {} as Agreements);
       relatedSummaries.push({
-        summary,
+        summary: data.summary,
         agreements,
       });
     }
-  });
+  }
   return relatedSummaries;
 }
 

--- a/functions-v2/lib/src/ai-categorize-document.ts
+++ b/functions-v2/lib/src/ai-categorize-document.ts
@@ -207,7 +207,6 @@ async function findRelatedSummaries(summary: string, apiKey: string, firestoreDo
   return mapRelatedSummaries(docs);
 }
 
-/** The relevant fields of a document found by the related-summaries search. */
 export interface RelatedSummarySource {
   summary?: unknown;
   aiAgreements?: Record<string, AiAgreement>;
@@ -215,7 +214,8 @@ export interface RelatedSummarySource {
 
 /**
  * Maps the documents found by the related-summaries search into the entries injected into the AI
- * prompt. Documents without agreements or a usable summary are skipped. Exported for unit testing.
+ * prompt. Documents missing `aiAgreements` (null/undefined)  or a usable summary are skipped.
+ * Exported for unit testing.
  */
 export function mapRelatedSummaries(docs: RelatedSummarySource[]): RelatedSummary[] {
   const relatedSummaries: RelatedSummary[] = [];

--- a/functions-v2/test/map-related-summaries.test.ts
+++ b/functions-v2/test/map-related-summaries.test.ts
@@ -1,0 +1,74 @@
+import {AiAgreement} from "../src/on-document-summarized";
+import {mapRelatedSummaries, RelatedSummarySource} from "../lib/src/ai-categorize-document";
+
+jest.mock("firebase-functions/logger");
+
+function agreement(value: AiAgreement["value"], content = "a comment", tags: string[] = []): AiAgreement {
+  return {version: 1, value, content, tags};
+}
+
+describe("mapRelatedSummaries", () => {
+  it("returns each found document's own summary", () => {
+    const docs: RelatedSummarySource[] = [
+      {summary: "Summary of related document ONE", aiAgreements: {c1: agreement("yes")}},
+      {summary: "Summary of related document TWO", aiAgreements: {c2: agreement("no")}},
+    ];
+
+    const result = mapRelatedSummaries(docs);
+
+    expect(result.map((entry) => entry.summary)).toEqual([
+      "Summary of related document ONE",
+      "Summary of related document TWO",
+    ]);
+  });
+
+  it("groups agreements by value with their content and tags", () => {
+    const docs: RelatedSummarySource[] = [{
+      summary: "A related summary",
+      aiAgreements: {
+        c1: agreement("yes", "spot on", ["user"]),
+        c2: agreement("yes", "agreed"),
+        c3: agreement("notSure", "hmm"),
+      },
+    }];
+
+    const [entry] = mapRelatedSummaries(docs);
+
+    expect(entry.agreements.yes).toEqual([
+      {content: "spot on", tags: ["user"]},
+      {content: "agreed", tags: []},
+    ]);
+    expect(entry.agreements.notSure).toEqual([{content: "hmm", tags: []}]);
+    expect(entry.agreements.no).toBeUndefined();
+  });
+
+  it("skips documents without agreements", () => {
+    const docs: RelatedSummarySource[] = [
+      {summary: "No agreements here"},
+      {summary: "Empty agreements", aiAgreements: {}},
+      {summary: "Has agreements", aiAgreements: {c1: agreement("yes")}},
+    ];
+
+    // An empty aiAgreements object is truthy, so it passes the guard and yields an entry with no
+    // grouped agreements — matching the original behavior; only a missing map is skipped.
+    expect(mapRelatedSummaries(docs).map((entry) => entry.summary)).toEqual([
+      "Empty agreements",
+      "Has agreements",
+    ]);
+  });
+
+  it("skips documents whose summary is missing, non-string, or empty", () => {
+    const docs: RelatedSummarySource[] = [
+      {aiAgreements: {c1: agreement("yes")}},
+      {summary: 42, aiAgreements: {c1: agreement("yes")}},
+      {summary: "", aiAgreements: {c1: agreement("yes")}},
+      {summary: "The only usable one", aiAgreements: {c1: agreement("yes")}},
+    ];
+
+    expect(mapRelatedSummaries(docs).map((entry) => entry.summary)).toEqual(["The only usable one"]);
+  });
+
+  it("returns an empty list for no documents", () => {
+    expect(mapRelatedSummaries([])).toEqual([]);
+  });
+});

--- a/functions-v2/test/map-related-summaries.test.ts
+++ b/functions-v2/test/map-related-summaries.test.ts
@@ -1,9 +1,10 @@
 import {AiAgreement} from "../src/on-document-summarized";
+import {AgreementValue} from "../../shared/shared";
 import {mapRelatedSummaries, RelatedSummarySource} from "../lib/src/ai-categorize-document";
 
 jest.mock("firebase-functions/logger");
 
-function agreement(value: AiAgreement["value"], content = "a comment", tags: string[] = []): AiAgreement {
+function agreement(value: AgreementValue, content = "a comment", tags: string[] = []): AiAgreement {
   return {version: 1, value, content, tags};
 }
 
@@ -42,15 +43,14 @@ describe("mapRelatedSummaries", () => {
     expect(entry.agreements.no).toBeUndefined();
   });
 
-  it("skips documents without agreements", () => {
+  it("skips documents with no aiAgreements map, but keeps an empty one", () => {
     const docs: RelatedSummarySource[] = [
       {summary: "No agreements here"},
       {summary: "Empty agreements", aiAgreements: {}},
       {summary: "Has agreements", aiAgreements: {c1: agreement("yes")}},
     ];
 
-    // An empty aiAgreements object is truthy, so it passes the guard and yields an entry with no
-    // grouped agreements — matching the original behavior; only a missing map is skipped.
+    // Matches the original behavior: an empty map yields an entry with no grouped agreements.
     expect(mapRelatedSummaries(docs).map((entry) => entry.summary)).toEqual([
       "Empty agreements",
       "Has agreements",


### PR DESCRIPTION
Fixes [CLUE-630](https://concord-consortium.atlassian.net/browse/CLUE-630): `findRelatedSummaries()` in `functions-v2/lib/src/ai-categorize-document.ts` returned the analyzed document's own summary for every related document it found, instead of each found document's stored summary.

The bug was a one-word variable mix-up: the loop pushed the object-shorthand `summary` — the function's input parameter — where it should have read `doc.data().summary`. The found documents' summaries were never read at all. The effect was that the "similar documents" context injected into the text-path AI prompt contained up to five copies of the student's own summary, while the teacher-agreement counts attached to each entry (which *were* read correctly) implied they were other students' work.

## Production impact

None observed. Verified against production on 2026-08-11 (read-only check plus a 30-day log search): the entire `summaries` collection contains a single demo-class document, alone in its class/unit/problem/investigation context, so the search — which excludes the document being analyzed — has never returned results for real data.

## Changes

- `findRelatedSummaries()` now delegates the result mapping to a new exported pure function, `mapRelatedSummaries()`, which uses each found document's own summary.
- The mapping binds `doc.data()` once and defensively skips documents whose `summary` is missing, non-string, or empty.
- One pre-existing behavior is deliberately preserved: a document with an *empty* `aiAgreements` object still yields an entry (only a missing map is skipped). The query filters on `numAiAgreements > 0`, so the case is theoretical; this PR doesn't change more behavior than it claims.
- New test file `functions-v2/test/map-related-summaries.test.ts` — first coverage for this logic (5 tests): each entry carries that document's own summary (fails against the pre-fix code), agreement grouping with content/tags, and the skip rules. The extraction also makes the original mistake structurally unrepeatable, since the analyzed document's summary is no longer in scope in the mapping.

## Testing

- `npx jest test/map-related-summaries.test.ts` — 5/5 pass
- Full `functions-v2` suite (with emulators) — passing
- `npm run build` in `functions-v2` — clean

NOTE: The failed test here in `functional/document_tests/tiles_copy_test_spec.js` is due to [this pre-existing bug ](https://concord-consortium.atlassian.net/browse/CLUE-622). It's not related to these changes.

[CLUE-630]: https://concord-consortium.atlassian.net/browse/CLUE-630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ