### PR TITLE
feat: AI harness milestone 3 (CLUE-371)

### DIFF
--- a/scripts/ai-harness/README.md
+++ b/scripts/ai-harness/README.md
@@ -4,12 +4,15 @@ A checked-in tool that runs (representation × prompt × message-shape) experime
 CLUE documents and reports quality inputs plus token and cost numbers — so text-only vs. image-only
 vs. mixed-mode claims are backed by measurements instead of intuition.
 
-This is **milestone 2** of [CLUE-371](../../docs/plans/CLUE-371-harness-plan.md). Milestone 1 built
+This is **milestone 3** of [CLUE-371](../../docs/plans/CLUE-371-harness-plan.md). Milestone 1 built
 the shared message builders, the harness skeleton, a synthetic corpus, text-only runs, the response
-cache, the spend ceiling, and reports as data. Milestone 2 adds the other production representation
-— the screenshot — so image-only baselines can run against the same corpus. Mixed mode (milestone 3),
-the HTML review report (milestone 4), rubric scoring (milestone 5) and the production corpus pull
-(milestone 6) are not here yet.
+cache, the spend ceiling, and reports as data. Milestone 2 added the other production representation
+— the screenshot — so image-only baselines could run against the same corpus. Milestone 3 adds the
+message the whole question is about, text **and** picture together, plus the dimensions an
+experiment needs to turn around it: image detail, per-tile and visual-tiles-only image sets, the
+three extras settings, two new text variants, and skip-empty execution. The HTML review report
+(milestone 4), rubric scoring (milestone 5) and the production corpus pull (milestone 6) are not
+here yet.
 
 All runs target `gpt-4o-mini`. That is deliberately the rolling alias, not a pinned snapshot:
 production calls the alias, and a harness that pinned a snapshot would stop measuring what production
@@ -79,10 +82,10 @@ OPENAI_API_KEY=sk-…
 npx tsx harness.ts import    --from examples/synthetic-corpus --corpus synthetic-corpus \
                              [--source synthetic|demo|qa] [--prune]
 npx tsx harness.ts represent --corpus synthetic-corpus --variants default,minimal
-npx tsx harness.ts render    --corpus synthetic-corpus \
-                             --mode puppeteer-full-height|shutterbug-production-current|shutterbug-parameterized \
+npx tsx harness.ts render    --corpus synthetic-corpus --mode <mode> \
                              [--clue-url <url>] [--unit <unit>] [--shutterbug-url <url>] \
-                             [--capture-height <px>] [--refresh]
+                             [--capture-height <px>] [--refresh] \
+                             [--concurrency <n>] [--timeout-ms <n>]
 npx tsx harness.ts plan      --corpus synthetic-corpus --experiment experiments/image-vs-text.json
 npx tsx harness.ts run       --corpus synthetic-corpus --experiment experiments/text-baselines.json \
                              --max-cost 0.50 [--output <file>] [--no-cache | --refresh-cache]
@@ -91,10 +94,15 @@ npx tsx harness.ts report    --results data/results/synthetic-corpus__text-basel
 
 Flags are plain `--name value` pairs. An unknown flag is an error, not a warning.
 
-`plan` on the committed synthetic corpus projects a worst case of about **$0.11** for both text
-baselines across all 25 documents, and roughly **$0.22** more for the image-only run — a full worst
-case of about **$0.33** for all three, which is the figure the recorded `image-vs-text` run below
-reports. Image tokens dominate, and the reservation assumes every retry is used.
+`plan` on the committed synthetic corpus projects a worst case of about **$0.03** for both text
+baselines — 14 calls, because skip-empty sends a text run only the documents that carry
+student-authored text (7 of 26), and records the other 19 as skipped rows. Image runs send every
+document that has any content at all, so they are both larger and dominated by image tokens; run
+`plan` after rendering to see the figure for a particular mode and image set, since a per-tile set
+multiplies the count. The reservation assumes every retry is used.
+
+The recorded run further down is a real `mixed-vs-baselines` run against this corpus as it now
+stands.
 
 ## Data safety
 
@@ -143,10 +151,25 @@ Staleness is decided by the envelope, not by the file existing: a representation
 `sourceContentSha256` and `variantVersion` both still match. Each variant in `src/represent-text.ts`
 exports a `variantVersion` that is bumped whenever its output would change for the same input.
 
-Variants: `default` and `minimal`. The `svg-drawings` variant
-(`documentSummarizerWithDrawings`) is **not** included — it imports `src/plugins/drawing`, which
-imports `.svg` assets that only a bundler can load, so it does not run under `tsx` without build
-gymnastics. It is a candidate for a later milestone.
+| Variant | What it sends |
+|---|---|
+| `default` | `documentSummarizer(content, {})` — what production produces. |
+| `minimal` | No boilerplate, headers or row/column structure: the text content and nothing else. |
+| `no-dataset-tables` | `default`, with each data set's *case data* left out. The heading, attributes table, formulas and case count stay, so the shape of the data is still described. A large table can be most of a document's summary, and whether a model needs the rows to categorize a design is worth measuring rather than assuming. |
+| `drawing-text` | `default`, with drawings **described** instead of merely mentioned: each object's type, position and size, and any text object's own text. The default handler says "This tile contains a drawing" and stops, so a text run otherwise learns nothing about what was drawn — including text a student typed *inside* a drawing, which no other text variant carries. |
+
+`drawing-text` is a measurement prototype, not a good description: it reports geometry and does not
+interpret it, because interpreting the picture is what the model is being measured on. Beating it is
+the point, and a new variant is how someone shows they have.
+
+Two further ways to shrink a data set — sending a fixed sample of cases, and sending aggregate
+statistics — are named in the plan and not built. Both are variants of their own when someone wants
+to measure them.
+
+The `svg-drawings` variant (`documentSummarizerWithDrawings`) is **not** included — it imports
+`src/plugins/drawing`, which imports `.svg` assets that only a bundler can load, so it does not run
+under `tsx` without build gymnastics. `drawing-text` exists because that limitation is not going
+away soon.
 
 ### Image representations
 
@@ -165,9 +188,10 @@ gymnastics. It is a candidate for a later milestone.
     "purpose": "full-document" }] }
 ```
 
-`images` is an array from the start so milestone 3's per-tile capture is additive, but **request
-construction requires exactly one**: zero and many both fail, and the first is never silently
-selected.
+`images` was an array from the start, which is what made per-tile capture additive. **Which** of an
+envelope's images a run sends is chosen by its `imageSet`, never inferred: a `full-document` run
+takes the one full-document picture and refuses an envelope that has none, rather than sending
+whatever happened to be first.
 
 Freshness checks the files, not just the envelope. A stored render is reused only when the content
 hash, mode, backend and backend version all match **and** every PNG it names still exists, still
@@ -185,6 +209,8 @@ modes are named and separate, and an improvement never gets folded into the base
 | `puppeteer-full-height` (default) | local | `--clue-url`, default `http://localhost:8080` | harness's own | full document, 960px wide |
 | `shutterbug-production-current` | yes | production's `branch/shutterbug-support` | `mods` | `height: 1500`, no `fullPage` |
 | `shutterbug-parameterized` | yes | `--clue-url`, default production's `branch/shutterbug-support` | `--unit`, default `mods` | `--capture-height`, default 1500; `--shutterbug-url`, default **staging** |
+| `puppeteer-per-tile` | local | `--clue-url`, default `http://localhost:8080` | harness's own | one image per top-level tile |
+| `shutterbug-accurate-height` | yes | `--clue-url`, default production's branch | `--unit`, default `mods` | each document's **own measured height** — needs a `puppeteer-full-height` render of the same corpus first |
 
 **`shutterbug-production-current` is the parity baseline.** It matches production's request envelope
 — the production endpoint, the `branch/shutterbug-support` CLUE URL, `unit=mods`, `height: 1500`, no
@@ -259,16 +285,22 @@ or other assets from elsewhere. If offline operation ever has to be a guarantee,
 intercept and reject non-localhost requests, and a test must assert it.
 
 **A cold dev server can time out the first documents in a run.** `render` drives four pages at a
-time, and the 30-second budget is *per document, covering load, readiness and the capture together*.
-Against a `npm start` server that is still compiling chunks on demand, the first batch pays that
-compile cost and the capture is what runs out of budget — the failure reads `capturing the iframe
-did not finish within the 30000ms budget`, with a clean console and a page screenshot showing a
-perfectly rendered document. Re-run the command: it re-attempts only what failed, against a server
-that is now warm.
+time by default, and the 30-second budget is *per document, covering load, readiness and the capture
+together*. Against a `npm start` server that is still compiling chunks on demand, the first batch
+pays that compile cost and the capture is what runs out of budget — the failure reads `capturing the
+iframe did not finish within the 30000ms budget`, with a clean console and a page screenshot showing
+a perfectly rendered document.
 
-Neither the concurrency nor the per-document timeout is reachable from the command line today —
-both are injectable for tests only, so re-running is the only lever. Flags for them are noted
-against milestone 3 in [the plan](../../docs/plans/CLUE-371-harness-plan.md).
+Re-running is usually enough: it re-attempts only what failed, against a server that is now warm.
+When it is not, `--concurrency 1` and `--timeout-ms 60000` turn the two knobs directly. Both are
+validated as positive whole numbers, and both are named in the run's own log line, so a run that
+needed them says so in its output rather than only in the shell history of whoever typed it.
+
+`--timeout-ms` belongs to the local modes only, and the Shutterbug modes refuse it rather than drop
+it. A per-document budget is a thing the local backend has — one deadline covering load, readiness
+and capture — and a hosted mode has no equivalent: it bounds its request and its download separately,
+with retries around them, so there is nothing for a whole-document budget to bound. Their log line
+names the concurrency alone, rather than a limit nothing enforces. `--concurrency` works everywhere.
 
 `npm ci` in this directory now installs puppeteer, which downloads a Chromium build on first
 install. If your environment blocks that download, set `PUPPETEER_SKIP_DOWNLOAD=true` to skip it and
@@ -306,7 +338,8 @@ plus a per-tile rate after the image is scaled down to fit the long side and the
 **`auto` is reserved at the high rate.** The shared builder sends `detail: "auto"` and the provider
 publishes an exact formula only for explicit low and high, so the harness assumes the expensive
 branch. Deliberately conservative, in the same spirit as the other ceiling caveats above. `detail`
-is fixed at `"auto"` by the shared builder; detail variants arrive with milestone 3.
+defaults to the `"auto"` the shared builder has always sent; a run asks for `low` or `high` with its
+`detail` setting, and the builder remains the only place a detail is attached to a message.
 
 The accounting data that makes this possible travels *beside* the request, not inside it:
 
@@ -410,15 +443,62 @@ identify a prompt by hash, not only by name. `test/prompt.test.ts` asserts the c
 
 ### Experiments
 
-An explicit run list only (no matrix expansion). `message` is `text-only` or `image-only`, `prompt`
-must name an existing prompt file, and run ids must be unique. A run names the representation its
-message shape uses, and only that one: a `text-only` run needs a `textVariant` and is refused if it
-also sets `imageMode`; an `image-only` run needs an `imageMode` and is refused if it also sets
-`textVariant`. Ignoring the spare field would produce a result table that looks fine and answers a
-different question from the one the file describes.
+An explicit run list only (no matrix expansion). `prompt` must name an existing prompt file, and run
+ids must be unique. `message` is one of:
 
-`experiments/image-vs-text.json` runs the milestone's headline comparison — `text-default`,
-`text-minimal` and `image-puppeteer` against the same prompt — from one file.
+| Shape | Names | Sends |
+|---|---|---|
+| `text-only` | `textVariant` | The summary, plus its related-summary parts. |
+| `image-only` | `imageMode` | The pictures. |
+| `mixed` | **both** | The summary *and* the pictures, in one request. |
+
+A run may only carry the dimensions its shape can use, and a spare one is refused rather than
+ignored — ignoring it produces a result table that looks fine and answers a different question from
+the one the file describes:
+
+| Field | Valid on | Default | Values |
+|---|---|---|---|
+| `detail` | image-carrying runs | the builder's `auto` | `low`, `high` |
+| `imageSet` | image-carrying runs | `full-document` | `per-tile`, `visual-tiles-only` |
+| `extras` | text-carrying runs | `extras-fixed` | `extras-production-current`, `no-extras` |
+
+`extras` is what a run puts in the related-summary parts. `extras-fixed` is each related document's
+own summary, from the manifest, which is what the harness has always sent — so an experiment file
+written before this dimension existed keeps its meaning *and its request key*.
+`extras-production-current` reproduces production's `findRelatedSummaries` bug on purpose (spike
+finding 6a, CLUE-630): every related entry is given the **analyzed document's own** summary, so the
+model is shown the same text several times over and told other people agreed with it. It is a named
+baseline, kept faithful so a before-and-after comparison stays honest. `no-extras` sends none.
+
+`experiments/mixed-vs-baselines.json` runs this milestone's headline comparison from one file: text,
+image and mixed against the same corpus, plus one run each for detail-low, per-tile,
+visual-tiles-only and the three extras settings. `experiments/image-vs-text.json` is milestone 2's
+narrower comparison, kept as it was.
+
+### Which documents a run declines to send
+
+A run does not send every document, and it says so rather than leaving gaps. The decision comes from
+classifying the document's own content — never from a `modalityOverride`, which is a reporting
+judgement about how to group a result, not a claim about what the document contains.
+
+- **Any shape** skips a document classified `empty`: no tile carries text, and none needs a picture.
+- **`text-only`** skips a document with no student-authored text — the summary would carry no
+  student content, which is the thing a text run measures. On the synthetic corpus that is most of
+  it: 7 of 26 documents carry student text.
+- **`mixed`** sends a document with no student text *without* its summary and related summaries, and
+  records `textPartOmitted` on the row. The picture still has something to say, so skipping it would
+  throw away the answer this shape exists to get.
+- **`visual-tiles-only`** skips a document where no captured tile is one the classification marks as
+  needing a picture.
+
+Every skipped pair becomes a `skipped` result row carrying its reasons and the content hash the
+decision was made from, written before anything is dispatched. A document that simply did not appear
+in the results would be indistinguishable from a bug. On a rerun, an unchanged document keeps its
+existing skipped row; an edited one is decided again.
+
+Worth knowing: a mixed message with its text half dropped is byte-for-byte an image-only message, so
+those rows share the image-only run's request key and are served from the cache rather than paid for
+twice.
 
 ### Cache
 
@@ -509,7 +589,7 @@ API-reported usage is authoritative for final numbers.
 
 Result rows are a discriminated union on `status` (`success`, `refusal`, `error`, `skipped`), all
 sharing the same identifying fields. `skipped` ships now but is unused: skip-empty *execution*
-arrives in milestone 3. `report` handles all four statuses exhaustively and writes
+is written by skip-empty execution. `report` handles all four statuses exhaustively and writes
 `<results-basename>.summary.json` next to the results file — named after it, because a single
 `summary.json` per directory meant every experiment in `data/results/` shared one path and reporting
 on one silently overwrote another's. Groups are per run configuration × message shape × modality,
@@ -526,11 +606,16 @@ both kinds populate — the text side carries the variant and its version, the i
 mode, backend, version, whole render target and image hashes, because that is what a screenshot's
 provenance is. Version-1 rows are **refused** with an instruction to re-run into a fresh `--output`
 rather than being silently mis-read; the response cache means unchanged requests are not paid for
-twice. This is also the extension point milestone 3's mixed rows need.
+twice. It is also the extension point the `mixed` descriptor kind uses.
 
 The report's `img tok est` column is the harness's pre-flight image-token estimate, shown beside the
 `tok in` the API actually billed. It is `-` for a text group rather than `0`, so the two cases cannot
-be confused.
+be confused; a mixed group carries it the same way an image group does.
+
+The `no text` column counts the mixed rows that went without their text half. Those rows carry half
+the input a mixed row usually does, so a reader comparing mixed against text-only needs the count
+before drawing a conclusion. Like `overridden`, it reads `-` where it never happened rather than
+`0`.
 
 Every on-disk format carries a `schemaVersion`, is described as a TypeScript type in
 [`src/schemas.ts`](src/schemas.ts), and is validated on every read; a bad file fails with a message
@@ -562,10 +647,10 @@ src/represent-image.ts     image envelopes: paths, writing, freshness (files inc
 src/png.ts                 PNG header reader (dimensions + "is this really a PNG?")
 src/files.ts               atomic writes, path containment, JSON reads, git
 src/backends/types.ts      what a render backend is, and the limits every one is held to
-src/backends/index.ts      the three named render modes
+src/backends/index.ts      the named render modes
 src/backends/render-html.ts  the render page, with safe interpolation — shared by all modes
 src/backends/puppeteer.ts  local capture through CLUE's iframe pathway
-src/backends/shutterbug.ts the two hosted modes and the network contract
+src/backends/shutterbug.ts the three hosted modes and the network contract
 src/backends/render-unit.ts  the harness's rendering unit and the server that hands it over
 src/messages.ts            request construction via shared/ai-analysis-messages
 src/cache.ts               response cache
@@ -609,9 +694,13 @@ Things this milestone surfaced that are not the harness's to fix.
 
 ## DEVIATIONS
 
-Where the implementation departs from
-[docs/plans/CLUE-371-harness-implementation-1.md](../../docs/plans/CLUE-371-harness-implementation-1.md),
-and why.
+Where the implementation departs from its specification, and why. Each milestone's entries are
+listed under the spec they depart from, and entries are never renumbered or removed — a deviation
+that a later milestone changed is rewritten in place, so a number cited elsewhere keeps pointing at
+the same subject.
+
+Milestone 1 (against
+[docs/plans/CLUE-371-harness-implementation-1.md](../../docs/plans/CLUE-371-harness-implementation-1.md)):
 
 1. **`moduleResolution` is `bundler`, not `nodenext`.** The spec prescribes
    `module: "nodenext"` / `moduleResolution: "nodenext"`. That configuration cannot type-check this
@@ -687,18 +776,24 @@ Milestone 2 (against
     should take it again, but it does not make the stored pixels the wrong pixels to send. `run`
     still checks the document hash, mode, backend, backend version and every file-level property,
     and the row records the whole render target either way, so provenance is kept.
-15. **An envelope with zero images reports "it records no images", not a milestone-3 error.** The
-    spec asks for the milestone-3 message on both zero and many. Zero images is a damaged envelope
-    rather than an unbuilt feature, and pointing the reader at milestone 3 would misdescribe it.
-    Two or more images does say milestone 3. Both fail, and the first image is never selected.
+15. **An envelope with zero images reports "it records no images" rather than a selection error.**
+    The milestone-2 spec asked for one message on both zero and many. Zero images is a damaged
+    envelope; many is a per-tile render meeting a run that asked for a page. Milestone 3 replaced
+    the "many" half with `imageSet` selection, and this entry now covers only the damaged case.
 16. **The render target's `unit` is a stable identifier, not the URL CLUE fetches.** The harness's
     own rendering unit is served on an ephemeral loopback port; recording that URL would make every
     stored render look stale the moment the server restarted. It is recorded as `harness-render`,
     with the served URL passed to CLUE separately.
-17. **`buildImageRequest` derives `detail` from the message it builds** rather than accepting one
-    from the caller, and refuses a caller-supplied `detail` outright. The caller knows facts about
-    the file; the builder knows what it just sent. This also means the cost model follows the shared
-    builder if its `detail` ever changes, instead of confidently pricing the old value.
+17. **A run may ask for an image `detail`; the accounting still records the one actually sent.**
+    Milestone 2 had `buildImageRequest` derive `detail` from the message it built and refuse a
+    caller-supplied one. Milestone 3's `image-detail-low` run has to be able to ask, so
+    `buildImageRequest` and `buildMixedRequest` now take a `detail` and hand it to the shared
+    builder. What did not change is where the cost model reads it back from: `accountingForImages`
+    re-reads every `image_url` part out of the finished message, and a `detail` passed in the
+    accounting is refused outright. The caller states facts about the file; the message states what
+    was asked of the provider. So a run can choose a detail, and nothing can describe an image as
+    having cost something other than what was sent — including if the shared builder's own default
+    ever changes.
 18. **Render diagnostics are a DOM count, not a console check.** CLUE logs nothing when a tile type
     is not registered — it substitutes an `Unknown` content model drawn by the placeholder
     component. The local backend therefore counts tiles inside the CLUE frame (`.tool-tile`, with
@@ -716,7 +811,11 @@ Milestone 2 (against
     `teacher-guide/content.json` that legitimately 404s, so failing on every console error or failed
     request failed every document. Page errors and failed script loads are fatal; everything else is
     recorded in the evidence file without failing the render. The unregistered-tile case is caught by
-    the DOM count above, since nothing is logged for it.
+    the DOM count above, since nothing is logged for it. Milestone 3 added a third fatal condition,
+    and it is also not a console check: if CLUE draws its own `.document-error` page instead of the
+    document, the render fails before the capture. CLUE logs nothing useful there either — it draws a
+    screen — and without the check the harness had been storing a picture of that error screen as a
+    valid render of the `graph` fixture since milestone 2.
 21. **"Not clipped" is guaranteed by construction, not by an overflow check.** The frame is sized
     from the document's measured tile rows and the capture is then checked to cover them. A DOM
     overflow signal would be the obvious check and is not trustworthy here: `.document-content`
@@ -736,28 +835,111 @@ Milestone 2 (against
     parameterized Shutterbug mode has to be able to set the height it clips at, or it is not
     parameterized; the local mode refuses the flag rather than silently dropping it.
 
+Milestone 3 (against
+[docs/plans/CLUE-371-harness-implementation-3.md](../../docs/plans/CLUE-371-harness-implementation-3.md)):
+
+25. **`shutterbug-accurate-height` is a two-step render.** The spec says to take each document's
+    height from its `puppeteer-full-height` envelope and refuse when there is not one, which is what
+    it does — but that makes it the only mode that depends on another mode having run first, against
+    the same corpus, recently enough to still be fresh. `render` reads every document's height
+    before posting anything and refuses the whole corpus at once, naming the documents and the fix:
+    a half-rendered corpus plus a bill for the part that worked is the outcome worth avoiding. The
+    mode table carries the dependency.
+26. **Result rows stay `schemaVersion: 2`.** The milestone-3 spec's item 23 asks for the decision
+    to be recorded either way, which is why this is here at all. The three statuses that send a
+    request are unchanged on disk; `skipped` rows are new in practice, since
+    nothing ever wrote one, and the fields this milestone adds (`textPartOmitted`,
+    `representationWarnings`, `imageSet`, the `mixed` descriptor kind) are all additive. A version
+    bump would invalidate every milestone-2 results file to describe rows those files cannot
+    contain.
+27. **A skipped row carries no `representation`.** The spec has skipped rows recording "the
+    representation descriptor or content hash it was decided from"; they record the hash. Nothing
+    was represented, and a placeholder descriptor would put a variant or a render mode in the
+    results for a request that never existed. `decidedFromContentSha256` is what resume compares.
+28. **The per-tile capture photographs top-level tiles only.** Classification walks into Question
+    tiles, so a visual tile nested in one has a classification entry and no picture of its own — it
+    is drawn inside its parent's. `visual-tiles-only` matches on the images that exist and records
+    the difference in the row's `representationWarnings`, per the spec's own instruction, rather
+    than failing.
+29. **A corpus can mark a document as expected not to render.** The spec has no such notion: a
+    document either renders or the render fails. But `error-test` exists precisely to be
+    unrenderable — it is how the local backend's failure path gets exercised — so every render of
+    the example corpus reported a failure that was really the fixture doing its job, and a genuine
+    failure looked no different. `expectedRenderFailure` on a manifest entry carries the reason.
+    `render` counts those documents apart from real failures so its exit code keeps meaning
+    something, and writes their evidence either way, since a document expected to fail one way and
+    failing another is exactly what the screenshot is for. A document that renders despite the
+    marker gets a warning telling you to clear it: a stale expectation is worse than none, because
+    it would go on hiding a real failure the day that document breaks again. Example corpora seed
+    the marker from `expectations.json`; a value already in the manifest wins, because a human put
+    it there on purpose.
+30. **A per-tile render of a document with no tiles is neither a success nor a failure.** The
+    `empty` fixture declares no tiles, so a per-tile capture has nothing to photograph. Calling it a
+    failure would make a correct corpus exit non-zero; writing an envelope with zero images would
+    make it indistinguishable from a damaged one, which entry 15 exists to keep separate. `render`
+    reports it as "nothing to capture" and writes no envelope. Nothing downstream needs the
+    envelope, because skip-empty declines to send a contentless document in any case.
+
 ### Verified against a real API call, a real browser, a real service?
 
-All of it, by hand. A local render of all 25 fixtures against a real dev server and a real headless Chromium,
-followed by a real `image-vs-text` run:
+All of it, by hand. The 26 fixtures were rendered against a real dev server and a real headless
+Chromium in both capture modes — 25 full-height envelopes and 24 per-tile ones, the missing entries
+being `error-test`, which is marked `expectedRenderFailure`, and `empty`, which has no tile for a
+per-tile capture to photograph. Then a real `mixed-vs-baselines` run:
 
 ```
-run    75 calls: 50 from cache, 25 API calls. Spent $0.0539 against a $0.3282 worst case.
+run     234 row(s): 138 sent (61 from cache, 77 API calls), 96 skipped.
+        Reserved at peak $0.2198 of a $1.1000 ceiling; actually spent $0.1570.
+run     (again) 0 row(s): 234 already complete, 0 API call(s).
 ```
 
-- **The image cost model checks out.** `plan` predicted 376,843 image tokens; the API billed 382,643
-  prompt tokens across those rows, so the estimate accounts for 98.5% of them, the rest being prompt
-  text. The median actual, 14,399, is exactly the formula for a 944×500 capture: 2833 + 2 tiles ×
-  5667, plus prompt.
-- **The cache did real work.** Every text request except two was served from milestone 1's cache;
-  the two were both `adversarial-text`, the fixture this milestone added.
-- **Observation, not a conclusion.** Image-only returned `unknown` for 21 of 25 documents against
-  text-default's 12; on visual-only documents specifically, 15/17 against 9/17. That is the opposite
-  of the hypothesis, and it is heavily confounded: these are one- and two-tile synthetic documents,
-  several render blank (see "What the synthetic corpus cannot show you yet"), and two pairs render
-  byte-identically. The model is being shown very little. **This establishes that the pipeline works
-  and what it costs — not that image mode is worse.** That comparison needs milestone 5's rubric and
-  a corpus of real documents.
+The corpus was then re-rendered and the affected rows re-run, after a fix to which tiles a per-tile
+capture photographs. Only 18 of the 234 rows changed, and resume dispatched exactly those:
+
+```
+run     18 row(s): 216 already complete, 3 from cache, 15 API call(s).
+        Reserved at peak $0.0562 of a $0.3000 ceiling; actually spent $0.0313.
+report  252 row(s) read; 234 current, 18 superseded by a later re-run.
+```
+
+The figures below are the current rows. Only `question` changed because of the fix; the other 15 are
+`data-card`, `dataflow` and `graph`, which do not render deterministically and produce different
+pixels every time — worth knowing before reaching for `--refresh`, since new pixels are new request
+keys and a re-spend on those documents whatever prompted the re-render.
+
+- **The image cost model checks out.** Estimated image tokens account for 98.6% of the prompt tokens
+  the API actually billed in `image-puppeteer` (371,177 of 376,513), 98.9% in `image-per-tile`
+  (467,511 of 472,847) and 98.4% in `image-visual-tiles-only`; the remainder is prompt text. The
+  median actual, 14,399, is exactly the formula for a 944×500 capture: 2833 + 2 tiles × 5667, plus
+  prompt. `image-detail-low` is the loosest at 92.4%, which is arithmetic rather than error: a
+  low-detail image is a flat 2833 tokens, so the fixed prompt text is a much larger share of a much
+  smaller total.
+- **The extras dimension is measurable.** Across the same 7 documents and the same prompt,
+  `no-extras` sent 3,725 prompt tokens, `extras-fixed` and the default sent 3,895, and
+  `extras-production-current` sent 4,537. The three differ on exactly the two documents that have
+  `relatedSummaries`, and the 642-token gap between `fixed` and `production-current` is the
+  production bug (spike finding 6a) reproduced and priced: it re-sends the analyzed document's own
+  summary in place of each related one.
+- **The cache is keyed on the whole request, prompt included.** A mixed message whose text half is
+  dropped is structurally identical to an image-only one, but this experiment gives the mixed run
+  its own `categorize-design-mixed` prompt, so none of its 16 text-free rows matched the image-only
+  cache. Two runs share cache entries only when they share the prompt as well as the payload —
+  which is why `text-extras-fixed` matched `text-default` on all 7 rows and cost nothing.
+- **Per-tile cost scales with tile count, not document size.** Its median document billed the same
+  14,399 prompt tokens as full-document, but `tall` — ten tiles, ten images — billed 141,902. The
+  per-document average hides this; budget for the widest document, not the typical one. Tile count
+  means *top-level* tiles: `question` draws two more inside itself, and photographing those as well
+  gave one document three overlapping pictures of the same content until the selector was fixed.
+- **Observation, not a conclusion.** Skip-empty means text and image runs no longer send the same
+  documents, so the only fair comparison is the 7 documents both send. There, mixed reproduced
+  text-only's category on all 7, while image-only lost 3 of them to `unknown` — the picture alone
+  was worse, and adding the picture to the text cost nothing in agreement. Across everything each
+  run did send, `unknown` came back 17/23 for image-only, 16/23 for mixed, 19/23 for per-tile and
+  1/7 for text. This is heavily confounded: these are one- and two-tile synthetic documents, several
+  render nearly blank (see "What the synthetic corpus cannot show you yet"), and n=7 on the paired
+  comparison. **This establishes that the pipeline works and what it costs — not that any
+  representation is better.** That comparison needs milestone 5's rubric and a corpus of real
+  documents.
 
 **The parity mode was verified by hand against the real service**, with the `drawing` fixture:
 

--- a/scripts/ai-harness/README.md
+++ b/scripts/ai-harness/README.md
@@ -479,10 +479,12 @@ finding 6a, CLUE-630): every related entry is given the **analyzed document's ow
 model is shown the same text several times over and told other people agreed with it. It is a named
 baseline, kept faithful so a before-and-after comparison stays honest. `no-extras` sends none.
 
-`experiments/mixed-vs-baselines.json` runs this milestone's headline comparison from one file: text,
-image and mixed against the same corpus, plus one run each for detail-low, per-tile,
-visual-tiles-only and the three extras settings. `experiments/image-vs-text.json` is milestone 2's
-narrower comparison, kept as it was.
+`experiments/mixed-vs-baselines.json` runs this milestone's headline comparison from one file: eleven
+runs over the same corpus. Text, image and mixed are the comparison itself; the other eight turn one
+dimension each around it — detail-low, per-tile and visual-tiles-only on the image side, the three
+extras settings and the two new text variants on the text side. Every dimension this milestone adds
+has a run, so none of them ships only exercised by a unit test.
+`experiments/image-vs-text.json` is milestone 2's narrower comparison, kept as it was.
 
 ### Which documents a run declines to send
 
@@ -894,27 +896,33 @@ Milestone 3 (against
 All of it, by hand. The 26 fixtures were rendered against a real dev server and a real headless
 Chromium in both capture modes — 25 full-height envelopes and 24 per-tile ones, the missing entries
 being `error-test`, which is marked `expectedRenderFailure`, and `empty`, which has no tile for a
-per-tile capture to photograph. Then a real `mixed-vs-baselines` run:
+per-tile capture to photograph. Then a real `mixed-vs-baselines` run, assembled over several
+sittings as review turned up fixes:
 
 ```
-run     234 row(s): 138 sent (61 from cache, 77 API calls), 96 skipped.
-        Reserved at peak $0.2198 of a $1.1000 ceiling; actually spent $0.1570.
-run     (again) 0 row(s): 234 already complete, 0 API call(s).
+run     286 row(s): 153 sent, 133 skipped.
+        11 run(s) × 26 document(s) = 286 pair(s).
+report  286 current, 0 superseded.
 ```
 
-The corpus was then re-rendered and the affected rows re-run, after a fix to which tiles a per-tile
-capture photographs. Only 18 of the 234 rows changed, and resume dispatched exactly those:
+Three things were repaired between the first run and this one, and each is worth knowing before
+reading the numbers. A per-tile capture was photographing tiles nested inside a Question, so
+`question` produced three overlapping pictures instead of one. The mixed prompt told the model it
+had been given a summary on documents where the summary was dropped. And `drawing-text` had no
+experiment run at all.
 
-```
-run     18 row(s): 216 already complete, 3 from cache, 15 API call(s).
-        Reserved at peak $0.0562 of a $0.3000 ceiling; actually spent $0.0313.
-report  252 row(s) read; 234 current, 18 superseded by a later re-run.
-```
+Two of those cost money to correct and one did not. Re-rendering changed 18 rows, of which only
+`question` changed because of the fix — the other 15 are `data-card`, `dataflow` and `graph`, which
+do not render deterministically and produce different pixels every time. Worth knowing before
+reaching for `--refresh`: new pixels are new request keys, and a re-spend on those documents
+whatever prompted the re-render.
 
-The figures below are the current rows. Only `question` changed because of the fix; the other 15 are
-`data-card`, `dataflow` and `graph`, which do not render deterministically and produce different
-pixels every time — worth knowing before reaching for `--refresh`, since new pixels are new request
-keys and a re-spend on those documents whatever prompted the re-render.
+Adding the two variant runs edited the experiment file, and `experimentSha256` is part of resume
+identity — deliberately, so an edited experiment cannot silently resume rows built under the old
+definition. Every row therefore rebuilt, `report` refused a file holding two definitions, and
+recovering meant re-running into a clean one. That cost nothing: the cache is keyed on the request
+rather than the experiment, so all 153 rows came straight back out of it. The whole session's real
+spend was about $0.25.
 
 - **The image cost model checks out.** Estimated image tokens account for 98.6% of the prompt tokens
   the API actually billed in `image-puppeteer` (371,177 of 376,513), 98.9% in `image-per-tile`
@@ -923,32 +931,42 @@ keys and a re-spend on those documents whatever prompted the re-render.
   prompt. `image-detail-low` is the loosest at 92.4%, which is arithmetic rather than error: a
   low-detail image is a flat 2833 tokens, so the fixed prompt text is a much larger share of a much
   smaller total.
-- **The extras dimension is measurable.** Across the same 7 documents and the same prompt,
-  `no-extras` sent 3,725 prompt tokens, `extras-fixed` and the default sent 3,895, and
-  `extras-production-current` sent 4,537. The three differ on exactly the two documents that have
-  `relatedSummaries`, and the 642-token gap between `fixed` and `production-current` is the
-  production bug (CLUE-630) reproduced and priced: it re-sends the analyzed document's own
-  summary in place of each related one.
-- **The cache is keyed on the whole request, prompt included.** A mixed message whose text half is
-  dropped is structurally identical to an image-only one, but this experiment gives the mixed run
-  its own `categorize-design-mixed` prompt, so none of its 16 text-free rows matched the image-only
-  cache. Two runs share cache entries only when they share the prompt as well as the payload —
-  which is why `text-extras-fixed` matched `text-default` on all 7 rows and cost nothing.
+- **Every text dimension is priced, over the same 7 documents and the same prompt.** `no-extras`
+  sends 3,725 prompt tokens; `no-dataset-tables` 3,823; `default` and `extras-fixed` 3,895;
+  `drawing-text` 3,958; `extras-production-current` 4,537. The 642-token gap between `extras-fixed`
+  and `extras-production-current` is the production bug (CLUE-630) reproduced and priced: it
+  re-sends the analyzed document's own summary in place of each related one.
+- **`drawing-text` is the only run that ever answered `form`.** Across all 153 rows the categories
+  are 91 `unknown`, 45 `function`, 16 `user` and a single `form` — the `drawing` fixture, two shapes
+  and no text, which every other run either skips or calls `unknown`. The model gave "drawing with 2
+  objects", "rectangle and ellipse", "specified positions and sizes" as its indicators. One document
+  is not evidence that describing geometry beats photographing it, but it is the variant doing
+  exactly what it was built to do, on the document it was built for.
 - **Per-tile cost scales with tile count, not document size.** Its median document billed the same
   14,399 prompt tokens as full-document, but `tall` — ten tiles, ten images — billed 141,902. The
   per-document average hides this; budget for the widest document, not the typical one. Tile count
   means *top-level* tiles: `question` draws two more inside itself, and photographing those as well
   gave one document three overlapping pictures of the same content until the selector was fixed.
+- **The cache is keyed on the whole request, prompt included.** A mixed message whose text half is
+  dropped is structurally identical to an image-only one, but this experiment gives the mixed run
+  its own `categorize-design-mixed` prompt, so none of its 16 text-free rows matched the image-only
+  cache. Two runs share cache entries only when they share the prompt as well as the payload —
+  which is why `text-extras-fixed` matched `text-default` on all 7 rows and cost nothing.
+- **Fixing the mixed prompt changed no answers.** It had told the model it was given "a written
+  summary and a picture", on 16 of 23 rows where the summary was dropped. Rewording it to promise a
+  summary only when there is one moved **0 of 23** categories. The fidelity problem was real and its
+  measured effect here was nil; both halves are worth stating, because a fix reported without its
+  measurement is just a claim.
 - **Observation, not a conclusion.** Skip-empty means text and image runs no longer send the same
   documents, so the only fair comparison is the 7 documents both send. There, mixed reproduced
-  text-only's category on all 7, while image-only lost 3 of them to `unknown` — the picture alone
+  text-only's category on all 7, while image-only lost 4 of them to `unknown` — the picture alone
   was worse, and adding the picture to the text cost nothing in agreement. Across everything each
-  run did send, `unknown` came back 17/23 for image-only, 16/23 for mixed, 19/23 for per-tile and
-  1/7 for text. This is heavily confounded: these are one- and two-tile synthetic documents, several
-  render nearly blank (see "What the synthetic corpus cannot show you yet"), and n=7 on the paired
-  comparison. **This establishes that the pipeline works and what it costs — not that any
-  representation is better.** That comparison needs milestone 5's rubric and a corpus of real
-  documents.
+  run did send, `unknown` came back 17/23 for image-only, 16/23 for mixed, 19/23 for per-tile, 1/7
+  for text and 1/8 for `drawing-text`. This is heavily confounded: these are one- and two-tile
+  synthetic documents, several render nearly blank (see "What the synthetic corpus cannot show you
+  yet"), and n=7 on the paired comparison. **This establishes that the pipeline works and what it
+  costs — not that any representation is better.** That comparison needs milestone 5's rubric and a
+  corpus of real documents.
 
 **The parity mode was verified by hand against the real service**, with the `drawing` fixture:
 

--- a/scripts/ai-harness/README.md
+++ b/scripts/ai-harness/README.md
@@ -162,6 +162,15 @@ exports a `variantVersion` that is bumped whenever its output would change for t
 interpret it, because interpreting the picture is what the model is being measured on. Beating it is
 the point, and a new variant is how someone shows they have.
 
+**A text run reaches it only on a document that carries student text elsewhere**, which today means
+the geometry half is barely exercised. Skip-empty asks the classifier whether any tile holds
+student-authored text, and a Drawing tile counts only when it has a text object with something in it
+(`drawingTileHasText` in `src/capability.ts`) — so the `drawing` fixture, two shapes and no text, is
+skipped by a text-only run before the variant is consulted. Of the two fixtures with Drawing tiles,
+only `mixed` is sent, and that one has a Text tile as well. The variant's own summary of a drawing
+*is* student content, so the skip is asking the wrong question for this combination; the decision is
+made from the classifier alone and knows nothing about which variant is about to run.
+
 Two further ways to shrink a data set — sending a fixed sample of cases, and sending aggregate
 statistics — are named in the plan and not built. Both are variants of their own when someone wants
 to measure them.
@@ -918,7 +927,7 @@ keys and a re-spend on those documents whatever prompted the re-render.
   `no-extras` sent 3,725 prompt tokens, `extras-fixed` and the default sent 3,895, and
   `extras-production-current` sent 4,537. The three differ on exactly the two documents that have
   `relatedSummaries`, and the 642-token gap between `fixed` and `production-current` is the
-  production bug (spike finding 6a) reproduced and priced: it re-sends the analyzed document's own
+  production bug (CLUE-630) reproduced and priced: it re-sends the analyzed document's own
   summary in place of each related one.
 - **The cache is keyed on the whole request, prompt included.** A mixed message whose text half is
   dropped is structurally identical to an image-only one, but this experiment gives the mixed run

--- a/scripts/ai-harness/examples/synthetic-corpus/documents/error-test.json
+++ b/scripts/ai-harness/examples/synthetic-corpus/documents/error-test.json
@@ -19,7 +19,7 @@
       "content": {
         "type": "ErrorTest",
         "fixtureMarker": "error-test-fixture-marker",
-        "failureMode": "render"
+        "throwRenderError": true
       }
     }
   }

--- a/scripts/ai-harness/examples/synthetic-corpus/documents/graph.json
+++ b/scripts/ai-harness/examples/synthetic-corpus/documents/graph.json
@@ -23,10 +23,14 @@
         "yAttributeLabel": "Height (cm)",
         "axes": {
           "bottom": {
+            "type": "numeric",
+            "place": "bottom",
             "min": 0,
             "max": 10
           },
           "left": {
+            "type": "numeric",
+            "place": "left",
             "min": 0,
             "max": 25
           }

--- a/scripts/ai-harness/examples/synthetic-corpus/documents/tall.json
+++ b/scripts/ai-harness/examples/synthetic-corpus/documents/tall.json
@@ -1,0 +1,198 @@
+{
+  "rowOrder": [
+    "row-1",
+    "row-2",
+    "row-3",
+    "row-4",
+    "row-5",
+    "row-6",
+    "row-7",
+    "row-8",
+    "row-9",
+    "row-10"
+  ],
+  "rowMap": {
+    "row-1": {
+      "id": "row-1",
+      "isSectionHeader": false,
+      "height": 120,
+      "tiles": [
+        {
+          "tileId": "tall-text-1"
+        }
+      ]
+    },
+    "row-2": {
+      "id": "row-2",
+      "isSectionHeader": false,
+      "height": 120,
+      "tiles": [
+        {
+          "tileId": "tall-text-2"
+        }
+      ]
+    },
+    "row-3": {
+      "id": "row-3",
+      "isSectionHeader": false,
+      "height": 120,
+      "tiles": [
+        {
+          "tileId": "tall-text-3"
+        }
+      ]
+    },
+    "row-4": {
+      "id": "row-4",
+      "isSectionHeader": false,
+      "height": 120,
+      "tiles": [
+        {
+          "tileId": "tall-text-4"
+        }
+      ]
+    },
+    "row-5": {
+      "id": "row-5",
+      "isSectionHeader": false,
+      "height": 120,
+      "tiles": [
+        {
+          "tileId": "tall-text-5"
+        }
+      ]
+    },
+    "row-6": {
+      "id": "row-6",
+      "isSectionHeader": false,
+      "height": 120,
+      "tiles": [
+        {
+          "tileId": "tall-text-6"
+        }
+      ]
+    },
+    "row-7": {
+      "id": "row-7",
+      "isSectionHeader": false,
+      "height": 120,
+      "tiles": [
+        {
+          "tileId": "tall-text-7"
+        }
+      ]
+    },
+    "row-8": {
+      "id": "row-8",
+      "isSectionHeader": false,
+      "height": 120,
+      "tiles": [
+        {
+          "tileId": "tall-text-8"
+        }
+      ]
+    },
+    "row-9": {
+      "id": "row-9",
+      "isSectionHeader": false,
+      "height": 120,
+      "tiles": [
+        {
+          "tileId": "tall-text-9"
+        }
+      ]
+    },
+    "row-10": {
+      "id": "row-10",
+      "isSectionHeader": false,
+      "height": 120,
+      "tiles": [
+        {
+          "tileId": "tall-text-10"
+        }
+      ]
+    }
+  },
+  "tileMap": {
+    "tall-text-1": {
+      "id": "tall-text-1",
+      "content": {
+        "type": "Text",
+        "format": "html",
+        "text": "<p>Our team is designing a lunchbox latch for a first grader who cannot work a stiff clasp. We watched three children try the old latch and none of them opened it without help.</p>"
+      }
+    },
+    "tall-text-2": {
+      "id": "tall-text-2",
+      "content": {
+        "type": "Text",
+        "format": "html",
+        "text": "<p>The latch has to survive being dropped on a hard floor and being opened many times a day. We chose a moulded hinge rather than a metal spring, because a spring bends out of shape.</p>"
+      }
+    },
+    "tall-text-3": {
+      "id": "tall-text-3",
+      "content": {
+        "type": "Text",
+        "format": "html",
+        "text": "<p>We tried a slider first. It opened easily, but it also opened inside a bag and a drink spilled over a reading book, so we went back to something that needs a deliberate push.</p>"
+      }
+    },
+    "tall-text-4": {
+      "id": "tall-text-4",
+      "content": {
+        "type": "Text",
+        "format": "html",
+        "text": "<p>The second prototype uses a wide lever with a raised edge. A small hand can push it with one thumb, and it does not move when the box is squeezed from the sides.</p>"
+      }
+    },
+    "tall-text-5": {
+      "id": "tall-text-5",
+      "content": {
+        "type": "Text",
+        "format": "html",
+        "text": "<p>We measured how long each child took to open the box. The lever took about two seconds; the original clasp took more than ten, and two children gave up before it opened.</p>"
+      }
+    },
+    "tall-text-6": {
+      "id": "tall-text-6",
+      "content": {
+        "type": "Text",
+        "format": "html",
+        "text": "<p>The lid needs a seal or the food dries out, and a seal makes the lid harder to lift. A tighter seal means a stiffer lid, and a stiffer lid needs a stronger latch.</p>"
+      }
+    },
+    "tall-text-7": {
+      "id": "tall-text-7",
+      "content": {
+        "type": "Text",
+        "format": "html",
+        "text": "<p>Most other lunchboxes use two small clips on opposite sides, which means using two hands at once. A first grader holding a tray cannot do that.</p>"
+      }
+    },
+    "tall-text-8": {
+      "id": "tall-text-8",
+      "content": {
+        "type": "Text",
+        "format": "html",
+        "text": "<p>Our third prototype puts the lever on the front face rather than the top, which keeps it away from the handle so the box does not open while it is being carried.</p>"
+      }
+    },
+    "tall-text-9": {
+      "id": "tall-text-9",
+      "content": {
+        "type": "Text",
+        "format": "html",
+        "text": "<p>We considered a magnet instead. Magnets are easy to open, but a magnet strong enough to stay shut when the box is knocked was too strong for a small hand to pull apart.</p>"
+      }
+    },
+    "tall-text-10": {
+      "id": "tall-text-10",
+      "content": {
+        "type": "Text",
+        "format": "html",
+        "text": "<p>Next we want to test the lever after a dishwasher cycle, because the plastic may become brittle. A latch that snaps is worse than one that is stiff. tall-fixture-marker</p>"
+      }
+    }
+  }
+}

--- a/scripts/ai-harness/examples/synthetic-corpus/expectations.json
+++ b/scripts/ai-harness/examples/synthetic-corpus/expectations.json
@@ -107,7 +107,7 @@
         "requiresVisualRepresentation": true
       },
       "handlerTier": "stub",
-      "notes": "No text objects, so the instance-level check keeps containsStudentText false. The stub handler emits one sentence — that weak summary is the measurement, not a failure."
+      "notes": "No text objects, so the instance-level check keeps containsStudentText false. The stub handler emits one sentence \u2014 that weak summary is the measurement, not a failure."
     },
     "empty": {
       "expectDistinctiveInDefaultSummary": false,
@@ -136,7 +136,9 @@
         "containsStudentText": false,
         "requiresVisualRepresentation": true
       },
-      "handlerTier": "fallback"
+      "handlerTier": "fallback",
+      "expectedRenderFailure": "the ErrorTest tile throws during render on purpose, which takes the whole document down and makes CLUE show its error page",
+      "notes": "Exists to prove the harness notices a render that fails. There is nothing to fix here: a successful render of this document would mean the tile stopped throwing."
     },
     "expression": {
       "expectDistinctiveInDefaultSummary": false,
@@ -317,6 +319,21 @@
       "computedModality": "text-only",
       "tileTypes": [
         "Table"
+      ],
+      "capability": {
+        "containsStudentText": true,
+        "requiresVisualRepresentation": false
+      },
+      "handlerTier": "full"
+    },
+    "tall": {
+      "expectDistinctiveInDefaultSummary": true,
+      "defaultSummaryMustSucceed": true,
+      "minimalSummaryMustSucceed": true,
+      "distinctiveString": "tall-fixture-marker",
+      "computedModality": "text-only",
+      "tileTypes": [
+        "Text"
       ],
       "capability": {
         "containsStudentText": true,

--- a/scripts/ai-harness/examples/synthetic-corpus/expectations.json
+++ b/scripts/ai-harness/examples/synthetic-corpus/expectations.json
@@ -107,7 +107,7 @@
         "requiresVisualRepresentation": true
       },
       "handlerTier": "stub",
-      "notes": "No text objects, so the instance-level check keeps containsStudentText false. The stub handler emits one sentence \u2014 that weak summary is the measurement, not a failure."
+      "notes": "No text objects, so the instance-level check keeps containsStudentText false. The stub handler emits one sentence — that weak summary is the measurement, not a failure."
     },
     "empty": {
       "expectDistinctiveInDefaultSummary": false,

--- a/scripts/ai-harness/experiments/mixed-vs-baselines.json
+++ b/scripts/ai-harness/experiments/mixed-vs-baselines.json
@@ -1,0 +1,67 @@
+{
+  "schemaVersion": 1,
+  "name": "mixed-vs-baselines",
+  "runs": [
+    {
+      "id": "text-default",
+      "message": "text-only",
+      "textVariant": "default",
+      "prompt": "categorize-design-default"
+    },
+    {
+      "id": "image-puppeteer",
+      "message": "image-only",
+      "imageMode": "puppeteer-full-height",
+      "prompt": "categorize-design-default"
+    },
+    {
+      "id": "mixed",
+      "message": "mixed",
+      "textVariant": "default",
+      "imageMode": "puppeteer-full-height",
+      "prompt": "categorize-design-mixed"
+    },
+    {
+      "id": "image-detail-low",
+      "message": "image-only",
+      "imageMode": "puppeteer-full-height",
+      "detail": "low",
+      "prompt": "categorize-design-default"
+    },
+    {
+      "id": "image-per-tile",
+      "message": "image-only",
+      "imageMode": "puppeteer-per-tile",
+      "imageSet": "per-tile",
+      "prompt": "categorize-design-default"
+    },
+    {
+      "id": "image-visual-tiles-only",
+      "message": "image-only",
+      "imageMode": "puppeteer-per-tile",
+      "imageSet": "visual-tiles-only",
+      "prompt": "categorize-design-default"
+    },
+    {
+      "id": "text-extras-fixed",
+      "message": "text-only",
+      "textVariant": "default",
+      "extras": "extras-fixed",
+      "prompt": "categorize-design-default"
+    },
+    {
+      "id": "text-extras-production-current",
+      "message": "text-only",
+      "textVariant": "default",
+      "extras": "extras-production-current",
+      "prompt": "categorize-design-default"
+    },
+    {
+      "id": "text-no-extras",
+      "message": "text-only",
+      "textVariant": "default",
+      "extras": "no-extras",
+      "prompt": "categorize-design-default"
+    }
+  ]
+}

--- a/scripts/ai-harness/experiments/mixed-vs-baselines.json
+++ b/scripts/ai-harness/experiments/mixed-vs-baselines.json
@@ -62,6 +62,18 @@
       "textVariant": "default",
       "extras": "no-extras",
       "prompt": "categorize-design-default"
+    },
+    {
+      "id": "text-no-dataset-tables",
+      "message": "text-only",
+      "textVariant": "no-dataset-tables",
+      "prompt": "categorize-design-default"
+    },
+    {
+      "id": "text-drawing-text",
+      "message": "text-only",
+      "textVariant": "drawing-text",
+      "prompt": "categorize-design-default"
     }
   ]
 }

--- a/scripts/ai-harness/harness.ts
+++ b/scripts/ai-harness/harness.ts
@@ -655,9 +655,9 @@ function commandPlan(flags: Record<string, string | true>, deps: HarnessDeps): v
     // Read from the mode descriptor rather than by building a backend: construction validates URLs
     // and limits, and shells out to git for the local mode, none of which belongs in a command that
     // promises to touch nothing.
-    // Built from what the shape actually sends rather than from a two-way ternary. The old one
-    // predated `mixed` and labelled it "text-only", so `plan` -- the record of what a run was about
-    // to do -- described a mixed run as something else while printing its images underneath.
+    // `plan` is the record of what a run was about to do, so this label has to name the shape that
+    // will actually run: one naming the wrong shape would describe a mixed run as something else
+    // while printing its images underneath.
     const carries = [run.message as string];
     if (sendsText(run.message)) carries.push(run.textVariant!);
     if (sendsImages(run.message)) carries.push(`--mode ${run.imageMode}`);

--- a/scripts/ai-harness/harness.ts
+++ b/scripts/ai-harness/harness.ts
@@ -5,6 +5,7 @@
  *   npx tsx harness.ts represent --corpus <name> --variants default,minimal
  *   npx tsx harness.ts render    --corpus <name> --mode <mode> [--clue-url <url>] [--unit <unit>]
  *                                [--shutterbug-url <url>] [--capture-height <px>] [--refresh]
+ *                                [--concurrency <n>] [--timeout-ms <n>]
  *   npx tsx harness.ts plan      --corpus <name> --experiment <file>
  *   npx tsx harness.ts run       --corpus <name> --experiment <file> --max-cost <usd>
  *                                [--output <file>] [--no-cache | --refresh-cache]
@@ -27,20 +28,22 @@ import {
 } from "./src/execute.js";
 import { getTextVariant, textVariantIds } from "./src/represent-text.js";
 import {
-  imageRepresentationFreshness, imageRepresentationPath, readImageEnvelope, renderErrorDir,
-  writeImageRepresentation
+  imageRepresentationFreshness, imageRepresentationIsUsable, imageRepresentationPath,
+  readImageEnvelope, removeImageRepresentation, renderErrorDir, writeImageRepresentation
 } from "./src/represent-image.js";
 import {
   RenderModeOptions, assertRenderModeOptions, getRenderBackend, kDefaultClueUrl, kDefaultRenderModeId,
-  renderMode, renderModeIds
+  renderBackendIdentity, renderMode, renderModeIds
 } from "./src/backends/index.js";
 import type { RenderBackend } from "./src/backends/types.js";
+import { expectedTileCount, kDefaultRenderTimeoutMs } from "./src/backends/puppeteer.js";
 import {
   RenderUnitServer, kHarnessRenderUnitId, startRenderUnitServer
 } from "./src/backends/render-unit.js";
 import { formatSummaryTable, summarizeResults, summaryPathFor, writeSummary } from "./src/report.js";
 import {
-  CorpusSource, corpusSources, kSchemaVersion, sha256Canonical, validateExperimentFile
+  CorpusSource, corpusSources, kSchemaVersion, sendsImages, sendsText, sha256Canonical,
+  validateExperimentFile
 } from "./src/schemas.js";
 
 /** Four pages at a time: enough to be quick, few enough not to starve a dev server. */
@@ -117,7 +120,8 @@ export function parseArgs(argv: string[], knownFlags: Record<string, readonly st
 const kKnownFlags = {
   import: ["from", "corpus", "source", "prune"],
   represent: ["corpus", "variants"],
-  render: ["corpus", "mode", "clue-url", "unit", "shutterbug-url", "capture-height", "refresh"],
+  render: ["corpus", "mode", "clue-url", "unit", "shutterbug-url", "capture-height", "refresh",
+    "concurrency", "timeout-ms"],
   plan: ["corpus", "experiment"],
   run: ["corpus", "experiment", "max-cost", "output", "no-cache", "refresh-cache"],
   report: ["results"]
@@ -265,6 +269,75 @@ function commandRepresent(flags: Record<string, string | true>, deps: HarnessDep
  * no envelope, leaves what evidence it has under `render-errors/`, and does not stop the others; the
  * command exits non-zero at the end.
  */
+/**
+ * The height each document should be captured at, from its local full-document render.
+ *
+ * A hosted service cannot measure anything: it is handed a page and a height and clips to it. The
+ * only thing that knows how tall a CLUE document really is, is a browser that has laid it out — so
+ * an accurate-height render is a two-step operation, and this is the step that reads the answer.
+ *
+ * Every document is checked before any is posted. Failing document by document would leave a
+ * half-rendered corpus, and a bill for the part that worked.
+ */
+function measuredHeightsFor(
+  paths: ReturnType<typeof corpusPaths>,
+  documents: { id: string; contentSha256: string; expectedRenderFailure: string | null }[],
+  modeId: string
+): Map<string, number> {
+  const source = kDefaultRenderModeId;
+  const backend = renderBackendIdentity(source);
+  const heights = new Map<string, number>();
+  const missing: string[] = [];
+  // A document known not to render has no local render to measure from, and never will. Demanding
+  // one would make any corpus holding a deliberately unrenderable fixture unusable with this mode.
+  // Only the demand is waived: a marked document that *does* have a usable render still contributes
+  // its height and is captured like any other, and one that does not is simply absent from the map,
+  // which the render loop skips rather than falling back on a height this mode was built to avoid.
+  const wanted = (document: { id: string; expectedRenderFailure: string | null }) => {
+    if (!document.expectedRenderFailure) missing.push(document.id);
+  };
+  for (const document of documents) {
+    const file = imageRepresentationPath(paths, source, document.id);
+    if (!fs.existsSync(file)) {
+      wanted(document);
+      continue;
+    }
+    try {
+      const envelope = readImageEnvelope(file);
+      const usable = imageRepresentationIsUsable(envelope, {
+        docId: document.id,
+        modeId: source,
+        backendId: backend.backendId,
+        backendVersion: backend.backendVersion,
+        contentSha256: document.contentSha256
+      }, file);
+      const image = envelope.images.find((entry) => entry.purpose === "full-document");
+      if (!usable.fresh || !image) {
+        wanted(document);
+        continue;
+      }
+      heights.set(document.id, image.heightPx);
+    } catch {
+      wanted(document);
+    }
+  }
+  if (missing.length > 0) {
+    throw new Error(`--mode ${modeId} captures each document at its own measured height, and ` +
+      `${missing.length} document(s) have no usable ${source} render to measure from: ` +
+      `${missing.slice(0, 5).join(", ")}${missing.length > 5 ? ", …" : ""}. Render locally first: ` +
+      `harness.ts render --corpus <name> --mode ${source}`);
+  }
+  return heights;
+}
+
+/** The render target a document would be captured against now, height included. */
+function targetFor(
+  renderer: RenderBackend, measuredHeights: Map<string, number> | null, docId: string
+) {
+  if (!measuredHeights) return renderer.renderTarget;
+  return { ...renderer.renderTarget, captureHeightPx: measuredHeights.get(docId) ?? null };
+}
+
 async function commandRender(flags: Record<string, string | true>, deps: HarnessDeps): Promise<void> {
   const log = deps.log ?? console.log;
   const now = deps.now ?? (() => new Date());
@@ -274,12 +347,21 @@ async function commandRender(flags: Record<string, string | true>, deps: Harness
   const modeId = typeof flags.mode === "string" ? flags.mode : kDefaultRenderModeId;
   const refresh = flags.refresh === true;
 
-  const captureHeight = typeof flags["capture-height"] === "string"
-    ? Number(flags["capture-height"]) : undefined;
-  if (captureHeight !== undefined && (!Number.isInteger(captureHeight) || captureHeight <= 0)) {
-    throw new Error(`--capture-height must be a positive whole number of pixels, got ` +
-      `"${String(flags["capture-height"])}"`);
-  }
+  const positiveInteger = (name: string, unit: string): number | undefined => {
+    const raw = flags[name];
+    if (typeof raw !== "string") return undefined;
+    const value = Number(raw);
+    if (!Number.isInteger(value) || value <= 0) {
+      throw new Error(`--${name} must be a positive whole number of ${unit}, got "${String(raw)}"`);
+    }
+    return value;
+  };
+  const captureHeight = positiveInteger("capture-height", "pixels");
+  // Both default to what they always were. They exist because a cold dev server times out the first
+  // documents of a run — four pages at once against a server still compiling chunks — and until now
+  // re-running was the only lever.
+  const concurrencyFlag = positiveInteger("concurrency", "pages at a time");
+  const timeoutMs = positiveInteger("timeout-ms", "milliseconds");
 
   // The local mode needs a unit that registers every tile type the corpus uses, and CLUE registers
   // tile types from the unit's own configuration. With no unit it loads its default one and draws
@@ -293,6 +375,7 @@ async function commandRender(flags: Record<string, string | true>, deps: Harness
     unit: explicitUnit,
     shutterbugUrl: typeof flags["shutterbug-url"] === "string" ? flags["shutterbug-url"] : undefined,
     captureHeightPx: captureHeight,
+    ...(timeoutMs === undefined ? {} : { timeoutMs }),
     ...(deps.renderModeOptions ?? {})
   };
   // Validated *before* anything is started. When this ran after the unit server was listening, an
@@ -304,8 +387,12 @@ async function commandRender(flags: Record<string, string | true>, deps: Harness
 
   let rendered = 0;
   let reused = 0;
+  /** Documents a per-tile mode cannot represent, because their content declares no tiles. */
+  let nothingToCapture = 0;
+  /** Documents the manifest says cannot render, which failed as expected. */
+  const expectedFailures: string[] = [];
   const failures: string[] = [];
-  const concurrency = Math.max(1, deps.renderConcurrency ?? kDefaultRenderConcurrency);
+  const concurrency = concurrencyFlag ?? Math.max(1, deps.renderConcurrency ?? kDefaultRenderConcurrency);
 
   let unitServer: RenderUnitServer | undefined;
   let openBackend: RenderBackend | undefined;
@@ -318,6 +405,13 @@ async function commandRender(flags: Record<string, string | true>, deps: Harness
     // Built once, after the unit server is up, so the backend knows where its unit is served.
     const renderer = getRenderBackend(modeId, { ...backendOptions, unitUrl: unitServer?.unitUrl });
     openBackend = renderer;
+
+    // A mode whose height is measured needs a local full-document render to measure from. Read for
+    // the whole corpus before anything is posted: discovering it document by document would leave a
+    // half-rendered corpus and a bill for the part that worked.
+    const measuredHeights = mode.needsMeasuredHeight
+      ? measuredHeightsFor(paths, manifest.documents, modeId)
+      : null;
 
     // Nothing will notice if these renders are pictures of the wrong thing.
     //
@@ -352,7 +446,9 @@ async function commandRender(flags: Record<string, string | true>, deps: Harness
           backendId: renderer.backendId,
           backendVersion: renderer.backendVersion,
           contentSha256: document.contentSha256,
-          renderTarget: renderer.renderTarget
+          // Compared against the height this document would be captured at now, not the mode's
+          // nominal one: a document whose local render has since changed height is stale here too.
+          renderTarget: targetFor(renderer, measuredHeights, document.id)
         }, file).fresh) {
           reused += 1;
           return false;
@@ -371,10 +467,44 @@ async function commandRender(flags: Record<string, string | true>, deps: Harness
         if (index >= pending.length) return;
         const document = pending[index];
         const file = imageRepresentationPath(paths, renderer.modeId, document.id);
+        // A document this mode cannot represent leaves nothing behind. It is in `pending` because
+        // whatever is on disk is stale, and those files are pictures of a document that no longer
+        // looks like that — unusable, and student work once the corpus is real. Nothing else would
+        // ever clear them: `render` only overwrites what it re-renders, and `--prune` only reaches
+        // documents that have left the manifest.
+        const skipWithoutCapturing = (reason: string) => {
+          log(`skipped ${document.id}: ${reason}`);
+          const removed = removeImageRepresentation(file);
+          if (removed.length > 0) {
+            log(`  removed ${removed.length} stale file(s) from the previous ${renderer.modeId} render`);
+          }
+          nothingToCapture += 1;
+        };
         try {
+          const content = readCorpusDocument(paths, document);
+          const declaredTiles = expectedTileCount(content);
+          // A per-tile mode has nothing to photograph in a document whose content declares no tiles.
+          // That is a fact about the document, not a failure of the render — the mode simply cannot
+          // represent it, and a run skips it for the same reason.
+          if (renderer.renderTarget.captureMode === "per-tile" && declaredTiles === 0) {
+            skipWithoutCapturing("its content declares no tiles, so a per-tile capture has " +
+              "nothing to photograph");
+            continue;
+          }
+          // A measured-height mode has no height for a document that is known not to render, and
+          // must not fall back: an absent `captureHeightPx` reaches the backend as the fixed
+          // production height, which is the very thing this mode exists not to do — and the result
+          // would be filed as a capture at the document's own measured height.
+          if (measuredHeights && !measuredHeights.has(document.id)) {
+            skipWithoutCapturing(`${document.expectedRenderFailure
+              ? `it is expected not to render ("${document.expectedRenderFailure}"), so there is no `
+              : "it has no "}measured height for --mode ${modeId} to capture at`);
+            continue;
+          }
           const outcome = await renderer.render({
             docId: document.id,
-            content: readCorpusDocument(paths, document)
+            content,
+            ...(measuredHeights ? { captureHeightPx: measuredHeights.get(document.id) } : {})
           });
           writeImageRepresentation({
             envelopeFile: file,
@@ -382,7 +512,9 @@ async function commandRender(flags: Record<string, string | true>, deps: Harness
             modeId: renderer.modeId,
             backendId: renderer.backendId,
             backendVersion: renderer.backendVersion,
-            renderTarget: renderer.renderTarget,
+            // The backend reports its own target when the render differed from the mode's nominal
+            // one, which is how a per-document height reaches the envelope.
+            renderTarget: outcome.renderTarget ?? renderer.renderTarget,
             sourceContentSha256: document.contentSha256,
             generatedAt: now().toISOString(),
             images: outcome.images.map((image) => ({
@@ -393,6 +525,19 @@ async function commandRender(flags: Record<string, string | true>, deps: Harness
           // The document renders now, so the previous run's evidence is evidence of nothing — and
           // leaving it behind would keep a PNG of student work that no envelope refers to.
           fs.rmSync(renderErrorDir(paths, renderer.modeId, document.id), { recursive: true, force: true });
+          // The document loaded and drew nothing. Not fatal — `empty` is a real fixture — but for
+          // any document whose content declares tiles it means the picture is of the wrong thing,
+          // and until now only *unknown* tiles were ever mentioned.
+          if (document.expectedRenderFailure) {
+            // The expectation is now wrong, and a stale one is worse than none: it would go on
+            // hiding a real failure the day this document breaks again.
+            log(`warning: ${document.id} rendered, but the manifest says it should not ` +
+              `("${document.expectedRenderFailure}"). Clear expectedRenderFailure for it.`);
+          }
+          if (declaredTiles > 0 && outcome.diagnostics.totalTiles === 0) {
+            log(`warning: ${document.id} declares ${declaredTiles} tile(s) but drew none; the ` +
+              "capture is of a document that rendered nothing");
+          }
           if (outcome.diagnostics.unknownTiles) {
             // Not fatal — the Unknown and Placeholder fixtures are *supposed* to draw this way — but
             // never silent, because for any other document it means the unit did not register its
@@ -401,7 +546,13 @@ async function commandRender(flags: Record<string, string | true>, deps: Harness
               `of ${outcome.diagnostics.totalTiles ?? "?"}`);
           }
         } catch (error) {
-          failures.push(document.id);
+          // Known not to render, and why: reported apart from real failures so the exit code keeps
+          // meaning something, since a corpus that always exits non-zero is one nobody checks. The
+          // evidence is written either way — a document expected to fail one way and failing
+          // another is exactly the case the screenshot is for, and the failure message points at it.
+          const expected = document.expectedRenderFailure;
+          if (expected) expectedFailures.push(document.id);
+          else failures.push(document.id);
           const directory = renderErrorDir(paths, renderer.modeId, document.id);
           // Cleared first: a previous attempt's screenshot and console output would otherwise be
           // presented as evidence for this error, and would keep an older copy of the document.
@@ -419,8 +570,10 @@ async function commandRender(flags: Record<string, string | true>, deps: Harness
           // The picture of the failure, where the backend could take one. For a visual failure this
           // is often the only evidence there is — the console is empty and the page is half drawn.
           if (context?.screenshot) fs.writeFileSync(path.join(directory, "screenshot.png"), context.screenshot);
-          log(`error: ${(error as Error).message}`);
-          log(`  evidence written to ${directory}`);
+          log(expected
+            ? `expected failure: ${document.id} (${expected})`
+            : `error: ${(error as Error).message}`);
+          log(`  ${expected ? `${(error as Error).message}\n  ` : ""}evidence written to ${directory}`);
         }
       }
     };
@@ -444,8 +597,18 @@ async function commandRender(flags: Record<string, string | true>, deps: Harness
     await closeQuietly("the unit server", unitServer?.close?.bind(unitServer));
   }
 
+  // The settings are named in the line, so a run that needed them says so in its own output rather
+  // than only in the shell history of whoever typed it. The per-document budget is named only by the
+  // modes that keep one: a hosted mode bounds its request and its download separately and has no
+  // whole-document deadline, so printing one would describe a limit nothing enforces.
+  const settings = mode.unusableFlags.includes("timeoutMs")
+    ? `${concurrency} at a time`
+    : `${concurrency} at a time, ${timeoutMs ?? kDefaultRenderTimeoutMs}ms per document`;
   log(`Rendered ${rendered} document(s) with --mode ${modeId}, reused ${reused} still-fresh ` +
-    `one(s), ${failures.length} failed.`);
+    `one(s), ${failures.length} failed` +
+    (expectedFailures.length > 0 ? `, ${expectedFailures.length} expected to fail` : "") +
+    (nothingToCapture > 0 ? `, ${nothingToCapture} with nothing to capture` : "") +
+    `. (${settings}.)`);
   if (rendered > 0) {
     // New pixels mean new request keys, which means a full re-spend on any run that uses them.
     log("Regenerated renders produce new request keys, so runs using them will pay for those calls again.");
@@ -469,7 +632,7 @@ function commandPlan(flags: Record<string, string | true>, deps: HarnessDeps): v
   const { experiment } = loadExperiment(required(flags, "experiment"));
   const pricingConfig = loadPricingConfig();
   const pricing = pricingFor(pricingConfig, kDefaultModel);
-  const { tasks } = buildTasks({
+  const { tasks, skipped, documents } = buildTasks({
     corpusPaths: corpusPaths(dataRootFor(deps), corpus),
     experiment,
     promptsDir,
@@ -477,7 +640,8 @@ function commandPlan(flags: Record<string, string | true>, deps: HarnessDeps): v
   });
 
   log(`Experiment "${experiment.name}": ${experiment.runs.length} run(s) × ` +
-    `${tasks.length / Math.max(1, experiment.runs.length)} document(s) = ${tasks.length} call(s).`);
+    `${documents.length} document(s) = ${tasks.length} call(s)` +
+    (skipped.length > 0 ? `, ${skipped.length} skipped.` : "."));
   log(`Model ${kDefaultModel}, prices effective ${pricingConfig.effectiveDate}, ` +
     `max_completion_tokens ${pricing.maxOutputTokens}.`);
   let total = 0;
@@ -491,16 +655,28 @@ function commandPlan(flags: Record<string, string | true>, deps: HarnessDeps): v
     // Read from the mode descriptor rather than by building a backend: construction validates URLs
     // and limits, and shells out to git for the local mode, none of which belongs in a command that
     // promises to touch nothing.
-    const shape = run.message === "image-only"
-      ? ` [image-only, --mode ${run.imageMode}; ${renderMode(run.imageMode!).prerequisites}]`
-      : ` [text-only, ${run.textVariant}]`;
+    // Built from what the shape actually sends rather than from a two-way ternary. The old one
+    // predated `mixed` and labelled it "text-only", so `plan` -- the record of what a run was about
+    // to do -- described a mixed run as something else while printing its images underneath.
+    const carries = [run.message as string];
+    if (sendsText(run.message)) carries.push(run.textVariant!);
+    if (sendsImages(run.message)) carries.push(`--mode ${run.imageMode}`);
+    const shape = ` [${carries.join(", ")}` +
+      (run.imageMode ? `; ${renderMode(run.imageMode).prerequisites}` : "") + "]";
     log(`  ${run.id}: ${runTasksForRun.length} call(s), worst case $${runTotal.toFixed(4)}${shape}`);
-    if (run.message === "image-only") {
+    if (run.imageMode) {
       // Where the pictures came from, resolved rather than described. Every render target value has
       // a default, and omitting `--shutterbug-url` posts student work at staging without saying so.
-      log(`    renders against: ${renderMode(run.imageMode!).renderTargetSummary}`);
+      log(`    renders against: ${renderMode(run.imageMode).renderTargetSummary}`);
     }
     if (imageTokens > 0) {
+      // How many pictures, not just what they cost: a per-tile set sends one image per tile, and
+      // each one carries the base charge again. That multiplication is the thing to see *before*
+      // paying for it, so it is stated per run beside the total it produces.
+      const images = runTasksForRun.reduce((sum, task) => sum + task.imageCount, 0);
+      const perDocument = images / Math.max(1, runTasksForRun.length);
+      log(`    ${images} image(s) across ${runTasksForRun.length} call(s) ` +
+        `(${perDocument.toFixed(1)} per document, imageSet ${run.imageSet ?? "full-document"})`);
       // Reserved at the high-detail rate, because the shared builder sends `auto` and the provider
       // publishes an exact formula only for explicit low and high.
       log(`    image tokens (estimated, auto priced at the high rate): ${imageTokens}`);
@@ -527,7 +703,7 @@ async function commandRun(flags: Record<string, string | true>, deps: HarnessDep
   const dataRoot = dataRootFor(deps);
   const pricingConfig = loadPricingConfig();
   const pricing = pricingFor(pricingConfig, kDefaultModel);
-  const { tasks } = buildTasks({
+  const { tasks, skipped } = buildTasks({
     corpusPaths: corpusPaths(dataRoot, corpus),
     experiment,
     promptsDir,
@@ -569,6 +745,7 @@ async function commandRun(flags: Record<string, string | true>, deps: HarnessDep
     experiment,
     experimentSha256,
     tasks,
+    skipped,
     outputFile,
     ledger,
     cache: new ResponseCache(path.join(dataRoot, "cache"), cacheOptions),
@@ -581,6 +758,12 @@ async function commandRun(flags: Record<string, string | true>, deps: HarnessDep
 
   log(`Wrote ${summary.written} row(s) to ${outputFile} ` +
     `(${summary.resumed} already complete, ${summary.cacheHits} from cache, ${summary.apiCalls} API call(s)).`);
+  if (summary.skipped > 0) {
+    // Named rather than folded into the row count: a skipped row costs nothing and answers nothing,
+    // and a reader comparing runs needs to know how much of the corpus each one actually looked at.
+    log(`${summary.skipped} (run, document) pair(s) were skipped and recorded as skipped rows, with ` +
+      "reasons. See the `skipped` column in `report`.");
+  }
   log(`Reserved at peak $${summary.reservedPeakUsd.toFixed(4)} of the $${maxCost.toFixed(4)} ceiling; ` +
     `actually spent $${summary.incurredUsd.toFixed(4)}.`);
   // Gated on work actually skipped, not merely on the ceiling having been reached: a run that

--- a/scripts/ai-harness/harness.ts
+++ b/scripts/ai-harness/harness.ts
@@ -639,9 +639,16 @@ function commandPlan(flags: Record<string, string | true>, deps: HarnessDeps): v
     pricing
   });
 
+  // The product is of runs and documents, which is the number of *pairs* — not the number of calls,
+  // because skip-empty declines some of them. Stating it as `= N call(s), M skipped` made the
+  // multiplication false on any corpus with a skip, in the one command someone reads to decide
+  // whether to spend money. Both figures below are checkable: the product, and the split of it.
+  const pairs = experiment.runs.length * documents.length;
   log(`Experiment "${experiment.name}": ${experiment.runs.length} run(s) × ` +
-    `${documents.length} document(s) = ${tasks.length} call(s)` +
-    (skipped.length > 0 ? `, ${skipped.length} skipped.` : "."));
+    `${documents.length} document(s) = ${pairs} pair(s)` +
+    (skipped.length > 0
+      ? `; ${tasks.length} call(s), ${skipped.length} skipped.`
+      : `, all sent as ${tasks.length} call(s).`));
   log(`Model ${kDefaultModel}, prices effective ${pricingConfig.effectiveDate}, ` +
     `max_completion_tokens ${pricing.maxOutputTokens}.`);
   let total = 0;

--- a/scripts/ai-harness/prompts/categorize-design-mixed.json
+++ b/scripts/ai-harness/prompts/categorize-design-mixed.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "name": "categorize-design-mixed",
   "aiPrompt": {
-    "mainPrompt": "This is a student document, given to you as a written summary and a picture of it.\nThey are working on engineering task. Please tell me which of the following areas of their design they are focusing on:\n- user: who's it for?\n- environment: where's it used?\n- form: what's it look like?\n- function: what does it do?\nand why you chose that area.\nOr if the document doesn't include enough content to clearly identify a focus area let me know by setting \"category\" to \"unknown\".\nYour answer should be a JSON document in the given format.",
+    "mainPrompt": "This is a student document. You are given a picture of it. When the student has written something, you are also given a written summary of the document.\nThey are working on engineering task. Please tell me which of the following areas of their design they are focusing on:\n- user: who's it for?\n- environment: where's it used?\n- form: what's it look like?\n- function: what does it do?\nand why you chose that area.\nOr if the document doesn't include enough content to clearly identify a focus area let me know by setting \"category\" to \"unknown\".\nYour answer should be a JSON document in the given format.",
     "categorizationDescription": "Categorize the document based on its content.",
     "categories": [
       "user",
@@ -15,8 +15,8 @@
     "systemPrompt": "You are a teaching assistant in an engineering design course."
   },
   "provenance": {
-    "source": "authored for the harness: categorize-design-default with its opening sentence reworded for a message carrying both a summary and a picture. Only that sentence differs, deliberately -- everything else is production's wording verbatim, including \"working on engineering task\", which is production's grammar and not a typo to fix here. Correcting it would make this prompt differ from the one the image-only and text-only runs use in a second way, and those comparisons are the point. It would also change aiPromptSha256, which is part of every request key: the fix belongs in shared/ai-analysis-messages.ts, and this copy follows it.",
+    "source": "authored for the harness: categorize-design-default with its opening replaced, for a message carrying a picture and -- when the student wrote something -- a summary as well. It has to cover both, because a mixed run sends the pictures for a document with no student text and drops the summary; an opening that promised one described a message the model had not been given, which was true of 16 of the 23 rows the first recorded run sent. Only the opening differs -- everything else is production's wording verbatim, including \"working on engineering task\", which is production's grammar and not a typo to fix here. Correcting it would make this prompt differ from the one the image-only and text-only runs use in a further way, and those comparisons are the point. It would also change aiPromptSha256, which is part of every request key: the fix belongs in shared/ai-analysis-messages.ts, and this copy follows it.",
     "retrievedAt": "2026-08-18",
-    "aiPromptSha256": "4970687e85754bf4b10370dfa674439d8dc154f0d56bd11b8d3713afad1c1ce5"
+    "aiPromptSha256": "e9c17e34f3494923473ada2b8879a62021d5a63892dbd13ed6937ac3535551fb"
   }
 }

--- a/scripts/ai-harness/prompts/categorize-design-mixed.json
+++ b/scripts/ai-harness/prompts/categorize-design-mixed.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "name": "categorize-design-mixed",
   "aiPrompt": {
-    "mainPrompt": "This is a student document, given to you as a written summary and a picture of it.\nThey are working on an engineering task. Please tell me which of the following areas of their design they are focusing on:\n- user: who's it for?\n- environment: where's it used?\n- form: what's it look like?\n- function: what does it do?\nand why you chose that area.\nOr if the document doesn't include enough content to clearly identify a focus area let me know by setting \"category\" to \"unknown\".\nYour answer should be a JSON document in the given format.",
+    "mainPrompt": "This is a student document, given to you as a written summary and a picture of it.\nThey are working on engineering task. Please tell me which of the following areas of their design they are focusing on:\n- user: who's it for?\n- environment: where's it used?\n- form: what's it look like?\n- function: what does it do?\nand why you chose that area.\nOr if the document doesn't include enough content to clearly identify a focus area let me know by setting \"category\" to \"unknown\".\nYour answer should be a JSON document in the given format.",
     "categorizationDescription": "Categorize the document based on its content.",
     "categories": [
       "user",
@@ -15,7 +15,7 @@
     "systemPrompt": "You are a teaching assistant in an engineering design course."
   },
   "provenance": {
-    "source": "authored for the harness: categorize-design-default with its opening sentence reworded for a message carrying both a summary and a picture",
+    "source": "authored for the harness: categorize-design-default with its opening sentence reworded for a message carrying both a summary and a picture. Only that sentence differs, deliberately -- everything else is production's wording verbatim, including \"working on engineering task\", which is production's grammar and not a typo to fix here. Correcting it would make this prompt differ from the one the image-only and text-only runs use in a second way, and those comparisons are the point. It would also change aiPromptSha256, which is part of every request key: the fix belongs in shared/ai-analysis-messages.ts, and this copy follows it.",
     "retrievedAt": "2026-08-18",
     "aiPromptSha256": "4970687e85754bf4b10370dfa674439d8dc154f0d56bd11b8d3713afad1c1ce5"
   }

--- a/scripts/ai-harness/prompts/categorize-design-mixed.json
+++ b/scripts/ai-harness/prompts/categorize-design-mixed.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "name": "categorize-design-mixed",
   "aiPrompt": {
-    "mainPrompt": "This is a student document, given to you as a written summary and a picture of it.\nThey are working on engineering task. Please tell me which of the following areas of their design they are focusing on:\n- user: who's it for?\n- environment: where's it used?\n- form: what's it look like?\n- function: what does it do?\nand why you chose that area.\nOr if the document doesn't include enough content to clearly identify a focus area let me know by setting \"category\" to \"unknown\".\nYour answer should be a JSON document in the given format.",
+    "mainPrompt": "This is a student document, given to you as a written summary and a picture of it.\nThey are working on an engineering task. Please tell me which of the following areas of their design they are focusing on:\n- user: who's it for?\n- environment: where's it used?\n- form: what's it look like?\n- function: what does it do?\nand why you chose that area.\nOr if the document doesn't include enough content to clearly identify a focus area let me know by setting \"category\" to \"unknown\".\nYour answer should be a JSON document in the given format.",
     "categorizationDescription": "Categorize the document based on its content.",
     "categories": [
       "user",

--- a/scripts/ai-harness/prompts/categorize-design-mixed.json
+++ b/scripts/ai-harness/prompts/categorize-design-mixed.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": 1,
+  "name": "categorize-design-mixed",
+  "aiPrompt": {
+    "mainPrompt": "This is a student document, given to you as a written summary and a picture of it.\nThey are working on engineering task. Please tell me which of the following areas of their design they are focusing on:\n- user: who's it for?\n- environment: where's it used?\n- form: what's it look like?\n- function: what does it do?\nand why you chose that area.\nOr if the document doesn't include enough content to clearly identify a focus area let me know by setting \"category\" to \"unknown\".\nYour answer should be a JSON document in the given format.",
+    "categorizationDescription": "Categorize the document based on its content.",
+    "categories": [
+      "user",
+      "environment",
+      "form",
+      "function"
+    ],
+    "keyIndicatorsPrompt": "What are the key indicators that support this categorization?",
+    "discussionPrompt": "Please provide any additional discussion or context regarding the categorization.",
+    "systemPrompt": "You are a teaching assistant in an engineering design course."
+  },
+  "provenance": {
+    "source": "authored for the harness: categorize-design-default with its opening sentence reworded for a message carrying both a summary and a picture",
+    "retrievedAt": "2026-08-18",
+    "aiPromptSha256": "4970687e85754bf4b10370dfa674439d8dc154f0d56bd11b8d3713afad1c1ce5"
+  }
+}

--- a/scripts/ai-harness/src/backends/index.ts
+++ b/scripts/ai-harness/src/backends/index.ts
@@ -11,8 +11,9 @@ import { git } from "../files.js";
 import { RenderBackend } from "./types.js";
 import { kPuppeteerBackendVersion, puppeteerBackend } from "./puppeteer.js";
 import {
-  kProductionCaptureHeightPx, kProductionClueUrl, kProductionShutterbugUrl, kProductionUnit,
-  kShutterbugBackendVersion, kStagingShutterbugUrl, shutterbugParameterized, shutterbugProductionCurrent
+  FetchLike, kProductionCaptureHeightPx, kProductionClueUrl, kProductionShutterbugUrl,
+  kProductionUnit, kShutterbugBackendVersion, kStagingShutterbugUrl, shutterbugAccurateHeight,
+  shutterbugParameterized, shutterbugProductionCurrent
 } from "./shutterbug.js";
 import { kHarnessRenderUnitId } from "./render-unit.js";
 
@@ -45,6 +46,14 @@ export interface RenderModeDescriptor {
   defaultUnit: string | null;
   /** Whether `render` must serve the harness's own rendering unit for this mode. */
   needsUnitServer: boolean;
+  /**
+   * Whether each document is captured at its own measured height, which `render` reads from a
+   * previous local full-document render and hands over per document.
+   *
+   * It makes this mode a two-step operation — render locally, then here — which is a real cost, and
+   * the only way to send a true height to a service that cannot measure anything itself.
+   */
+  needsMeasuredHeight?: boolean;
   /** Options this mode cannot honour, by the CLI flag a caller would have used. */
   unusableFlags: (keyof RenderModeOptions)[];
   build(options: RenderModeOptions): RenderBackend;
@@ -52,8 +61,10 @@ export interface RenderModeDescriptor {
 
 export const renderModeIds = [
   "puppeteer-full-height",
+  "puppeteer-per-tile",
   "shutterbug-production-current",
-  "shutterbug-parameterized"
+  "shutterbug-parameterized",
+  "shutterbug-accurate-height"
 ] as const;
 export type RenderModeId = typeof renderModeIds[number];
 
@@ -65,8 +76,18 @@ const kFlagNames: Partial<Record<keyof RenderModeOptions, string>> = {
   clueUrl: "--clue-url",
   unit: "--unit",
   shutterbugUrl: "--shutterbug-url",
-  captureHeightPx: "--capture-height"
+  captureHeightPx: "--capture-height",
+  timeoutMs: "--timeout-ms"
 };
+
+/**
+ * The flags that say where a render is taken, as opposed to how it is driven.
+ *
+ * Only these are answered with "use the parameterized mode instead", which is advice about the
+ * render target and no help at all to someone who asked for a longer timeout.
+ */
+const kRenderTargetFlags: (keyof RenderModeOptions)[] =
+  ["clueUrl", "unit", "shutterbugUrl", "captureHeightPx"];
 
 export interface RenderModeOptions {
   clueUrl?: string;
@@ -78,9 +99,17 @@ export interface RenderModeOptions {
   /** What CLUE build is being rendered. `null` is recorded, and `render` warns about it. */
   clueRevision?: string | null;
   launch?: Parameters<typeof puppeteerBackend>[0]["launch"];
+  /**
+   * Injected by tests so a Shutterbug mode can be driven through the CLI without a network, the
+   * same seam `launch` gives the local mode. Without it these modes could only be tested one layer
+   * down, and nothing covered what `render` itself hands them.
+   */
+  fetchImpl?: FetchLike;
   /** Readiness timing, lowered by tests so a fake browser does not sit through real intervals. */
   stableForMs?: number;
   pollIntervalMs?: number;
+  /** The whole budget for one document: load, readiness and capture together. */
+  timeoutMs?: number;
 }
 
 export const renderModes: Record<RenderModeId, RenderModeDescriptor> = {
@@ -96,13 +125,45 @@ export const renderModes: Record<RenderModeId, RenderModeDescriptor> = {
     // would silently answer a different question from the one that was asked.
     unusableFlags: ["shutterbugUrl", "captureHeightPx"],
     build: (options) => puppeteerBackend({
+      modeId: "puppeteer-full-height",
       clueUrl: options.clueUrl ?? kDefaultClueUrl,
       unit: requireUnit(options.unit, "puppeteer-full-height"),
       unitUrl: options.unitUrl,
       clueRevision: options.clueRevision === undefined ? localClueRevision() : options.clueRevision,
       launch: options.launch,
       stableForMs: options.stableForMs,
-      pollIntervalMs: options.pollIntervalMs
+      pollIntervalMs: options.pollIntervalMs,
+      timeoutMs: options.timeoutMs
+    })
+  },
+  /**
+   * The same page, the same readiness protocol and the same sizing as `puppeteer-full-height` —
+   * only the last step differs, so the two cannot disagree about when a document is ready to
+   * photograph. It exists so a run can send one picture per tile instead of one of the page.
+   *
+   * Filed under its own mode id, like every mode, so a per-tile render and a full-document one can
+   * both exist for the same document.
+   */
+  "puppeteer-per-tile": {
+    backendId: "puppeteer",
+    backendVersion: kPuppeteerBackendVersion,
+    prerequisites: `a CLUE dev server at ${kDefaultClueUrl} (npm start); no OpenAI key`,
+    renderTargetSummary: `${kDefaultClueUrl} (--clue-url), unit ${kHarnessRenderUnitId} (--unit), ` +
+      "captured one image per top-level tile",
+    defaultUnit: kHarnessRenderUnitId,
+    needsUnitServer: true,
+    unusableFlags: ["shutterbugUrl", "captureHeightPx"],
+    build: (options) => puppeteerBackend({
+      modeId: "puppeteer-per-tile",
+      clueUrl: options.clueUrl ?? kDefaultClueUrl,
+      unit: requireUnit(options.unit, "puppeteer-per-tile"),
+      unitUrl: options.unitUrl,
+      clueRevision: options.clueRevision === undefined ? localClueRevision() : options.clueRevision,
+      launch: options.launch,
+      stableForMs: options.stableForMs,
+      pollIntervalMs: options.pollIntervalMs,
+      timeoutMs: options.timeoutMs,
+      capture: "per-tile"
     })
   },
   "shutterbug-production-current": {
@@ -114,8 +175,11 @@ export const renderModes: Record<RenderModeId, RenderModeDescriptor> = {
     defaultUnit: null,
     needsUnitServer: false,
     // Frozen by definition: this mode exists to match production's request envelope.
-    unusableFlags: ["clueUrl", "unit", "shutterbugUrl", "captureHeightPx"],
-    build: (options) => shutterbugProductionCurrent({ clueRevision: options.clueRevision ?? null })
+    unusableFlags: ["clueUrl", "unit", "shutterbugUrl", "captureHeightPx", "timeoutMs"],
+    build: (options) => shutterbugProductionCurrent({
+      clueRevision: options.clueRevision ?? null,
+      fetchImpl: options.fetchImpl
+    })
   },
   "shutterbug-parameterized": {
     backendId: "shutterbug",
@@ -129,13 +193,35 @@ export const renderModes: Record<RenderModeId, RenderModeDescriptor> = {
       "(--capture-height)",
     defaultUnit: null,
     needsUnitServer: false,
-    unusableFlags: [],
+    unusableFlags: ["timeoutMs"],
     build: (options) => shutterbugParameterized({
       clueUrl: options.clueUrl,
       unit: options.unit,
       shutterbugUrl: options.shutterbugUrl,
       captureHeightPx: options.captureHeightPx,
-      clueRevision: options.clueRevision ?? null
+      clueRevision: options.clueRevision ?? null,
+      fetchImpl: options.fetchImpl
+    })
+  },
+  "shutterbug-accurate-height": {
+    backendId: "shutterbug",
+    backendVersion: kShutterbugBackendVersion,
+    prerequisites: `a local ${kDefaultRenderModeId} render of the same corpus, plus network access ` +
+      `to the Shutterbug endpoint (${kStagingShutterbugUrl} unless --shutterbug-url says otherwise) ` +
+      "and the CLUE URL; no OpenAI key",
+    renderTargetSummary: `${kProductionClueUrl} (--clue-url), unit ${kProductionUnit} (--unit), via ` +
+      `${kStagingShutterbugUrl} (--shutterbug-url), clipped at each document's own measured height`,
+    defaultUnit: null,
+    needsUnitServer: false,
+    needsMeasuredHeight: true,
+    // The height is measured, not chosen, so accepting one would answer a different question.
+    unusableFlags: ["captureHeightPx", "timeoutMs"],
+    build: (options) => shutterbugAccurateHeight({
+      clueUrl: options.clueUrl,
+      unit: options.unit,
+      shutterbugUrl: options.shutterbugUrl,
+      clueRevision: options.clueRevision ?? null,
+      fetchImpl: options.fetchImpl
     })
   }
 };
@@ -183,12 +269,14 @@ export function localClueRevision(): string | null {
  * the backend first meant an invalid flag left the server listening and hung the CLI.
  */
 export function assertRenderModeOptions(modeId: string, options: RenderModeOptions = {}): void {
-  const given = renderMode(modeId).unusableFlags
-    .filter((option) => options[option] !== undefined)
-    .map((option) => kFlagNames[option] ?? String(option));
+  const rejected = renderMode(modeId).unusableFlags.filter((option) => options[option] !== undefined);
+  const given = rejected.map((option) => kFlagNames[option] ?? String(option));
   if (given.length > 0) {
+    const hint = rejected.some((option) => kRenderTargetFlags.includes(option))
+      ? " Use --mode shutterbug-parameterized to change the render target."
+      : "";
     throw new Error(`${given.join(", ")} ${given.length === 1 ? "is" : "are"} not configurable for ` +
-      `--mode ${modeId}. Use --mode shutterbug-parameterized to change the render target.`);
+      `--mode ${modeId}.${hint}`);
   }
 }
 

--- a/scripts/ai-harness/src/backends/puppeteer.ts
+++ b/scripts/ai-harness/src/backends/puppeteer.ts
@@ -363,9 +363,9 @@ export function expectedTileCount(content: unknown): number {
   for (const row of Object.values(rowMap ?? {})) {
     for (const tile of row?.tiles ?? []) if (tile?.tileId) ids.add(tile.tileId);
   }
-  // An empty walk falls through to the tile map rather than answering 0. A present-but-empty
-  // `rowMap` used to take this branch and expect no tiles at all, which any state satisfies —
-  // including a page that has not finished loading, whose screenshot is blank.
+  // An empty walk falls through to the tile map rather than answering 0. Expecting no tiles at all
+  // is satisfied by any state whatsoever, including a page that has not finished loading, whose
+  // screenshot is blank.
   if (ids.size > 0) return ids.size;
   const tileMap = (content as { tileMap?: Record<string, unknown> })?.tileMap;
   return tileMap ? Object.keys(tileMap).length : 0;
@@ -469,11 +469,6 @@ async function waitUntilSettled(
   // the tiles has settled". A page that never reaches its expected tile count must still stop
   // waiting eventually, so the second clock accepts what is there once it has been quiet for a good
   // while longer, and the caller decides whether what is there is worth keeping.
-  //
-  // This comment used to say the ErrorTest fixture "renders an error boundary and no tile at all",
-  // and that a capture of it was wanted. Both halves were wrong: ErrorTest takes the whole document
-  // down, so CLUE shows its error page, and a picture of that page is the one thing a render must
-  // not store. `documentFailedToLoad` fails it now.
   const graceMs = stableForMs * 6;
   let previous: FrameMeasurement | undefined;
   let stableSince: number | undefined;
@@ -662,9 +657,9 @@ export function puppeteerBackend(options: PuppeteerBackendOptions): RenderBacken
           measured = await waitUntilSettled(
             frame, request.docId, deadline, stableForMs, pollIntervalMs, expectedTiles, contextOf);
         }
-        // Checked again after the resize. A fatal console line or a failed script request during the
-        // second settle used to land in the evidence file without failing the render, so the
-        // document was captured and stored as if nothing had gone wrong.
+        // Checked again after the resize, because the second settle has its own failures: a fatal
+        // console line or a failed script request there would otherwise reach the evidence file
+        // without failing anything, and the document would be captured as if nothing had happened.
         failOnFatal();
         // The guarantee that nothing is cut off is made by construction — the frame is sized to
         // cover the tile rows, and the capture is checked against them below — rather than by a DOM
@@ -773,7 +768,7 @@ export function puppeteerBackend(options: PuppeteerBackendOptions): RenderBacken
       } catch (error) {
         // Evidence is attached to *any* failure, not only to a RenderFailed. A navigation error, a
         // size-limit rejection or a raw protocol error is exactly when the console output and a
-        // picture of the page are most wanted, and those used to arrive carrying neither.
+        // picture of the page are most wanted.
         const context = error instanceof RenderFailed ? error.context : contextOf();
         if (!context.screenshot) {
           try {

--- a/scripts/ai-harness/src/backends/puppeteer.ts
+++ b/scripts/ai-harness/src/backends/puppeteer.ts
@@ -10,7 +10,7 @@
  * Puppeteer is imported lazily so that every other module here — and every test that does not drive
  * a browser — loads without it.
  */
-import { RenderTarget } from "../schemas.js";
+import { CaptureMode, RenderTarget } from "../schemas.js";
 import { readPngInfo } from "../png.js";
 import { generateRenderHtml, iframeUrlFor, kInitialFrameHeightPx } from "./render-html.js";
 import {
@@ -30,6 +30,8 @@ export interface ElementLike {
 export interface FrameLike {
   url(): string;
   evaluate<T>(fn: string | ((...args: any[]) => T), ...args: any[]): Promise<T>;
+  /** Every element matching the selector, in document order. Used by the per-tile capture. */
+  $$(selector: string): Promise<ElementLike[]>;
 }
 
 export interface PageLike {
@@ -98,6 +100,12 @@ export class RenderFailed extends Error {
 }
 
 export interface PuppeteerBackendOptions {
+  /**
+   * The `--mode` id this backend is being built for, which is also the directory its envelopes are
+   * filed under. Passed in rather than fixed: the same backend serves more than one mode, and a
+   * hardcoded id filed a per-tile render on top of the full-document one.
+   */
+  modeId: string;
   clueUrl: string;
   /**
    * The unit's stable identifier — what goes into the render target and is compared for freshness.
@@ -121,6 +129,13 @@ export interface PuppeteerBackendOptions {
   launch?: () => Promise<BrowserLike>;
   /** Injected by tests, so a fake browser needs no real loopback server. */
   startPageServer?: () => Promise<RenderPageServer>;
+  /**
+   * What the mode captures: one picture of the whole document, or one per top-level tile.
+   *
+   * Per-tile is the same page, the same readiness protocol and the same sizing — only the last step
+   * differs, so the two modes cannot disagree about when a document is ready to photograph.
+   */
+  capture?: Extract<CaptureMode, "full-document" | "per-tile">;
 }
 
 async function launchPuppeteer(): Promise<BrowserLike> {
@@ -150,13 +165,21 @@ const kMeasureFrameScript = `(() => {
   const rows = document.querySelectorAll('.tile-row');
   let rowsHeight = 0;
   rows.forEach((row) => { rowsHeight += row.getBoundingClientRect().height; });
+  const documentError = document.querySelector('.document-error');
   return {
+    // CLUE renders its own "Error loading the document" page when it cannot deserialize what it was
+    // handed. That page photographs perfectly well, which is exactly the problem: without this the
+    // capture is a valid PNG of an error screen, stored as though it were the student's work.
+    documentFailedToLoad: !!documentError,
     contentHeightPx: app ? app.scrollHeight : 0,
     // The document's own height — the tile rows themselves. CLUE lays out to fill its viewport (the
     // iframe element) rather than to its content, so nothing else reports how tall the document
     // actually is: the scroller always matches the frame exactly, at any frame height. Sizing the
     // frame from this is what makes the capture the whole document rather than a viewport of it.
     contentRowsHeightPx: Math.ceil(rowsHeight),
+    // Every tile, nested ones included — deliberately not \`kTileSelector\`, which photographs
+    // top-level tiles only. This one is counting what drew, and an unregistered tile type inside a
+    // Question is exactly as worth reporting as one in a row of its own.
     totalTiles: document.querySelectorAll('.tool-tile').length,
     unknownTiles: document.querySelectorAll('.placeholder-tile').length,
     fontsReady: !document.fonts || document.fonts.status === 'loaded'
@@ -170,6 +193,8 @@ const kMeasureFrameScript = `(() => {
 const kReadDocumentTextScript = "document.body ? document.body.innerText : ''";
 
 export interface FrameMeasurement {
+  /** True when CLUE showed its document-error page instead of the document. */
+  documentFailedToLoad: boolean;
   contentHeightPx: number;
   contentRowsHeightPx: number;
   totalTiles: number;
@@ -353,6 +378,23 @@ export { kInitialFrameHeightPx };
 const kDocumentChromePx = 80;
 
 /**
+ * The tile elements a per-tile capture photographs, and the attribute carrying each one's id.
+ *
+ * `.tool-tile` is the element `TileComponent` renders (`data-testid="tool-tile"`), and it carries
+ * `data-tool-id` — the tile model's id, which is what the envelope records so a per-tile image can
+ * be matched back to the tile it is a picture of.
+ *
+ * The `:not()` is what makes this top-level tiles rather than all of them. A Question tile renders a
+ * `RowListComponent` (`src/components/tiles/question/question-tile.tsx`), and the tiles inside it are
+ * `.tool-tile` elements too — so a bare `.tool-tile` photographs the Question *and* each tile drawn
+ * inside it, which duplicates content the outer picture already contains and gives one top-level tile
+ * several images. A nested tile is drawn within its parent's picture; that is the picture of it.
+ */
+const kTileSelector = ".tool-tile:not(.tool-tile .tool-tile)";
+const kReadTileIdsScript = `Array.from(document.querySelectorAll('${kTileSelector}'))
+  .map((tile) => tile.getAttribute('data-tool-id') || '')`;
+
+/**
  * An overflow this small, which growing the frame does not reduce, is a rounding or border artifact
  * rather than a clipped document — some containers report a scrollHeight a few pixels over their
  * clientHeight however tall they are made. Anything larger that will not shrink is a real clip, and
@@ -424,9 +466,14 @@ async function waitUntilSettled(
   pollIntervalMs: number, expectedTiles: number, contextOf: () => RenderFailed["context"]
 ): Promise<FrameMeasurement> {
   // Two clocks: one for "everything has settled, tiles included", and one for "everything except
-  // the tiles has settled". A document whose tile legitimately never draws — the ErrorTest fixture
-  // renders an error boundary and no tile at all — must still be captured, so the second clock
-  // accepts what is there once it has been quiet for a good while longer.
+  // the tiles has settled". A page that never reaches its expected tile count must still stop
+  // waiting eventually, so the second clock accepts what is there once it has been quiet for a good
+  // while longer, and the caller decides whether what is there is worth keeping.
+  //
+  // This comment used to say the ErrorTest fixture "renders an error boundary and no tile at all",
+  // and that a capture of it was wanted. Both halves were wrong: ErrorTest takes the whole document
+  // down, so CLUE shows its error page, and a picture of that page is the one thing a render must
+  // not store. `documentFailedToLoad` fails it now.
   const graceMs = stableForMs * 6;
   let previous: FrameMeasurement | undefined;
   let stableSince: number | undefined;
@@ -470,14 +517,15 @@ async function waitUntilSettled(
 
 export function puppeteerBackend(options: PuppeteerBackendOptions): RenderBackend {
   const {
-    clueUrl, unit, clueRevision,
+    modeId, clueUrl, unit, clueRevision,
     // Loaded from wherever it is served; recorded under its stable identifier.
     unitUrl = unit,
     viewportWidthPx = kDefaultViewportWidthPx,
     limits = kDefaultRenderLimits,
     timeoutMs = kDefaultRenderTimeoutMs,
     stableForMs = kDefaultStableForMs,
-    pollIntervalMs = 100
+    pollIntervalMs = 100,
+    capture = "full-document"
   } = options;
   const launch = options.launch ?? launchPuppeteer;
   const startPageServer = options.startPageServer;
@@ -488,7 +536,7 @@ export function puppeteerBackend(options: PuppeteerBackendOptions): RenderBacken
     clueRevision,
     shutterbugUrl: null,
     viewportWidthPx,
-    captureMode: "full-document",
+    captureMode: capture,
     captureHeightPx: null
   };
 
@@ -503,7 +551,7 @@ export function puppeteerBackend(options: PuppeteerBackendOptions): RenderBacken
   const openPageServer = () => (pageServerPromise ??= (startPageServer ?? startRenderPageServer)());
 
   return {
-    modeId: "puppeteer-full-height",
+    modeId,
     backendId: "puppeteer",
     backendVersion: kPuppeteerBackendVersion,
     // "local", not "offline": the CLUE page it loads may still pull fonts, images or other assets
@@ -583,6 +631,15 @@ export function puppeteerBackend(options: PuppeteerBackendOptions): RenderBacken
         let measured = await waitUntilSettled(
           frame, request.docId, deadline, stableForMs, pollIntervalMs, expectedTiles, contextOf);
 
+        // Checked before the resize, so a document that never loaded fails on the cheap path rather
+        // than after being measured, resized, settled again and photographed.
+        if (measured.documentFailedToLoad) {
+          throw new RenderFailed(request.docId,
+            "CLUE could not load this document and showed its error page instead. A capture would " +
+            "be a valid picture of an error screen stored as though it were the student's work — " +
+            "see the screenshot in this document's render-errors directory", contextOf());
+        }
+
         const failOnFatal = () => {
           if (state.fatal.length > 0) {
             throw new RenderFailed(request.docId, `the page reported ${state.fatal.length} error(s): ` +
@@ -617,6 +674,67 @@ export function puppeteerBackend(options: PuppeteerBackendOptions): RenderBacken
         // document is cut off".
         state.heightPx = measured.contentHeightPx;
 
+        const diagnosticsOf = async (): Promise<RenderDiagnostics> => ({
+          reportedHeightPx: measured.contentHeightPx,
+          unknownTiles: measured.unknownTiles,
+          totalTiles: measured.totalTiles,
+          documentText: await withinDeadline(
+            frame.evaluate<string>(kReadDocumentTextScript), request.docId, "reading the document text",
+            deadline, contextOf).catch(() => null),
+          consoleWarnings: state.consoleOutput.filter((line) => line.startsWith("warning:"))
+        });
+
+        if (capture === "per-tile") {
+          // One picture per top-level tile, of the same settled and resized page. Both reads use
+          // `kTileSelector`, so the handles and the ids describe the same elements — the mismatch
+          // check below is the backstop for that, since they are paired by index.
+          const [handles, tileIds] = await Promise.all([
+            withinDeadline(frame.$$(kTileSelector), request.docId, "finding the document's tiles",
+              deadline, contextOf),
+            withinDeadline(frame.evaluate<string[]>(kReadTileIdsScript), request.docId,
+              "reading the tile ids", deadline, contextOf)
+          ]);
+          if (handles.length === 0) {
+            // An envelope with no images is already treated as damaged everywhere else, so a
+            // document that photographs to nothing is a failure with evidence rather than an empty
+            // envelope nobody can tell from a broken one.
+            throw new RenderFailed(request.docId,
+              "the document drew no tiles, so a per-tile capture would produce no images at all",
+              contextOf());
+          }
+          if (handles.length !== tileIds.length) {
+            throw new RenderFailed(request.docId,
+              `found ${handles.length} tile element(s) but ${tileIds.length} tile id(s); the two ` +
+              "are read from the same selector, so they cannot be paired", contextOf());
+          }
+          const images = [];
+          for (const [index, handle] of handles.entries()) {
+            const tileBox = await withinDeadline(handle.boundingBox(), request.docId,
+              `measuring tile ${tileIds[index] || index + 1}`, deadline, contextOf);
+            if (!tileBox || tileBox.width <= 0 || tileBox.height <= 0) {
+              throw new RenderFailed(request.docId,
+                `tile ${tileIds[index] || index + 1} has no visible area ` +
+                `(${JSON.stringify(tileBox)})`, contextOf());
+            }
+            // Every bound applies per image: a per-tile capture multiplies the count, not the
+            // allowance.
+            checkCaptureSize(request.docId, Math.ceil(tileBox.width), Math.ceil(tileBox.height), limits);
+            const tileBytes = Buffer.from(await withinDeadline(handle.screenshot({ type: "png" }),
+              request.docId, `capturing tile ${tileIds[index] || index + 1}`, deadline, contextOf));
+            checkEncodedSize(request.docId, tileBytes, limits);
+            readPngInfo(tileBytes, `${request.docId} tile ${tileIds[index] || index + 1}`);
+            images.push({
+              bytes: tileBytes,
+              url: null,
+              // Empty rather than absent would be a lie: a tile with no id cannot be matched back to
+              // the classification, and the selection step needs to know that.
+              tileId: tileIds[index] || null,
+              purpose: "tile" as const
+            });
+          }
+          return { images, diagnostics: await diagnosticsOf() };
+        }
+
         // Every step of the capture is inside the budget, not merely started inside it.
         const element = await withinDeadline(
           page.$("#clue-frame"), request.docId, "finding the iframe", deadline, contextOf);
@@ -648,18 +766,9 @@ export function puppeteerBackend(options: PuppeteerBackendOptions): RenderBacken
         // the capture path itself is broken, and that is worth saying at the point it happened.
         readPngInfo(bytes, `${request.docId} screenshot`);
 
-        const diagnostics: RenderDiagnostics = {
-          reportedHeightPx: measured.contentHeightPx,
-          unknownTiles: measured.unknownTiles,
-          totalTiles: measured.totalTiles,
-          documentText: await withinDeadline(
-            frame.evaluate<string>(kReadDocumentTextScript), request.docId, "reading the document text",
-            deadline, contextOf).catch(() => null),
-          consoleWarnings: state.consoleOutput.filter((line) => line.startsWith("warning:"))
-        };
         return {
           images: [{ bytes, url: null, tileId: null, purpose: "full-document" }],
-          diagnostics
+          diagnostics: await diagnosticsOf()
         };
       } catch (error) {
         // Evidence is attached to *any* failure, not only to a RenderFailed. A navigation error, a

--- a/scripts/ai-harness/src/backends/shutterbug.ts
+++ b/scripts/ai-harness/src/backends/shutterbug.ts
@@ -317,15 +317,32 @@ export function shutterbugBackend(options: ShutterbugOptions): RenderBackend {
     prerequisites: `network access to ${shutterbugUrl} and ${clueUrl}; no OpenAI key`,
     renderTarget,
     async render(request: RenderRequest): Promise<RenderOutcome> {
+      // A mode with a per-document height is handed one per request; every other mode uses the
+      // height it was configured with. Checked here as well as at construction, because a measured
+      // height is only known once the document has been rendered locally.
+      const heightPx = request.captureHeightPx ?? captureHeightPx;
+      if (request.captureHeightPx !== undefined) {
+        if (!Number.isInteger(heightPx) || heightPx <= 0) {
+          throw new ShutterbugError(request.docId,
+            `was given a capture height of ${JSON.stringify(request.captureHeightPx)}, which is not ` +
+            "a positive whole number of pixels");
+        }
+        checkCaptureSize(request.docId, viewportWidthPx, heightPx, limits);
+      }
       const url = await post(request.docId,
-        shutterbugRequestBody(request.content, { clueUrl, unit, captureHeightPx }));
+        shutterbugRequestBody(request.content, { clueUrl, unit, captureHeightPx: heightPx }));
       const bytes = await download(request.docId, url);
       // The hosted URL is kept beside the downloaded copy: it is what production sends to the model,
       // and it is what `run` has to check is still resolving before it spends anything.
       return {
         images: [{ bytes, url, tileId: null, purpose: "full-document" }],
         // The render happened on someone else's browser, so there is nothing to report about it.
-        diagnostics: { ...kUnobservedDiagnostics }
+        diagnostics: { ...kUnobservedDiagnostics },
+        // Recorded per document when the height was, so freshness compares against the height this
+        // picture was actually taken at rather than the mode's nominal one.
+        ...(request.captureHeightPx === undefined
+          ? {}
+          : { renderTarget: { ...renderTarget, captureHeightPx: heightPx } })
       };
     }
   };
@@ -369,6 +386,35 @@ export function shutterbugParameterized(options: ParameterizedOptions = {}): Ren
     clueUrl: options.clueUrl ?? kProductionClueUrl,
     unit: options.unit ?? kProductionUnit,
     shutterbugUrl: options.shutterbugUrl ?? kStagingShutterbugUrl,
+    captureHeightPx: options.captureHeightPx ?? kProductionCaptureHeightPx,
+    clueRevision: options.clueRevision ?? null,
+    fetchImpl: options.fetchImpl,
+    limits: options.limits,
+    sleep: options.sleep
+  });
+}
+
+/**
+ * The same transport again, but each document is captured at *its own* measured height.
+ *
+ * This is the prototype for the production fix the spike proposes: production posts a hardcoded
+ * `height: 1500` for every document, so a shorter one is padded and a longer one is silently
+ * clipped. Sending the real height instead is a small change to
+ * `on-analysis-document-pending.ts` — and the point of this mode is to measure what it buys before
+ * anyone makes it.
+ *
+ * The height itself comes from a previous local `puppeteer-full-height` render, which is the only
+ * thing that knows how tall a document actually is. `render` reads it and hands it over per
+ * document; nothing here knows the corpus exists.
+ */
+export function shutterbugAccurateHeight(options: ParameterizedOptions = {}): RenderBackend {
+  return shutterbugBackend({
+    modeId: "shutterbug-accurate-height",
+    clueUrl: options.clueUrl ?? kProductionClueUrl,
+    unit: options.unit ?? kProductionUnit,
+    shutterbugUrl: options.shutterbugUrl ?? kStagingShutterbugUrl,
+    // Only a fallback: every render is handed the document's measured height. It is the production
+    // height so that a document with no measurement would be no worse than production, not better.
     captureHeightPx: options.captureHeightPx ?? kProductionCaptureHeightPx,
     clueRevision: options.clueRevision ?? null,
     fetchImpl: options.fetchImpl,

--- a/scripts/ai-harness/src/backends/types.ts
+++ b/scripts/ai-harness/src/backends/types.ts
@@ -13,6 +13,12 @@ export interface RenderRequest {
   docId: string;
   /** The document content, as an object. */
   content: unknown;
+  /**
+   * The height to capture this particular document at, for a mode whose height is per document
+   * rather than fixed. Supplied by the caller because it comes from a previous local render, which
+   * lives in the corpus — something a backend has no business knowing about.
+   */
+  captureHeightPx?: number;
 }
 
 export interface RenderedImage {
@@ -67,6 +73,12 @@ export const kUnobservedDiagnostics: RenderDiagnostics = {
 export interface RenderOutcome {
   images: RenderedImage[];
   diagnostics: RenderDiagnostics;
+  /**
+   * What this particular render was produced against, when it differs from the backend's own
+   * target. Only a per-document height does that today, and the envelope records the real one so
+   * freshness compares against what actually happened.
+   */
+  renderTarget?: RenderTarget;
 }
 
 export interface RenderBackend {

--- a/scripts/ai-harness/src/cache.ts
+++ b/scripts/ai-harness/src/cache.ts
@@ -41,9 +41,9 @@ export function cacheOptionsFor(noCache: boolean, refreshCache: boolean): CacheO
 
 /**
  * Returns the entry only if it is actually usable. JSON.parse succeeding is not enough: a file
- * truncated at a record boundary can still parse, and the old cast let it through to
- * `rowFromResponse`, which then crashed on a missing `usage`. Anything short of complete is a miss,
- * which is what the module already promised.
+ * truncated at a record boundary can still parse, and a cast rather than a check would hand it to
+ * `rowFromResponse`, which crashes on a missing `usage`. Anything short of complete is a miss,
+ * which is what the module promises.
  */
 export function validateCacheEntry(value: unknown, key: string): CacheEntry | undefined {
   if (value === null || typeof value !== "object" || Array.isArray(value)) return undefined;

--- a/scripts/ai-harness/src/corpus.ts
+++ b/scripts/ai-harness/src/corpus.ts
@@ -8,7 +8,8 @@ import fs from "node:fs";
 import path from "node:path";
 import {
   CorpusManifest, CorpusSource, ManifestDocument, Modality, RepresentationEnvelope,
-  kDocumentIdPattern, kSchemaVersion, sha256Canonical, validateCorpusManifest, validateRepresentationEnvelope
+  kDocumentIdPattern, kSchemaVersion, sha256Canonical, validateCorpusManifest, validateExpectationsFile,
+  validateRepresentationEnvelope
 } from "./schemas.js";
 import { classifyDocument } from "./capability.js";
 import { removeImageRepresentation } from "./represent-image.js";
@@ -128,6 +129,22 @@ export interface ImportResult {
 /** `production` is not accepted here; only the (gated) `pull` command may set it. */
 export const importableSources: readonly CorpusSource[] = ["synthetic", "demo", "qa"];
 
+/**
+ * Which documents in a source directory are known not to render, and why.
+ *
+ * `expectations.json` is the committed sidecar describing the example corpus, and "this fixture
+ * cannot render" is exactly the kind of thing it already records. A source directory without one —
+ * every real corpus — simply has no expectations, and the manifest keeps whatever a human set.
+ */
+function readSourceRenderExpectations(from: string): Map<string, string> {
+  const file = path.join(from, "expectations.json");
+  if (!fs.existsSync(file)) return new Map();
+  const expectations = validateExpectationsFile(readJsonFile(file), file);
+  return new Map(Object.entries(expectations.documents)
+    .filter(([, entry]) => entry.expectedRenderFailure !== undefined)
+    .map(([docId, entry]) => [docId, entry.expectedRenderFailure!]));
+}
+
 export function importCorpus(options: ImportOptions): ImportResult {
   const { from, corpus, source, prune, dataRoot } = options;
   // Stamped once, so every document in one import shares a retrievedAt and a new corpus's createdAt
@@ -150,6 +167,7 @@ export function importCorpus(options: ImportOptions): ImportResult {
 
   const existing = fs.existsSync(paths.manifest) ? readManifest(paths) : null;
   const previous = new Map((existing?.documents ?? []).map((entry) => [entry.id, entry]));
+  const sourceExpectations = readSourceRenderExpectations(from);
 
   const warnings: string[] = [];
   const imported: string[] = [];
@@ -199,6 +217,11 @@ export function importCorpus(options: ImportOptions): ImportResult {
       contextId: before?.contextId ?? null,
       computedModality: classification.computedModality,
       modalityOverride: before?.modalityOverride ?? null,
+      // Seeded from the source directory's expectations, so a corpus imported from `examples/`
+      // knows which of its fixtures cannot render without anyone hand-editing a generated file. A
+      // hand-set value on an existing manifest wins, because a human said it on purpose.
+      expectedRenderFailure:
+        before?.expectedRenderFailure ?? sourceExpectations.get(id) ?? null,
       labels: before?.labels ?? {},
       relatedSummaries: before?.relatedSummaries ?? [],
       historical: before?.historical ?? null

--- a/scripts/ai-harness/src/execute.ts
+++ b/scripts/ai-harness/src/execute.ts
@@ -32,7 +32,7 @@ import { renderBackendIdentity } from "./backends/index.js";
 import {
   ExperimentFile, ExperimentRun, ImageRepresentation, ManifestDocument, MessageShape, ModelPricing,
   RepresentationDescriptor, ResponseOriginMeta, ResultRow, RunMeta, SkippedResultRow,
-  TextRepresentation, effectiveModality, kResultSchemaVersion, kSchemaVersion, sendsImages,
+  TextRepresentation, effectiveModality, kResultSchemaVersion, kSchemaVersion, sendsImages, sendsText,
   validatePromptFile, validateResultRow
 } from "./schemas.js";
 import { DocumentClassification, classifyDocument } from "./capability.js";
@@ -92,11 +92,13 @@ export interface RunTask {
   requestKey: string;
   worstCaseUsd: number;
   /**
-   * How many retries `worstCaseUsd` was reserved for. Carried on the task rather than read
-   * independently by the run loop: the two used to be separate reads of `options.retries`, with
-   * nothing tying them together, so a caller passing `retries: 5` to `buildTasks` and not to
-   * `runTasks` would reserve for three attempts and dispatch six. The invariant that makes
-   * `--max-cost` a bound is now code rather than convention.
+   * How many retries `worstCaseUsd` was reserved for.
+   *
+   * Carried on the task rather than read independently by the run loop, so the number reserved for
+   * and the number dispatched cannot disagree: two separate reads of `options.retries` would let a
+   * caller passing `retries: 5` to `buildTasks` and not to `runTasks` reserve for three attempts
+   * and send six. Keeping them one value is what makes `--max-cost` a bound rather than a
+   * convention.
    */
   retries: number;
   /** What this row will record about where its input came from. */
@@ -180,11 +182,12 @@ function checkedImageBytes(file: string, expectedSha256: string): Buffer {
 /**
  * The related summaries a run sends, which is a dimension rather than a fact about the document.
  *
- * `extras-production-current` reproduces a real production bug on purpose (spike finding 6a,
- * CLUE-630): `findRelatedSummaries` hands every related entry the *analyzed document's own* summary
- * instead of the related document's, so the model is shown the same text several times over and told
- * other people agreed with it. It is a named baseline so a before/after comparison stays honest —
- * measuring the fix means measuring against what production does today. Do not improve it.
+ * `extras-production-current` reproduces a real production bug on purpose (CLUE-630, written up as
+ * finding 6a in `docs/plans/CLUE-371-spike.md`): `findRelatedSummaries` hands every related entry
+ * the *analyzed document's own* summary instead of the related document's, so the model is shown
+ * the same text several times over and told other people agreed with it. It is a named baseline so
+ * a before/after comparison stays honest — measuring the fix means measuring against what
+ * production does today. Do not improve it.
  */
 export function relatedSummariesFor(
   run: ExperimentRun, document: ManifestDocument, markdown: string
@@ -207,8 +210,20 @@ export function relatedSummariesFor(
  * reporting judgement about how to group a result, not a claim about what the document contains,
  * and letting it drive a skip would silently change what was measured.
  */
+/**
+ * Whether the variant a text-carrying run would use finds student content the classifier does not.
+ *
+ * Returns false for a run that sends no text, and for every variant that only passes text through.
+ */
+export function variantFindsStudentContentIn(run: ExperimentRun, content: unknown): boolean {
+  if (!sendsText(run.message)) return false;
+  const variant = getTextVariant(run.textVariant ?? "default");
+  return variant.findsStudentContentWithoutText?.(content) ?? false;
+}
+
 export function skipReasonsFor(
-  message: MessageShape, classification: DocumentClassification, document?: ManifestDocument
+  message: MessageShape, classification: DocumentClassification, document?: ManifestDocument,
+  variantFindsStudentContent = false
 ): string[] {
   const hasStudentText = classification.tiles.some((tile) => tile.hasStudentText);
   const reasons: string[] = [];
@@ -225,7 +240,11 @@ export function skipReasonsFor(
       "no tile carries text, and none needs a picture");
     return reasons;
   }
-  if (message === "text-only" && !hasStudentText) {
+  // The variant gets the last word, because it is the thing that builds the summary. `hasStudentText`
+  // asks whether a tile holds text a student wrote, which is the right question only for a variant
+  // that passes text through — `drawing-text` turns geometry into words, and a document of two
+  // shapes has student work in it that this question cannot see.
+  if (message === "text-only" && !hasStudentText && !variantFindsStudentContent) {
     reasons.push("text-only run: no tile carries student-authored text, so the summary would " +
       "carry no student content");
   }
@@ -276,13 +295,17 @@ export function buildTasks(options: BuildTasksOptions): BuildTasksResult {
    * of the document's own file. Cached per document: a corpus is classified once however many runs
    * an experiment defines.
    */
-  const classifications = new Map<string, DocumentClassification>();
-  const classify = (document: ManifestDocument): DocumentClassification => {
+  const classifications = new Map<string, { content: unknown; classification: DocumentClassification }>();
+  // The content is kept alongside, because a skip decision can need it: a variant is asked whether
+  // it would find student content the classifier does not see, and only the document itself can
+  // answer that. Reading it twice would be the alternative.
+  const classify = (document: ManifestDocument) => {
     const cached = classifications.get(document.id);
     if (cached) return cached;
-    const classification = classifyDocument(readCorpusDocument(paths, document));
-    classifications.set(document.id, classification);
-    return classification;
+    const content = readCorpusDocument(paths, document);
+    const entry = { content, classification: classifyDocument(content) };
+    classifications.set(document.id, entry);
+    return entry;
   };
 
   /** The text side of a request: the summary to send, and what to record about where it came from. */
@@ -339,7 +362,7 @@ export function buildTasks(options: BuildTasksOptions): BuildTasksResult {
 
     // Which pictures this run sends, chosen by its image set rather than by whatever is there.
     const imageSet = run.imageSet ?? "full-document";
-    const selected = imagesForSet(envelope, file, imageSet, visualTileIdsOf(classify(document)));
+    const selected = imagesForSet(envelope, file, imageSet, visualTileIdsOf(classify(document).classification));
     // The paths are resolved now — a stale envelope should fail here rather than at dispatch — but
     // the bytes are read only when the request is actually built.
     const files = selected.images.map((image) => image.url ? null : resolveImageFile(file, image));
@@ -464,8 +487,9 @@ export function buildTasks(options: BuildTasksOptions): BuildTasksResult {
   for (const run of experiment.runs) {
     const { aiPrompt, sha256 } = loadPrompt(run.prompt);
     for (const document of manifest.documents) {
-      const classification = classify(document);
-      const skipReasons = skipReasonsFor(run.message, classification, document);
+      const { content, classification } = classify(document);
+      const skipReasons = skipReasonsFor(run.message, classification, document,
+        variantFindsStudentContentIn(run, content));
       if (skipReasons.length > 0) {
         // A decision, not an absence: the pair lands in the results as a skipped row saying why.
         skipped.push({

--- a/scripts/ai-harness/src/execute.ts
+++ b/scripts/ai-harness/src/execute.ts
@@ -8,19 +8,21 @@ import OpenAI, { APIConnectionError } from "openai";
 import { VERSION as kOpenAiSdkVersion } from "openai/version";
 import type { IAiPrompt, RelatedSummary } from "../../../shared/ai-analysis-messages.js";
 import {
-  CorpusPaths, readJsonFile, readManifest, readRepresentation, representationIsFresh, representationPath
+  CorpusPaths, readCorpusDocument, readJsonFile, readManifest, readRepresentation,
+  representationIsFresh, representationPath
 } from "./corpus.js";
 import { CacheEntry, ResponseCache } from "./cache.js";
 import {
   CostCeilingExceeded, CostLedger, estimateImageTokens, kRetries, priceTokens, worstCaseUsd
 } from "./cost.js";
 import {
-  HarnessRequest, buildImageRequest, buildRequest, chatCompletionParams, requestKeyFor, responseFormatFor
+  HarnessRequest, RequestImage, buildImageRequest, buildMixedRequest, buildRequest,
+  chatCompletionParams, requestKeyFor, responseFormatFor
 } from "./messages.js";
 import { getTextVariant } from "./represent-text.js";
 import {
-  dataUrlFor, imageRepresentationIsUsable, imageRepresentationPath, readImageEnvelope, resolveImageFile,
-  sha256Bytes, singleImageOf
+  dataUrlFor, imageRepresentationIsUsable, imageRepresentationPath, imagesForSet, readImageEnvelope,
+  resolveImageFile, sha256Bytes
 } from "./represent-image.js";
 import { readPngHeader } from "./png.js";
 import { createHash } from "node:crypto";
@@ -28,10 +30,12 @@ import { git } from "./files.js";
 import { kDefaultRenderLimits, redirectDowngradeReason } from "./backends/types.js";
 import { renderBackendIdentity } from "./backends/index.js";
 import {
-  ExperimentFile, ExperimentRun, ManifestDocument, ModelPricing, RepresentationDescriptor,
-  ResponseOriginMeta, ResultRow, RunMeta, effectiveModality, kResultSchemaVersion, kSchemaVersion,
+  ExperimentFile, ExperimentRun, ImageRepresentation, ManifestDocument, MessageShape, ModelPricing,
+  RepresentationDescriptor, ResponseOriginMeta, ResultRow, RunMeta, SkippedResultRow,
+  TextRepresentation, effectiveModality, kResultSchemaVersion, kSchemaVersion, sendsImages,
   validatePromptFile, validateResultRow
 } from "./schemas.js";
+import { DocumentClassification, classifyDocument } from "./capability.js";
 
 /**
  * Enough of the file to read the IHDR chunk; the rest is hashed and discarded.
@@ -99,6 +103,12 @@ export interface RunTask {
   representation: RepresentationDescriptor;
   /** The image-token share of the input estimate; 0 for a text run. */
   imageTokensEstimated: number;
+  /** How many pictures this task sends. `plan` totals it, because a per-tile set multiplies it. */
+  imageCount: number;
+  /** True on a mixed task whose document had no student text, so only its pictures are sent. */
+  textPartOmitted: boolean;
+  /** Non-failures worth recording about how this task's input was assembled. */
+  representationWarnings: string[];
   /**
    * Hosted images this task's request points at, each with the sha256 the envelope recorded for it.
    * A local capture sends its bytes inline and has none. `run` checks these still serve exactly
@@ -116,8 +126,28 @@ export interface BuildTasksOptions {
   retries?: number;
 }
 
+/**
+ * A (run, document) pair the experiment declines to send, and why.
+ *
+ * Carried out of `buildTasks` rather than dropped: every one becomes a `skipped` result row. A
+ * document that simply does not appear in the results is indistinguishable from a bug.
+ */
+export interface SkippedTask {
+  docId: string;
+  runId: string;
+  run: ExperimentRun;
+  modality: ManifestDocument["computedModality"];
+  computedModality: ManifestDocument["computedModality"];
+  promptName: string;
+  promptSha256: string;
+  skipReasons: string[];
+  /** The content the decision was made from, so a rerun can tell whether it still applies. */
+  decidedFromContentSha256: string;
+}
+
 export interface BuildTasksResult {
   tasks: RunTask[];
+  skipped: SkippedTask[];
   documents: ManifestDocument[];
 }
 
@@ -148,8 +178,76 @@ function checkedImageBytes(file: string, expectedSha256: string): Buffer {
 }
 
 /**
- * Expands (runs × documents) into concrete requests. `plan` and `run` both go through here, so the
- * cost they compute comes from exactly the same requests.
+ * The related summaries a run sends, which is a dimension rather than a fact about the document.
+ *
+ * `extras-production-current` reproduces a real production bug on purpose (spike finding 6a,
+ * CLUE-630): `findRelatedSummaries` hands every related entry the *analyzed document's own* summary
+ * instead of the related document's, so the model is shown the same text several times over and told
+ * other people agreed with it. It is a named baseline so a before/after comparison stays honest —
+ * measuring the fix means measuring against what production does today. Do not improve it.
+ */
+export function relatedSummariesFor(
+  run: ExperimentRun, document: ManifestDocument, markdown: string
+): RelatedSummary[] {
+  const entries = (document.relatedSummaries ?? []) as unknown as RelatedSummary[];
+  switch (run.extras ?? "extras-fixed") {
+    case "no-extras":
+      return [];
+    case "extras-production-current":
+      return entries.map((entry) => ({ ...entry, summary: markdown }));
+    default:
+      return entries;
+  }
+}
+
+/**
+ * Why this run should not send this document, or an empty list when it should.
+ *
+ * Decided from the document's own content, never from `modalityOverride`: an override is a
+ * reporting judgement about how to group a result, not a claim about what the document contains,
+ * and letting it drive a skip would silently change what was measured.
+ */
+export function skipReasonsFor(
+  message: MessageShape, classification: DocumentClassification, document?: ManifestDocument
+): string[] {
+  const hasStudentText = classification.tiles.some((tile) => tile.hasStudentText);
+  const reasons: string[] = [];
+  // A document the corpus says cannot be rendered has no picture to send, and never will. That is a
+  // fact about the document, so an image-carrying run skips it rather than failing on a missing
+  // render the way it would for one somebody simply forgot to render.
+  if (document?.expectedRenderFailure && sendsImages(message)) {
+    reasons.push(`${message} run: this document cannot be rendered ` +
+      `(${document.expectedRenderFailure}), so there is no picture to send`);
+    return reasons;
+  }
+  if (classification.computedModality === "empty") {
+    reasons.push(`${message} run: the document has no student content at all — ` +
+      "no tile carries text, and none needs a picture");
+    return reasons;
+  }
+  if (message === "text-only" && !hasStudentText) {
+    reasons.push("text-only run: no tile carries student-authored text, so the summary would " +
+      "carry no student content");
+  }
+  return reasons;
+}
+
+/** The tiles a classification says need a picture, by id — what `visual-tiles-only` selects on. */
+export function visualTileIdsOf(classification: DocumentClassification): Set<string> {
+  return new Set(classification.tiles
+    .filter((tile) => tile.requiresVisualRepresentation)
+    .map((tile) => tile.tileId));
+}
+
+/** Whether a mixed run can send a summary for this document, or only its pictures. */
+export function mixedSendsText(classification: DocumentClassification): boolean {
+  return classification.tiles.some((tile) => tile.hasStudentText);
+}
+
+/**
+ * Expands (runs × documents) into concrete requests, plus the pairs this experiment declines to
+ * send. `plan` and `run` both go through here, so the cost they compute — and the skips they report
+ * — come from exactly the same decisions.
  */
 export function buildTasks(options: BuildTasksOptions): BuildTasksResult {
   const { corpusPaths: paths, experiment, promptsDir, pricing } = options;
@@ -171,8 +269,24 @@ export function buildTasks(options: BuildTasksOptions): BuildTasksResult {
 
   const generationSettings = { max_completion_tokens: pricing.maxOutputTokens };
 
-  /** Everything a text-only run needs for one document. */
-  const textInput = (run: ExperimentRun, document: ManifestDocument, aiPrompt: IAiPrompt) => {
+  /**
+   * What the document actually contains, read from its content rather than from the manifest.
+   *
+   * Skip decisions are about what is in front of us, so they are made from a fresh classification
+   * of the document's own file. Cached per document: a corpus is classified once however many runs
+   * an experiment defines.
+   */
+  const classifications = new Map<string, DocumentClassification>();
+  const classify = (document: ManifestDocument): DocumentClassification => {
+    const cached = classifications.get(document.id);
+    if (cached) return cached;
+    const classification = classifyDocument(readCorpusDocument(paths, document));
+    classifications.set(document.id, classification);
+    return classification;
+  };
+
+  /** The text side of a request: the summary to send, and what to record about where it came from. */
+  const textSide = (run: ExperimentRun, document: ManifestDocument) => {
     const variant = getTextVariant(run.textVariant!);
     const file = representationPath(paths, variant.id, document.id);
     if (!fs.existsSync(file)) {
@@ -190,25 +304,19 @@ export function buildTasks(options: BuildTasksOptions): BuildTasksResult {
         `"${envelope.docId}" / variant "${envelope.variantId}" at version ${envelope.variantVersion}). ` +
         `Run: harness.ts represent --corpus ${manifest.name} --variants ${variant.id}`);
     }
-    const makeRequest = () => buildRequest({
-      model,
-      aiPrompt,
-      message: run.message,
+    return {
       markdown: envelope.markdown,
-      relatedSummaries: document.relatedSummaries as unknown as RelatedSummary[],
-      generationSettings
-    });
-    const representation: RepresentationDescriptor = {
-      kind: "text",
-      variantId: variant.id,
-      variantVersion: variant.variantVersion,
-      sourceContentSha256: envelope.sourceContentSha256
+      relatedSummaries: relatedSummariesFor(run, document, envelope.markdown),
+      representation: {
+        variantId: variant.id,
+        variantVersion: variant.variantVersion,
+        sourceContentSha256: envelope.sourceContentSha256
+      } satisfies TextRepresentation
     };
-    return { makeRequest, representation, hostedImages: [] as { url: string; sha256: string }[] };
   };
 
-  /** Everything an image-only run needs for one document. */
-  const imageInput = (run: ExperimentRun, document: ManifestDocument, aiPrompt: IAiPrompt) => {
+  /** The image side of a request: which pictures to send, and what to record about them. */
+  const imageSide = (run: ExperimentRun, document: ManifestDocument) => {
     const modeId = run.imageMode!;
     const backend = renderBackendIdentity(modeId);
     const file = imageRepresentationPath(paths, modeId, document.id);
@@ -229,44 +337,172 @@ export function buildTasks(options: BuildTasksOptions): BuildTasksResult {
         `Run: harness.ts render --corpus ${manifest.name} --mode ${modeId} --refresh`);
     }
 
-    // Exactly one image, never the first of several — see singleImageOf.
-    const image = singleImageOf(envelope, file);
-    // The path is resolved now — it is a check, and a stale envelope should fail here rather than
-    // at dispatch — but the bytes are read only when the request is actually built.
-    const imageFile = image.url ? null : resolveImageFile(file, image);
-    const makeRequest = () => buildImageRequest({
-      model,
-      aiPrompt,
-      message: run.message,
-      // A hosted render sends the URL production sends; a local capture sends its bytes inline, the
-      // way production's categorizeDocument() does with a local file.
-      imageUrl: image.url ?? dataUrlFor(checkedImageBytes(imageFile!, image.sha256)),
-      accounting: { sha256: image.sha256, widthPx: image.widthPx, heightPx: image.heightPx },
-      generationSettings
-    });
-    const representation: RepresentationDescriptor = {
-      kind: "image",
-      modeId,
-      backendId: envelope.backendId,
-      backendVersion: envelope.backendVersion,
-      renderTarget: envelope.renderTarget,
-      sourceContentSha256: envelope.sourceContentSha256,
-      imageSha256s: envelope.images.map((entry) => entry.sha256)
-    };
+    // Which pictures this run sends, chosen by its image set rather than by whatever is there.
+    const imageSet = run.imageSet ?? "full-document";
+    const selected = imagesForSet(envelope, file, imageSet, visualTileIdsOf(classify(document)));
+    // The paths are resolved now — a stale envelope should fail here rather than at dispatch — but
+    // the bytes are read only when the request is actually built.
+    const files = selected.images.map((image) => image.url ? null : resolveImageFile(file, image));
     return {
-      makeRequest,
-      representation,
-      hostedImages: image.url ? [{ url: image.url, sha256: image.sha256 }] : []
+      images: selected.images,
+      warnings: selected.warnings,
+      makeImages: (): RequestImage[] => selected.images.map((image, index) => ({
+        // A hosted render sends the URL production sends; a local capture sends its bytes inline,
+        // the way production's categorizeDocument() does with a local file.
+        imageUrl: image.url ?? dataUrlFor(checkedImageBytes(files[index]!, image.sha256)),
+        accounting: { sha256: image.sha256, widthPx: image.widthPx, heightPx: image.heightPx }
+      })),
+      hostedImages: selected.images
+        .filter((image): image is typeof image & { url: string } => image.url !== null)
+        .map((image) => ({ url: image.url, sha256: image.sha256 })),
+      representation: {
+        modeId,
+        backendId: envelope.backendId,
+        backendVersion: envelope.backendVersion,
+        renderTarget: envelope.renderTarget,
+        sourceContentSha256: envelope.sourceContentSha256,
+        // Every image the envelope holds, not only the ones sent: this is the render's provenance,
+        // and `imageSet` beside it says which of them this row used.
+        imageSha256s: envelope.images.map((entry) => entry.sha256),
+        imageSet
+      } satisfies ImageRepresentation
+    };
+  };
+
+  /** Everything a text-only run needs for one document. */
+  const textInput = (run: ExperimentRun, document: ManifestDocument, aiPrompt: IAiPrompt) => {
+    const text = textSide(run, document);
+    return {
+      makeRequest: () => buildRequest({
+        model,
+        aiPrompt,
+        message: run.message,
+        markdown: text.markdown,
+        relatedSummaries: text.relatedSummaries,
+        generationSettings
+      }),
+      representation: { kind: "text", ...text.representation } as RepresentationDescriptor,
+      hostedImages: [] as { url: string; sha256: string }[],
+      textPartOmitted: false,
+      imageCount: null as number | null,
+      warnings: [] as string[]
+    };
+  };
+
+  /** Everything an image-only run needs for one document. */
+  const imageInput = (run: ExperimentRun, document: ManifestDocument, aiPrompt: IAiPrompt) => {
+    const image = imageSide(run, document);
+    return {
+      makeRequest: () => buildImageRequest({
+        model,
+        aiPrompt,
+        message: run.message,
+        images: image.makeImages(),
+        detail: run.detail,
+        generationSettings
+      }),
+      representation: { kind: "image", ...image.representation } as RepresentationDescriptor,
+      hostedImages: image.hostedImages,
+      textPartOmitted: false,
+      imageCount: image.images.length as number | null,
+      warnings: image.warnings
+    };
+  };
+
+  /**
+   * Everything a mixed run needs for one document: both sides at once.
+   *
+   * `sendsText` is false for a document with no student-authored text. The pictures still go — that
+   * is the whole point of asking about such a document — and the row records that its text half was
+   * dropped, rather than the run skipping it.
+   */
+  const mixedInput = (
+    run: ExperimentRun, document: ManifestDocument, aiPrompt: IAiPrompt, withText: boolean
+  ) => {
+    const image = imageSide(run, document);
+    const text = withText ? textSide(run, document) : null;
+    return {
+      makeRequest: () => buildMixedRequest({
+        model,
+        aiPrompt,
+        message: run.message,
+        markdown: text?.markdown ?? null,
+        relatedSummaries: text?.relatedSummaries ?? [],
+        images: image.makeImages(),
+        detail: run.detail,
+        generationSettings
+      }),
+      representation: {
+        kind: "mixed",
+        // The text half is still recorded when the summary was dropped: which variant *would* have
+        // produced it, and from which content, is what makes the omission readable rather than a
+        // gap. `textPartOmitted` on the row says it did not go.
+        text: text?.representation ?? textVariantDescriptorFor(run, document),
+        image: image.representation
+      } as RepresentationDescriptor,
+      hostedImages: image.hostedImages,
+      textPartOmitted: !withText,
+      imageCount: image.images.length as number | null,
+      warnings: image.warnings
+    };
+  };
+
+  /** The text descriptor for a mixed row whose summary was dropped: the variant that would have run. */
+  const textVariantDescriptorFor = (
+    run: ExperimentRun, document: ManifestDocument
+  ): TextRepresentation => {
+    const variant = getTextVariant(run.textVariant!);
+    return {
+      variantId: variant.id,
+      variantVersion: variant.variantVersion,
+      sourceContentSha256: document.contentSha256
     };
   };
 
   const tasks: RunTask[] = [];
+  const skipped: SkippedTask[] = [];
   for (const run of experiment.runs) {
     const { aiPrompt, sha256 } = loadPrompt(run.prompt);
     for (const document of manifest.documents) {
-      const { makeRequest, representation, hostedImages } = run.message === "text-only"
-        ? textInput(run, document, aiPrompt)
-        : imageInput(run, document, aiPrompt);
+      const classification = classify(document);
+      const skipReasons = skipReasonsFor(run.message, classification, document);
+      if (skipReasons.length > 0) {
+        // A decision, not an absence: the pair lands in the results as a skipped row saying why.
+        skipped.push({
+          docId: document.id,
+          runId: run.id,
+          run,
+          modality: effectiveModality(document),
+          computedModality: document.computedModality,
+          promptName: run.prompt,
+          promptSha256: sha256,
+          skipReasons,
+          decidedFromContentSha256: document.contentSha256
+        });
+        continue;
+      }
+      const input =
+        run.message === "text-only" ? textInput(run, document, aiPrompt)
+        : run.message === "image-only" ? imageInput(run, document, aiPrompt)
+        : mixedInput(run, document, aiPrompt, mixedSendsText(classification));
+      if (input.imageCount === 0) {
+        // The envelope has per-tile images, but none of them is a tile this set wants. A decision
+        // about what the document contains, so it lands as a skipped row like any other.
+        skipped.push({
+          docId: document.id,
+          runId: run.id,
+          run,
+          modality: effectiveModality(document),
+          computedModality: document.computedModality,
+          promptName: run.prompt,
+          promptSha256: sha256,
+          skipReasons: [`${run.message} run with imageSet "${run.imageSet}": no captured tile is one ` +
+            "the classification marks as needing a picture", ...input.warnings],
+          decidedFromContentSha256: document.contentSha256
+        });
+        continue;
+      }
+      const { makeRequest, representation, hostedImages, textPartOmitted } = input;
       // Built once for the key and the reservation, then released — see `makeRequest`.
       const request = makeRequest();
       const imageTokensEstimated = request.inputAccounting.images
@@ -286,11 +522,14 @@ export function buildTasks(options: BuildTasksOptions): BuildTasksResult {
         retries,
         representation,
         imageTokensEstimated,
-        hostedImages
+        imageCount: request.inputAccounting.images.length,
+        hostedImages,
+        textPartOmitted,
+        representationWarnings: input.warnings
       });
     }
   }
-  return { tasks, documents: manifest.documents };
+  return { tasks, skipped, documents: manifest.documents };
 }
 
 // ---------------------------------------------------------------------------
@@ -495,6 +734,8 @@ export interface RunOptions {
   experiment: ExperimentFile;
   experimentSha256: string;
   tasks: RunTask[];
+  /** Pairs this experiment declined to send. Each becomes a `skipped` row before anything runs. */
+  skipped?: SkippedTask[];
   outputFile: string;
   ledger: CostLedger;
   cache: ResponseCache;
@@ -660,6 +901,23 @@ export interface RunSummary {
   committedOvershootUsd: number;
   /** Tasks that were never dispatched because the run stopped. 0 when everything ran. */
   notDispatched: number;
+  /** Skipped rows written this run. Resumed skips are counted in `resumed`, not here. */
+  skipped: number;
+}
+
+/**
+ * Resume identity for a skipped (run, document) pair.
+ *
+ * A skip has no request key — it built no request — so it resumes on the content its decision was
+ * made from. Same content, same decision, so the existing row still stands; changed content means
+ * the document must be looked at again.
+ */
+export function skipResumeKeyFor(row: {
+  corpus: string; experimentSha256: string; docId: string; runId: string;
+  decidedFromContentSha256: string;
+}): string {
+  return `${row.corpus}\u0001${row.experimentSha256}\u0001${row.docId}\u0001${row.runId}` +
+    `\u0001${row.decidedFromContentSha256}`;
 }
 
 const defaultSleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
@@ -679,7 +937,19 @@ export async function runTasks(options: RunOptions): Promise<RunSummary> {
   // sharing a document id (or the same experiment edited between runs) would resume each other's
   // rows: the requestKey covers the request, but not which corpus or experiment produced it.
   const completed = new Set<string>();
+  // Skipped rows resume on the content they were decided from rather than on a request key, which
+  // they do not have. A rerun against unchanged content keeps the existing row instead of appending
+  // a second one saying the same thing; an edited document is re-decided.
+  const alreadySkipped = new Set<string>();
   for (const row of readResultRows(outputFile)) {
+    if (row.status === "skipped") {
+      // From the row's own corpus and experiment, the way `resumeKeyFor(row)` does below. Building
+      // the key from the *current* ones instead relabelled every stored skip as belonging to this
+      // run, so a row written for another corpus or an earlier experiment would suppress a skip that
+      // is genuinely new — the one thing including them in the key is meant to prevent.
+      alreadySkipped.add(skipResumeKeyFor(row));
+      continue;
+    }
     if (row.status === "error" || row.requestKey === null) continue;
     completed.add(resumeKeyFor(row));
   }
@@ -687,8 +957,40 @@ export async function runTasks(options: RunOptions): Promise<RunSummary> {
   const writer = new JsonlWriter(outputFile);
   const summary: RunSummary = {
     written: 0, resumed: 0, cacheHits: 0, apiCalls: 0, stoppedOnCeiling: false, reservedPeakUsd: 0,
-    incurredUsd: 0, overshootUsd: 0, committedOvershootUsd: 0, notDispatched: 0
+    incurredUsd: 0, overshootUsd: 0, committedOvershootUsd: 0, notDispatched: 0, skipped: 0
   };
+
+  // Written before anything is dispatched, so the results file describes the whole experiment even
+  // if a spend ceiling stops the run partway through.
+  for (const skip of options.skipped ?? []) {
+    const key = skipResumeKeyFor({
+      corpus, experimentSha256, docId: skip.docId, runId: skip.runId,
+      decidedFromContentSha256: skip.decidedFromContentSha256
+    });
+    if (alreadySkipped.has(key)) {
+      summary.resumed += 1;
+      continue;
+    }
+    await writer.write({
+      schemaVersion: kResultSchemaVersion,
+      experiment: experiment.name,
+      experimentSha256,
+      runId: skip.runId,
+      corpus,
+      docId: skip.docId,
+      modality: skip.modality,
+      computedModality: skip.computedModality,
+      message: skip.run.message,
+      prompt: { name: skip.promptName, sha256: skip.promptSha256 },
+      requestKey: null,
+      runMeta,
+      status: "skipped",
+      skipReasons: skip.skipReasons,
+      decidedFromContentSha256: skip.decidedFromContentSha256
+    } satisfies SkippedResultRow);
+    summary.written += 1;
+    summary.skipped += 1;
+  }
 
   const taskResumeKey = (task: RunTask) =>
     resumeKeyFor({ corpus, experimentSha256, docId: task.docId, runId: task.runId, requestKey: task.requestKey });
@@ -735,8 +1037,13 @@ export async function runTasks(options: RunOptions): Promise<RunSummary> {
     representation: task.representation,
     // Only on rows that actually sent a picture, so the report's image column never shows a number
     // belonging to nothing.
-    ...(task.representation.kind === "image"
+    ...(task.representation.kind === "image" || task.representation.kind === "mixed"
       ? { promptImageTokensEstimated: task.imageTokensEstimated }
+      : {}),
+    // Only when it happened, so its absence means "the text part went" rather than "unknown".
+    ...(task.textPartOmitted ? { textPartOmitted: true as const } : {}),
+    ...(task.representationWarnings.length > 0
+      ? { representationWarnings: task.representationWarnings }
       : {}),
     prompt: { name: task.promptName, sha256: task.promptSha256 },
     requestKey: task.requestKey,
@@ -923,9 +1230,13 @@ export async function runTasks(options: RunOptions): Promise<RunSummary> {
   summary.overshootUsd = Math.max(0, ledger.incurredUsd - ledger.maxCostUsd);
   summary.committedOvershootUsd = ledger.overshootUsd;
   // Counted from what is left rather than tracked as we go, so it is right however the run ended.
-  // `written` already includes cache hits — a hit writes a row — so subtracting `cacheHits` as well
-  // double-counted them, under-reporting the skipped work and, with enough hits, driving this to 0
-  // and suppressing the "stopped early" message for a run that really did stop.
-  summary.notDispatched = Math.max(0, pending.length - summary.written);
+  //
+  // Both sides have to describe the same population. `pending` holds request tasks only, while
+  // `written` counts every row this run produced — including the skipped ones, written before
+  // dispatch for pairs that were never in `pending` at all. Subtracting those back out is what keeps
+  // a run that skipped as many pairs as it abandoned from reporting nothing left. Cache hits do stay
+  // in: a hit is a pending task that got its row, so it is dispatched work as far as this is
+  // concerned, and subtracting them as well would count them twice.
+  summary.notDispatched = Math.max(0, pending.length - (summary.written - summary.skipped));
   return summary;
 }

--- a/scripts/ai-harness/src/messages.ts
+++ b/scripts/ai-harness/src/messages.ts
@@ -4,8 +4,8 @@
  */
 import type { ChatCompletionMessageParam } from "openai/resources/chat/completions";
 import {
-  IAiPrompt, RelatedSummary, buildImageMessages, buildSummaryMessages, buildZodResponseSchema,
-  categorizationResponseFormat
+  IAiPrompt, RelatedSummary, buildImageMessages, buildMixedMessages, buildSummaryMessages,
+  buildZodResponseSchema, categorizationResponseFormat
 } from "../../../shared/ai-analysis-messages.js";
 import { ImageDetail, MessageShape, imageDetails, sha256Canonical } from "./schemas.js";
 
@@ -61,18 +61,43 @@ export interface BuildTextRequestOptions {
   generationSettings: GenerationSettings;
 }
 
+/**
+ * Facts about an image *file*. `detail` is deliberately absent: it is a fact about the request, not
+ * about the file, and the builders read it back out of the message they just built. A caller cannot
+ * declare a detail that disagrees with what is actually sent.
+ */
+export type ImageFileFacts = Omit<InputImageAccounting, "detail">;
+
+/** One image in a request: what goes into the message, and what is known about the file behind it. */
+export interface RequestImage {
+  /** A hosted URL for a Shutterbug render, a data URL for a local capture. */
+  imageUrl: string;
+  accounting: ImageFileFacts;
+}
+
 export interface BuildImageRequestOptions {
   model: string;
   aiPrompt: IAiPrompt;
   message: MessageShape;
-  /** What goes into the message: a hosted URL for Shutterbug, a data URL for a local capture. */
-  imageUrl: string;
+  /** Every image the request sends, in the order it sends them. */
+  images: RequestImage[];
+  /** What the run asked the provider to look at. Absent means the builder's `"auto"`. */
+  detail?: ImageDetail;
+  generationSettings: GenerationSettings;
+}
+
+export interface BuildMixedRequestOptions {
+  model: string;
+  aiPrompt: IAiPrompt;
+  message: MessageShape;
   /**
-   * Facts about the image file. `detail` is deliberately absent: it is a fact about the request, not
-   * about the file, so `buildImageRequest` reads it back out of the message it just built. A caller
-   * cannot declare a detail that disagrees with what is actually sent.
+   * The text side, or `null` for a document with no student-authored text — the run still sends the
+   * pictures, and the row records that the text part was dropped.
    */
-  accounting: Omit<InputImageAccounting, "detail">;
+  markdown: string | null;
+  relatedSummaries?: RelatedSummary[];
+  images: RequestImage[];
+  detail?: ImageDetail;
   generationSettings: GenerationSettings;
 }
 
@@ -129,62 +154,81 @@ export function buildRequest(options: BuildTextRequestOptions): HarnessRequest {
 }
 
 /**
- * Reads back the `detail` of the single image part in a built message list.
+ * Reads back the `detail` of every image part in a built message list, in the order they are sent.
  *
- * The value is taken from the message rather than assumed, so the accounting can never disagree with
- * the request: if the shared builder's `detail` ever changes, the cost model follows it instead of
- * pricing the old one. A message list that is not one image part is the builder's contract having
- * changed underneath us, which stops the harness rather than being guessed at — the same reasoning as
- * `projectResponseFormat`.
+ * The values are taken from the message rather than assumed, so the accounting can never disagree
+ * with the request: if the shared builder's default ever changes, or a per-image detail does not
+ * arrive the way the caller believed, the cost model follows the message instead of pricing the
+ * intention. An unrecognized value is the builder's contract having changed underneath us, which
+ * stops the harness rather than being guessed at — the same reasoning as `projectResponseFormat`.
  */
-export function detailOfSingleImage(messages: ChatCompletionMessageParam[]): ImageDetail {
-  const parts: { detail?: unknown }[] = [];
+export function detailsOfImages(messages: ChatCompletionMessageParam[]): ImageDetail[] {
+  const details: ImageDetail[] = [];
   for (const message of messages) {
     const content = (message as { content?: unknown }).content;
     if (!Array.isArray(content)) continue;
     for (const part of content) {
       const typed = part as { type?: string; image_url?: { detail?: unknown } };
-      if (typed?.type === "image_url") parts.push({ detail: typed.image_url?.detail });
+      if (typed?.type !== "image_url") continue;
+      // An absent detail is the provider's own default, which is `auto`.
+      const detail = typed.image_url?.detail ?? "auto";
+      if (!(imageDetails as readonly unknown[]).includes(detail)) {
+        throw new Error(`The shared image builder sent an unrecognised detail ` +
+          `${JSON.stringify(detail)}. Known values: ${imageDetails.join(", ")}.`);
+      }
+      details.push(detail as ImageDetail);
     }
   }
-  if (parts.length !== 1) {
-    throw new Error(`Expected the shared image builder to produce exactly one image part, got ` +
-      `${parts.length}. The cost model prices images from this, so the harness stops rather than ` +
-      "reserve for the wrong number of them.");
-  }
-  // An absent detail is the provider's own default, which is `auto`.
-  const detail = parts[0].detail ?? "auto";
-  if (!(imageDetails as readonly unknown[]).includes(detail)) {
-    throw new Error(`The shared image builder sent an unrecognised detail ${JSON.stringify(detail)}. ` +
-      `Known values: ${imageDetails.join(", ")}.`);
-  }
-  return detail as ImageDetail;
+  return details;
 }
 
 /**
- * The image analogue, built by the shared `buildImageMessages` unmodified — `detail` stays the
- * hardcoded `"auto"` production sends, so an image run cannot win by asking for a different one.
- * Comparing detail settings would mean changing the shared builder, which is not something an
- * experiment definition can reach.
+ * Pairs each image's file facts with the detail read back from the message at the same position.
  *
- * The caller supplies what it knows about the file (its hash and its size) and the builder supplies
- * what it knows about the request (the detail it just sent), so there is no way to describe an image
- * as costing something other than what was asked for.
+ * A count mismatch means the message does not carry the images the caller thinks it does, so the
+ * cost model would reserve for the wrong number of them. That stops the run.
+ */
+function accountingForImages(
+  messages: ChatCompletionMessageParam[], images: RequestImage[]
+): InputImageAccounting[] {
+  const details = detailsOfImages(messages);
+  if (details.length !== images.length) {
+    throw new Error(`The shared builder produced ${details.length} image part(s) for ` +
+      `${images.length} image(s). The cost model prices images from the message, so the harness ` +
+      "stops rather than reserve for the wrong number of them.");
+  }
+  return images.map((image, index) => {
+    // The type says `detail` does not belong in accounting, but TypeScript only checks that on a
+    // fresh object literal — a spread or a named const carries it straight through, and the pairing
+    // below would then silently replace it. Say so instead.
+    if ("detail" in image.accounting) {
+      throw new Error("Image accounting describes the file, not the request: do not pass a `detail` " +
+        `in it (got ${JSON.stringify((image.accounting as InputImageAccounting).detail)}). Ask for a ` +
+        "detail with the builder's `detail` option, which is what actually reaches the message.");
+    }
+    return { ...image.accounting, detail: details[index] };
+  });
+}
+
+/**
+ * The image analogue, built by the shared `buildImageMessages` unmodified.
+ *
+ * The caller supplies what it knows about each file (its hash and its size) and the builder supplies
+ * what it knows about the request (the detail it just attached), so there is no way to describe an
+ * image as costing something other than what was asked for. The builder stays the only place a
+ * detail is put on a message; a run asks for one through `detail`.
  */
 export function buildImageRequest(options: BuildImageRequestOptions): HarnessRequest {
-  const { model, aiPrompt, message, imageUrl, accounting, generationSettings } = options;
+  const { model, aiPrompt, message, images, detail, generationSettings } = options;
   if (message !== "image-only") {
     throw new Error(`buildImageRequest builds image-only messages; got message shape "${message}".`);
   }
-  // The type says `detail` does not belong here, but TypeScript only checks that on a fresh object
-  // literal — a spread or a named const carries it straight through. Silently ignoring a caller's
-  // declared detail would be its own trap, so it is refused out loud.
-  if ("detail" in accounting) {
-    throw new Error("buildImageRequest derives `detail` from the message it builds; do not pass one " +
-      `in accounting (got ${JSON.stringify((accounting as InputImageAccounting).detail)}). ` +
-      "Detail variants arrive in milestone 3, by changing the shared builder.");
+  if (images.length === 0) {
+    throw new Error("buildImageRequest needs at least one image; an image-only request with no " +
+      "picture is a run that would ask about nothing.");
   }
-  const messages = buildImageMessages(aiPrompt, imageUrl);
+  const messages = buildImageMessages(
+    aiPrompt, images.map((image) => ({ url: image.imageUrl })), { detail });
   return {
     apiRequest: {
       model,
@@ -192,7 +236,38 @@ export function buildImageRequest(options: BuildImageRequestOptions): HarnessReq
       responseFormat: projectResponseFormat(responseFormatFor(aiPrompt)),
       generationSettings
     },
-    inputAccounting: { images: [{ ...accounting, detail: detailOfSingleImage(messages) }] }
+    inputAccounting: { images: accountingForImages(messages, images) }
+  };
+}
+
+/**
+ * Text and pictures in one request, built by the shared `buildMixedMessages` unmodified.
+ *
+ * `markdown` is `null` for a document with no student-authored text: the summary and related-summary
+ * parts are then absent and only the pictures go, which is the case the run records on its row
+ * rather than skipping.
+ */
+export function buildMixedRequest(options: BuildMixedRequestOptions): HarnessRequest {
+  const {
+    model, aiPrompt, message, markdown, relatedSummaries = [], images, detail, generationSettings
+  } = options;
+  if (message !== "mixed") {
+    throw new Error(`buildMixedRequest builds mixed messages; got message shape "${message}".`);
+  }
+  if (images.length === 0) {
+    throw new Error("buildMixedRequest needs at least one image; a mixed request with no picture is " +
+      "a text-only request wearing the wrong name, and would be filed under the wrong message shape.");
+  }
+  const messages = buildMixedMessages(
+    aiPrompt, markdown, relatedSummaries, images.map((image) => ({ url: image.imageUrl })), { detail });
+  return {
+    apiRequest: {
+      model,
+      messages,
+      responseFormat: projectResponseFormat(responseFormatFor(aiPrompt)),
+      generationSettings
+    },
+    inputAccounting: { images: accountingForImages(messages, images) }
   };
 }
 

--- a/scripts/ai-harness/src/report.ts
+++ b/scripts/ai-harness/src/report.ts
@@ -348,9 +348,7 @@ const kColumns: { header: string; value: (group: GroupSummary) => string }[] = [
 /**
  * True when a row aggregates more than one message shape, making per-row averages meaningless.
  *
- * Not to be confused with the `mixed` message shape, which is one shape and averages fine. The old
- * name for this was `mixedShapes`, which stopped being readable the moment a shape was called
- * `mixed`.
+ * Not to be confused with the `mixed` message shape, which is one shape and averages fine.
  */
 function spansMessageShapes(group: GroupSummary): boolean {
   return group.message === "all";

--- a/scripts/ai-harness/src/report.ts
+++ b/scripts/ai-harness/src/report.ts
@@ -33,6 +33,12 @@ export interface GroupSummary {
    * should know which part before comparing groups.
    */
   overriddenModality: number;
+  /**
+   * How many of this group's documents sent a mixed message with its text half dropped, because the
+   * document carried no student-authored text. Those rows are half the input a mixed row usually
+   * has, so a reader comparing mixed against text-only needs the count before drawing a conclusion.
+   */
+  textPartOmitted: number;
   cacheHits: number;
   statuses: { success: number; refusal: number; error: number; skipped: number };
   tokens: {
@@ -122,6 +128,7 @@ interface Accumulator {
   promptTokens: number[];
   completionTokens: number[];
   imageEstimatedTotal: number;
+  textPartOmitted: Set<string>;
   modeledUsd: number;
   incurredUsd: number;
   categories: Record<string, number>;
@@ -138,6 +145,7 @@ function newAccumulator(
     overriddenModality: new Set(),
     cacheHits: 0,
     statuses: { success: 0, refusal: 0, error: 0, skipped: 0 },
+    textPartOmitted: new Set(),
     promptTokens: [],
     completionTokens: [],
     imageEstimatedTotal: 0,
@@ -151,9 +159,12 @@ function accumulate(accumulator: Accumulator, row: ResultRow): void {
   accumulator.docs.add(row.docId);
   // Counted by document rather than by row, so it lines up with the `docs` column beside it.
   if (row.modality !== row.computedModality) accumulator.overriddenModality.add(row.docId);
-  // Counted for every status, including errors and skips: what a picture would have cost is a fact
-  // about the request, not about whether the model answered.
-  accumulator.imageEstimatedTotal += row.promptImageTokensEstimated ?? 0;
+  // Counted for every status that built a request, errors included: what a picture would have cost
+  // is a fact about the request, not about whether the model answered. A skipped row built none.
+  if (row.status !== "skipped") {
+    accumulator.imageEstimatedTotal += row.promptImageTokensEstimated ?? 0;
+    if (row.textPartOmitted) accumulator.textPartOmitted.add(row.docId);
+  }
   switch (row.status) {
     case "success": {
       accumulator.statuses.success += 1;
@@ -210,6 +221,7 @@ function finish(accumulator: Accumulator): GroupSummary {
     modality: accumulator.modality,
     docs: accumulator.docs.size,
     overriddenModality: accumulator.overriddenModality.size,
+    textPartOmitted: accumulator.textPartOmitted.size,
     cacheHits: accumulator.cacheHits,
     statuses: accumulator.statuses,
     tokens: {
@@ -307,6 +319,10 @@ const kColumns: { header: string; value: (group: GroupSummary) => string }[] = [
   { header: "refused", value: (group) => String(group.statuses.refusal) },
   { header: "errors", value: (group) => String(group.statuses.error) },
   { header: "skipped", value: (group) => String(group.statuses.skipped) },
+  // Mixed rows that went without their text half, because the document carried no student-authored
+  // text. "-" rather than 0, so a group where it never happened does not read like a measurement.
+  { header: "no text", value: (group) =>
+    group.textPartOmitted === 0 ? "-" : String(group.textPartOmitted) },
   { header: "cached", value: (group) => String(group.cacheHits) },
   { header: "tok in", value: (group) => String(group.tokens.promptTotal) },
   // What the harness estimated the pictures cost, beside what the API actually billed for the whole
@@ -318,19 +334,25 @@ const kColumns: { header: string; value: (group: GroupSummary) => string }[] = [
   // image-only and text-only rows is arithmetic over two incomparable populations — a ~14,000-token
   // screenshot and a ~400-token summary — and reads as a fact about neither. Sums stay: "what did
   // this file cost" is a real question.
-  { header: "in mean", value: (group) => mixedShapes(group) ? "-" : group.tokens.promptMean.toFixed(0) },
-  { header: "in med", value: (group) => mixedShapes(group) ? "-" : group.tokens.promptMedian.toFixed(0) },
+  { header: "in mean", value: (group) => spansMessageShapes(group) ? "-" : group.tokens.promptMean.toFixed(0) },
+  { header: "in med", value: (group) => spansMessageShapes(group) ? "-" : group.tokens.promptMedian.toFixed(0) },
   { header: "out mean", value: (group) =>
-    mixedShapes(group) ? "-" : group.tokens.completionMean.toFixed(0) },
+    spansMessageShapes(group) ? "-" : group.tokens.completionMean.toFixed(0) },
   { header: "out med", value: (group) =>
-    mixedShapes(group) ? "-" : group.tokens.completionMedian.toFixed(0) },
+    spansMessageShapes(group) ? "-" : group.tokens.completionMedian.toFixed(0) },
   { header: "modeled $", value: (group) => group.cost.modeledUsd.toFixed(4) },
   { header: "incurred $", value: (group) => group.cost.incurredUsd.toFixed(4) },
   { header: "categories", value: (group) => formatCategories(group.categories) }
 ];
 
-/** True when a row aggregates more than one message shape, making per-row averages meaningless. */
-function mixedShapes(group: GroupSummary): boolean {
+/**
+ * True when a row aggregates more than one message shape, making per-row averages meaningless.
+ *
+ * Not to be confused with the `mixed` message shape, which is one shape and averages fine. The old
+ * name for this was `mixedShapes`, which stopped being readable the moment a shape was called
+ * `mixed`.
+ */
+function spansMessageShapes(group: GroupSummary): boolean {
   return group.message === "all";
 }
 

--- a/scripts/ai-harness/src/represent-image.ts
+++ b/scripts/ai-harness/src/represent-image.ts
@@ -16,7 +16,7 @@ import type { CorpusPaths } from "./corpus.js";
 import { isContainedBy, kTemporaryFilePattern, readJsonFile, writeFileAtomically } from "./files.js";
 import { NotAPngError, readPngInfo } from "./png.js";
 import {
-  EnvelopeImage, ImageEnvelope, RenderTarget, kSchemaVersion, validateImageEnvelope
+  EnvelopeImage, ImageEnvelope, ImageSet, RenderTarget, kSchemaVersion, validateImageEnvelope
 } from "./schemas.js";
 
 export const kPngMimeType = "image/png";
@@ -291,19 +291,56 @@ export function writeImageRepresentation(options: WriteImageRepresentationOption
 }
 
 /**
- * The one image a request is built from.
+ * The images a run sends, chosen from the envelope by the run's image set.
  *
- * Zero and many both fail, and the first image is never quietly selected: an envelope with two
- * images is a per-tile capture, and picking one of them would produce a result row that looks like
- * a normal full-document run and is not.
+ * The set is part of what a run measures, so it is selected rather than inferred: a `full-document`
+ * run against a per-tile envelope is a mistake about what is being compared, and picking whatever
+ * happens to be there would produce a result row that looks ordinary and answers a different
+ * question.
+ *
+ * `visualTileIds` names the tiles the classification marked as needing a picture, and is only read
+ * for `visual-tiles-only`.
  */
-export function singleImageOf(envelope: ImageEnvelope, envelopeFile: string): EnvelopeImage {
-  if (envelope.images.length !== 1) {
-    throw new Error(`${envelopeFile} records ${envelope.images.length} images. Milestone 2 builds ` +
-      "requests from exactly one full-document image; multi-image requests (per-tile capture and " +
-      "mixed messages) arrive in milestone 3.");
+export function imagesForSet(
+  envelope: ImageEnvelope, envelopeFile: string, imageSet: ImageSet, visualTileIds?: Set<string>
+): { images: EnvelopeImage[]; warnings: string[] } {
+  const warnings: string[] = [];
+  if (imageSet === "full-document") {
+    const full = envelope.images.filter((image) => image.purpose === "full-document");
+    if (full.length !== 1) {
+      throw new Error(`${envelopeFile} records ${full.length} full-document image(s) out of ` +
+        `${envelope.images.length}. A "full-document" run sends exactly one picture of the whole ` +
+        "document; render with a full-document mode, or set imageSet on the run.");
+    }
+    return { images: full, warnings };
   }
-  return envelope.images[0];
+
+  const tiles = envelope.images.filter((image) => image.purpose === "tile");
+  if (tiles.length === 0) {
+    throw new Error(`${envelopeFile} records no per-tile images, so an "${imageSet}" run has ` +
+      "nothing to send. Render with --mode puppeteer-per-tile first.");
+  }
+  if (imageSet === "per-tile") return { images: tiles, warnings };
+
+  if (!visualTileIds) {
+    throw new Error(`A "visual-tiles-only" run needs the document's classification to know which ` +
+      "tiles need a picture; none was supplied.");
+  }
+  const captured = new Set(tiles.map((image) => image.tileId).filter((id): id is string => !!id));
+  // Classification walks into Question tiles; the per-tile capture photographs top-level tiles
+  // only. So a visual tile nested inside a Question has a classification entry and no picture of
+  // its own — it is drawn inside its parent's. Recorded rather than failed: the images that exist
+  // are still the right ones to send, and a reader comparing sets needs to know the difference.
+  const uncaptured = [...visualTileIds].filter((tileId) => !captured.has(tileId));
+  if (uncaptured.length > 0) {
+    warnings.push(`${uncaptured.length} tile(s) the classification marks as needing a picture have ` +
+      `no per-tile capture (${uncaptured.slice(0, 5).join(", ")}) — a tile nested inside a Question ` +
+      "is drawn within its parent's image rather than beside it");
+  }
+  return {
+    images: tiles.filter((image) => image.tileId !== null && visualTileIds.has(image.tileId)),
+    warnings
+  };
 }
 
 /** The base64 data URL a locally captured PNG is sent as — what production does with a local file. */

--- a/scripts/ai-harness/src/represent-text.ts
+++ b/scripts/ai-harness/src/represent-text.ts
@@ -19,6 +19,21 @@ export interface TextVariant {
   /** Bump when this variant's output would change for the same input. */
   variantVersion: number;
   render(content: unknown): string;
+  /**
+   * Whether this variant would put student content in the summary for a document the classifier
+   * says carries no student-authored text.
+   *
+   * Skip-empty asks "would the summary carry any student content", and answers it from the
+   * classifier: does any tile hold text a student wrote. That is the right question for every
+   * variant that only passes text through, and the wrong one for a variant whose whole purpose is
+   * turning something else into words — `drawing-text` describes geometry, and a drawing of two
+   * shapes holds no student *text* while very much holding student work. Without this the decision
+   * is variant-blind, and the fixture a variant exists for is skipped before the variant is
+   * consulted.
+   *
+   * Absent means "nothing the classifier missed", which is true of every pass-through variant.
+   */
+  findsStudentContentWithoutText?(content: unknown): boolean;
 }
 
 export const textVariants: Record<string, TextVariant> = {
@@ -65,9 +80,29 @@ export const textVariants: Record<string, TextVariant> = {
     // handler that answers wins, so this one takes the Drawing tiles and the rest are untouched.
     render: (content) => documentSummarizer(content, {
       tileHandlers: [handleDrawingTileText, ...defaultTileHandlers]
-    })
+    }),
+    // A drawing with objects in it is student work this variant can describe, whether or not any of
+    // those objects is a text object. An empty drawing is not: `handleDrawingTileText` answers
+    // "which is empty", and a summary saying that carries nothing.
+    findsStudentContentWithoutText: (content) =>
+      tilesOf(content).some((tile) => {
+        const tileContent = (tile as { content?: { type?: string; objects?: unknown } })?.content;
+        return tileContent?.type === "Drawing" && Array.isArray(tileContent.objects) &&
+          tileContent.objects.length > 0;
+      })
   }
 };
+
+/**
+ * Every tile in a document's tile map, nested ones included.
+ *
+ * The map is flat — a Question tile's children are entries in it like any other — so this is the
+ * whole document's tiles without walking rows.
+ */
+function tilesOf(content: unknown): unknown[] {
+  const tileMap = (content as { tileMap?: Record<string, unknown> })?.tileMap;
+  return tileMap && typeof tileMap === "object" ? Object.values(tileMap) : [];
+}
 
 export const textVariantIds: readonly string[] = Object.keys(textVariants);
 

--- a/scripts/ai-harness/src/represent-text.ts
+++ b/scripts/ai-harness/src/represent-text.ts
@@ -9,6 +9,10 @@
  * README. It pulls in src/plugins/drawing, which imports .svg assets that only a bundler can load.
  */
 import { documentSummarizer } from "../../../shared/ai-summarizer/ai-summarizer.js";
+import { defaultTileHandlers } from "../../../shared/ai-summarizer/ai-tile-summarizer.js";
+import {
+  handleDrawingTileText
+} from "../../../shared/ai-summarizer/tile-summarizers/handle-drawing-tile-text.js";
 
 export interface TextVariant {
   id: string;
@@ -27,6 +31,41 @@ export const textVariants: Record<string, TextVariant> = {
     id: "minimal",
     variantVersion: 1,
     render: (content) => documentSummarizer(content, { minimal: true })
+  },
+  /**
+   * `default` with each data set's case data left out — the heading, the attributes, the formulas
+   * and the case count stay, so the shape of the data is still described.
+   *
+   * A large table can be most of a document's summary, and whether a model needs the rows to
+   * categorize a *design* is exactly the sort of question the harness exists to answer rather than
+   * assume. Two further ways to shrink a table are named in the plan and not built here: sending a
+   * fixed sample of cases, and sending aggregate statistics instead. Both are variants of their own
+   * when someone wants to measure them.
+   */
+  "no-dataset-tables": {
+    id: "no-dataset-tables",
+    variantVersion: 1,
+    render: (content) => documentSummarizer(content, { dataSetTables: "schema-only" })
+  },
+  /**
+   * `default` with drawings described rather than merely mentioned.
+   *
+   * The default handler says "This tile contains a drawing" and stops, so a text-only run is told
+   * nothing about what the student drew — which is most of what a visual document *is*, and a large
+   * part of why an image run might beat a text one. This variant swaps in a pure serializer that
+   * lists each object's type, position and size, and any text objects' text.
+   *
+   * A measurement prototype, deliberately unambitious: it describes geometry and does not interpret
+   * it. Beating it is the point, and a variant is how someone would show that they had.
+   */
+  "drawing-text": {
+    id: "drawing-text",
+    variantVersion: 1,
+    // Ahead of the defaults, which is how `documentSummarizerWithDrawings` composes: the first
+    // handler that answers wins, so this one takes the Drawing tiles and the rest are untouched.
+    render: (content) => documentSummarizer(content, {
+      tileHandlers: [handleDrawingTileText, ...defaultTileHandlers]
+    })
   }
 };
 

--- a/scripts/ai-harness/src/schemas.ts
+++ b/scripts/ai-harness/src/schemas.ts
@@ -172,6 +172,17 @@ export interface ManifestDocument {
   computedModality: Modality;
   /** Only ever set by a human; tooling never writes it. */
   modalityOverride: Modality | null;
+  /**
+   * Why this document is known not to render, or `null` when it should.
+   *
+   * A document can be unrenderable on purpose — the ErrorTest fixture exists to make a tile throw —
+   * and without somewhere to say so, `render` reports a real failure every time and the exit code
+   * stops meaning anything. A run treats such a document as skipped rather than as a missing render.
+   *
+   * Set by a human, or seeded by `import` from the source directory's `expectations.json`. Never
+   * inferred from a render that happened to fail: that is the thing it would hide.
+   */
+  expectedRenderFailure: string | null;
   labels: Record<string, unknown>;
   relatedSummaries: RelatedSummaryEntry[];
   historical: HistoricalAnalysis | null;
@@ -224,6 +235,8 @@ function validateManifestDocument(value: unknown, file: string, field: string): 
     modalityOverride: record.modalityOverride == null
       ? null
       : asEnum(record.modalityOverride, modalities, file, `${field}.modalityOverride`),
+    expectedRenderFailure:
+      asOptionalString(record.expectedRenderFailure, file, `${field}.expectedRenderFailure`),
     labels: record.labels == null ? {} : asObject(record.labels, file, `${field}.labels`),
     relatedSummaries: record.relatedSummaries == null
       ? []
@@ -236,8 +249,9 @@ function validateManifestDocument(value: unknown, file: string, field: string): 
 }
 
 /**
- * Related summaries are not yet injected into request construction, and the manifest is
- * exactly the file a human hand-edits, so these are checked rather than cast.
+ * Related summaries *are* injected into request construction — every text-carrying run puts them in
+ * the message's related-summary parts — and the manifest is exactly the file a human hand-edits, so
+ * these are checked rather than cast.
  */
 function validateRelatedSummary(value: unknown, file: string, field: string): RelatedSummaryEntry {
   const record = asObject(value, file, field);
@@ -365,22 +379,53 @@ export function validatePromptFile(value: unknown, file: string): PromptFile {
 // Experiment file
 // ---------------------------------------------------------------------------
 
-/** Text-only and image-only are what run today; `mixed` is declared but nothing builds one yet. */
-export const messageShapes = ["text-only", "image-only"] as const;
+export const messageShapes = ["text-only", "image-only", "mixed"] as const;
 export type MessageShape = typeof messageShapes[number];
 
+/** Which images out of an envelope a run sends. */
+export const imageSets = ["full-document", "per-tile", "visual-tiles-only"] as const;
+export type ImageSet = typeof imageSets[number];
+
 /**
- * A run names one representation, and which one depends on its message shape: `text-only` runs carry
- * a `textVariant`, `image-only` runs carry an `imageMode`. The other field is refused rather than
- * ignored — a `text-only` run with an `imageMode` set is a mistake about what is being measured, and
- * silently dropping it would produce a result table that looks fine and answers a different question.
+ * What a run puts in the related-summary parts of a text or mixed message.
+ *
+ * `extras-fixed` is the default because it is what the harness has always done — each related
+ * document's actual summary, from the manifest — so existing experiment files keep their meaning and
+ * their request keys. `extras-production-current` reproduces production's `findRelatedSummaries` bug
+ * on purpose, as a named baseline; see the README.
+ */
+export const extrasModes = ["extras-fixed", "extras-production-current", "no-extras"] as const;
+export type ExtrasMode = typeof extrasModes[number];
+
+/**
+ * A run names its representation, and which one depends on its message shape: `text-only` carries a
+ * `textVariant`, `image-only` carries an `imageMode`, `mixed` carries both. A field that the shape
+ * cannot use is refused rather than ignored — a `text-only` run with an `imageMode` set is a mistake
+ * about what is being measured, and silently dropping it would produce a result table that looks
+ * fine and answers a different question. The same rule covers the three dimensions below.
  */
 export interface ExperimentRun {
   id: string;
   message: MessageShape;
   textVariant?: string;
   imageMode?: string;
+  /** Image runs only. Absent means the shared builder's `"auto"`. */
+  detail?: ImageDetail;
+  /** Image runs only. Absent means `full-document`. */
+  imageSet?: ImageSet;
+  /** Text-carrying runs only. Absent means `extras-fixed`. */
+  extras?: ExtrasMode;
   prompt: string;
+}
+
+/** Whether this shape sends a summary, and so can carry a text variant and an extras setting. */
+export function sendsText(message: MessageShape): boolean {
+  return message === "text-only" || message === "mixed";
+}
+
+/** Whether this shape sends pictures, and so can carry an image mode, a set and a detail. */
+export function sendsImages(message: MessageShape): boolean {
+  return message === "image-only" || message === "mixed";
 }
 
 export interface ExperimentFile {
@@ -425,26 +470,53 @@ export function validateExperimentFile(
     }
 
     const validated: ExperimentRun = { id, message, prompt };
-    if (message === "text-only") {
-      if (run.imageMode !== undefined) {
-        fail(file, `${field}.imageMode`, 'must not be set on a "text-only" run, which sends no image');
-      }
+    if (sendsText(message)) {
       const textVariant = asString(run.textVariant, file, `${field}.textVariant`);
       if (!context.knownTextVariants.includes(textVariant)) {
         fail(file, `${field}.textVariant`,
           `must be one of ${context.knownTextVariants.join(", ")}, got "${textVariant}"`);
       }
       validated.textVariant = textVariant;
+      if (run.extras !== undefined) {
+        validated.extras = asEnum(run.extras, extrasModes, file, `${field}.extras`);
+      }
     } else {
       if (run.textVariant !== undefined) {
-        fail(file, `${field}.textVariant`, 'must not be set on an "image-only" run, which sends no summary');
+        fail(file, `${field}.textVariant`,
+          `must not be set on an "${message}" run, which sends no summary`);
       }
+      if (run.extras !== undefined) {
+        fail(file, `${field}.extras`,
+          `must not be set on an "${message}" run: extras ride the summary, and none is sent`);
+      }
+    }
+
+    if (sendsImages(message)) {
       const imageMode = asString(run.imageMode, file, `${field}.imageMode`);
       if (!context.knownImageModes.includes(imageMode)) {
         fail(file, `${field}.imageMode`,
           `must be one of ${context.knownImageModes.join(", ")}, got "${imageMode}"`);
       }
       validated.imageMode = imageMode;
+      if (run.detail !== undefined) {
+        validated.detail = asEnum(run.detail, imageDetails, file, `${field}.detail`);
+      }
+      if (run.imageSet !== undefined) {
+        validated.imageSet = asEnum(run.imageSet, imageSets, file, `${field}.imageSet`);
+      }
+    } else {
+      if (run.imageMode !== undefined) {
+        fail(file, `${field}.imageMode`,
+          `must not be set on a "${message}" run, which sends no image`);
+      }
+      if (run.detail !== undefined) {
+        fail(file, `${field}.detail`,
+          `must not be set on a "${message}" run: detail describes an image, and none is sent`);
+      }
+      if (run.imageSet !== undefined) {
+        fail(file, `${field}.imageSet`,
+          `must not be set on a "${message}" run, which sends no image`);
+      }
     }
     return validated;
   });
@@ -483,15 +555,21 @@ export function validateRepresentationEnvelope(value: unknown, file: string): Re
 // Image representation envelope
 // ---------------------------------------------------------------------------
 
-/** What a capture covers. `fixed-height` is the Shutterbug modes' clipped capture. */
-export const captureModes = ["full-document", "fixed-height"] as const;
+/**
+ * What a capture covers.
+ *
+ * `fixed-height` is the Shutterbug modes' clipped capture. `per-tile` produces one image per
+ * top-level tile instead of one of the page, so the set covers the document while no single image
+ * is the document — which is why it is a capture mode of its own rather than a kind of full page.
+ */
+export const captureModes = ["full-document", "fixed-height", "per-tile"] as const;
 export type CaptureMode = typeof captureModes[number];
 
-/** What one stored image is a picture of. `tile` is written by nothing yet; it arrives in M3. */
+/** What one stored image is a picture of. */
 export const imagePurposes = ["full-document", "tile"] as const;
 export type ImagePurpose = typeof imagePurposes[number];
 
-/** OpenAI's image detail setting. The shared builder hardcodes `auto`; M3 adds the other two. */
+/** OpenAI's image detail setting, as sent on an image part. */
 export const imageDetails = ["low", "high", "auto"] as const;
 export type ImageDetail = typeof imageDetails[number];
 
@@ -600,8 +678,8 @@ export function validateRenderTarget(value: unknown, file: string, field: string
   if (captureMode === "fixed-height" && captureHeightPx === null) {
     fail(file, `${field}.captureHeightPx`, 'is required when captureMode is "fixed-height"');
   }
-  if (captureMode === "full-document" && captureHeightPx !== null) {
-    fail(file, `${field}.captureHeightPx`, 'must be null when captureMode is "full-document"');
+  if (captureMode !== "fixed-height" && captureHeightPx !== null) {
+    fail(file, `${field}.captureHeightPx`, `must be null when captureMode is "${captureMode}"`);
   }
   return {
     clueUrl: asString(record.clueUrl, file, `${field}.clueUrl`),
@@ -760,36 +838,77 @@ export type ResultStatus = typeof resultStatuses[number];
  *
  * This is also the extension point a mixed-message row will need.
  */
+/** What a text-carrying row sends: which variant produced the summary, from which content. */
+export interface TextRepresentation {
+  variantId: string;
+  variantVersion: number;
+  sourceContentSha256: string;
+}
+
+/** What an image-carrying row sends: which render produced the pictures, and which pictures. */
+export interface ImageRepresentation {
+  modeId: string;
+  backendId: string;
+  backendVersion: number;
+  renderTarget: RenderTarget;
+  sourceContentSha256: string;
+  imageSha256s: string[];
+  /** Which images out of the envelope were sent. Absent on rows written before sets existed. */
+  imageSet?: ImageSet;
+}
+
+/**
+ * Where a row's input came from.
+ *
+ * A `mixed` row carries both sides, as the same two shapes the single-representation rows use rather
+ * than a third flattened field list — so a reader (and a report) can read either half of a mixed row
+ * exactly as it reads the row that sent only that half.
+ */
 export type RepresentationDescriptor =
-  | { kind: "text"; variantId: string; variantVersion: number; sourceContentSha256: string }
-  | {
-      kind: "image";
-      modeId: string;
-      backendId: string;
-      backendVersion: number;
-      renderTarget: RenderTarget;
-      sourceContentSha256: string;
-      imageSha256s: string[];
-    };
+  | ({ kind: "text" } & TextRepresentation)
+  | ({ kind: "image" } & ImageRepresentation)
+  | { kind: "mixed"; text: TextRepresentation; image: ImageRepresentation };
+
+function validateTextRepresentation(
+  record: Record<string, unknown>, file: string, field: string
+): TextRepresentation {
+  return {
+    variantId: asString(record.variantId, file, `${field}.variantId`),
+    variantVersion: asNumber(record.variantVersion, file, `${field}.variantVersion`),
+    sourceContentSha256: asString(record.sourceContentSha256, file, `${field}.sourceContentSha256`)
+  };
+}
+
+function validateImageRepresentation(
+  record: Record<string, unknown>, file: string, field: string
+): ImageRepresentation {
+  return {
+    ...validateImageProvenance(record, file, field),
+    imageSha256s: asArray(record.imageSha256s, file, `${field}.imageSha256s`)
+      .map((hash, index) => asSha256(hash, file, `${field}.imageSha256s[${index}]`)),
+    ...(record.imageSet === undefined
+      ? {}
+      : { imageSet: asEnum(record.imageSet, imageSets, file, `${field}.imageSet`) })
+  };
+}
 
 export function validateRepresentationDescriptor(
   value: unknown, file: string, field: string
 ): RepresentationDescriptor {
   const record = asObject(value, file, field);
-  const kind = asEnum(record.kind, ["text", "image"] as const, file, `${field}.kind`);
+  const kind = asEnum(record.kind, ["text", "image", "mixed"] as const, file, `${field}.kind`);
   if (kind === "text") {
-    return {
-      kind,
-      variantId: asString(record.variantId, file, `${field}.variantId`),
-      variantVersion: asNumber(record.variantVersion, file, `${field}.variantVersion`),
-      sourceContentSha256: asString(record.sourceContentSha256, file, `${field}.sourceContentSha256`)
-    };
+    return { kind, ...validateTextRepresentation(record, file, field) };
+  }
+  if (kind === "image") {
+    return { kind, ...validateImageRepresentation(record, file, field) };
   }
   return {
     kind,
-    ...validateImageProvenance(record, file, field),
-    imageSha256s: asArray(record.imageSha256s, file, `${field}.imageSha256s`)
-      .map((hash, index) => asSha256(hash, file, `${field}.imageSha256s[${index}]`))
+    text: validateTextRepresentation(
+      asObject(record.text, file, `${field}.text`), file, `${field}.text`),
+    image: validateImageRepresentation(
+      asObject(record.image, file, `${field}.image`), file, `${field}.image`)
   };
 }
 
@@ -839,6 +958,20 @@ export interface ResultRowCommon {
    */
   computedModality: Modality;
   message: MessageShape;
+  prompt: { name: string; sha256: string };
+  /** The cache key, which doubles as resume identity. `null` on skipped rows: they build no request. */
+  requestKey: string | null;
+  runMeta: RunMeta;
+}
+
+/**
+ * What every row that actually built and sent a request carries.
+ *
+ * `representation` lives here rather than on `ResultRowCommon` because a skipped row has none —
+ * nothing was represented. Giving one a placeholder descriptor would put a variant or a render mode
+ * in the results for a request that never existed.
+ */
+export interface SentResultRowCommon extends ResultRowCommon {
   representation: RepresentationDescriptor;
   /**
    * The harness's pre-flight image-token estimate for this row's images, at the configured pricing.
@@ -846,13 +979,25 @@ export interface ResultRowCommon {
    * what was billed; this is recorded so a report can say how much of the prompt was picture.
    */
   promptImageTokensEstimated?: number;
-  prompt: { name: string; sha256: string };
-  /** The cache key, which doubles as resume identity. `null` on skipped rows: they build no request. */
-  requestKey: string | null;
-  runMeta: RunMeta;
+  /**
+   * Set on a mixed row whose document carried no student-authored text: the summary and the related
+   * summaries were dropped and only the pictures went. The request *was* sent, so this is not a
+   * skipped row — but a reader comparing mixed against text-only needs to know which mixed rows were
+   * missing half their input, and a report counts them.
+   */
+  textPartOmitted?: true;
+  /**
+   * Things worth knowing about how this row's input was assembled, which are not failures.
+   *
+   * The case this exists for: classification walks into Question tiles, but the per-tile capture
+   * photographs top-level tiles only, so a visual tile nested in a Question has a classification
+   * entry and no picture of its own. The images that exist are still the right ones to send, and a
+   * reader comparing image sets needs to know the difference rather than discovering it later.
+   */
+  representationWarnings?: string[];
 }
 
-export interface SuccessResultRow extends ResultRowCommon {
+export interface SuccessResultRow extends SentResultRowCommon {
   status: "success";
   requestKey: string;
   response: { parsed: unknown; raw: unknown };
@@ -861,7 +1006,7 @@ export interface SuccessResultRow extends ResultRowCommon {
   responseOriginMeta: ResponseOriginMeta;
 }
 
-export interface RefusalResultRow extends ResultRowCommon {
+export interface RefusalResultRow extends SentResultRowCommon {
   status: "refusal";
   requestKey: string;
   refusal: string;
@@ -870,7 +1015,7 @@ export interface RefusalResultRow extends ResultRowCommon {
   responseOriginMeta: ResponseOriginMeta;
 }
 
-export interface ErrorResultRow extends ResultRowCommon {
+export interface ErrorResultRow extends SentResultRowCommon {
   status: "error";
   requestKey: string;
   error: { type: string; message: string; attempts: number };
@@ -888,7 +1033,17 @@ export interface ErrorResultRow extends ResultRowCommon {
 export interface SkippedResultRow extends ResultRowCommon {
   status: "skipped";
   requestKey: null;
+  /** Why this (run, document) was not sent, in terms a reader can act on. */
   skipReasons: string[];
+  /**
+   * The document content the decision was made from.
+   *
+   * A skip is a judgement about what a document contains, so a rerun has to be able to tell whether
+   * that judgement still applies. Without this, an existing skipped row is indistinguishable from
+   * one decided against content that has since changed, and resume would either re-skip forever or
+   * never revisit an edited document.
+   */
+  decidedFromContentSha256: string;
 }
 
 export type ResultRow = SuccessResultRow | RefusalResultRow | ErrorResultRow | SkippedResultRow;
@@ -919,7 +1074,6 @@ function validateResultCommon(record: Record<string, unknown>, file: string): Re
     modality: asEnum(record.modality, modalities, file, "modality"),
     computedModality: asEnum(record.computedModality, modalities, file, "computedModality"),
     message: asEnum(record.message, messageShapes, file, "message"),
-    representation: validateRepresentationDescriptor(record.representation, file, "representation"),
     prompt: {
       name: asString(prompt.name, file, "prompt.name"),
       sha256: asString(prompt.sha256, file, "prompt.sha256")
@@ -932,20 +1086,44 @@ function validateResultCommon(record: Record<string, unknown>, file: string): Re
       gitDirty: asBoolean(runMeta.gitDirty, file, "runMeta.gitDirty")
     }
   };
+  return common;
+}
+
+/** The `representation` half of a row that sent a request, plus the fields that ride with it. */
+function validateSentRow(
+  record: Record<string, unknown>, file: string, common: ResultRowCommon
+): SentResultRowCommon {
+  const representation = validateRepresentationDescriptor(record.representation, file, "representation");
+  const sent: SentResultRowCommon = { ...common, representation };
   if (record.promptImageTokensEstimated !== undefined) {
     // Reports sum this, so a negative would quietly subtract from the image-token total.
-    common.promptImageTokensEstimated =
+    sent.promptImageTokensEstimated =
       asNonNegativeNumber(record.promptImageTokensEstimated, file, "promptImageTokensEstimated");
   }
   // An estimate on a row that sent no image, or its absence on one that did, would put a number in
   // the report's image column that belongs to nothing.
-  const sentAnImage = common.representation.kind === "image";
-  if (sentAnImage !== (common.promptImageTokensEstimated !== undefined)) {
+  const sentAnImage = representation.kind === "image" || representation.kind === "mixed";
+  if (sentAnImage !== (sent.promptImageTokensEstimated !== undefined)) {
     fail(file, "promptImageTokensEstimated",
       `must be ${sentAnImage ? "set" : "absent"} on a row whose representation is ` +
-      `"${common.representation.kind}"`);
+      `"${representation.kind}"`);
   }
-  return common;
+  if (record.representationWarnings !== undefined) {
+    sent.representationWarnings = asArray(record.representationWarnings, file, "representationWarnings")
+      .map((warning, index) => asString(warning, file, `representationWarnings[${index}]`));
+  }
+  if (record.textPartOmitted !== undefined) {
+    if (record.textPartOmitted !== true) {
+      fail(file, "textPartOmitted",
+        `is only ever true when present, got ${describe(record.textPartOmitted)}`);
+    }
+    if (representation.kind !== "mixed") {
+      fail(file, "textPartOmitted",
+        `only applies to a mixed row, and this one is "${representation.kind}"`);
+    }
+    sent.textPartOmitted = true;
+  }
+  return sent;
 }
 
 function validateUsage(value: unknown, file: string): ResultUsage {
@@ -984,21 +1162,30 @@ export function validateResultRow(value: unknown, file: string): ResultRow {
     if (record.requestKey != null) {
       fail(file, "requestKey", `must be null on a skipped row, got ${describe(record.requestKey)}`);
     }
+    const skipReasons = asArray(record.skipReasons, file, "skipReasons")
+      .map((reason, index) => asString(reason, file, `skipReasons[${index}]`));
+    // A skipped row with no reason is the failure mode this status exists to prevent: a document
+    // that simply does not appear, with nothing saying why.
+    if (skipReasons.length === 0) {
+      fail(file, "skipReasons", "must name at least one reason the document was not sent");
+    }
     return {
       ...common,
       status,
       requestKey: null,
-      skipReasons: asArray(record.skipReasons, file, "skipReasons")
-        .map((reason, index) => asString(reason, file, `skipReasons[${index}]`))
+      skipReasons,
+      decidedFromContentSha256:
+        asSha256(record.decidedFromContentSha256, file, "decidedFromContentSha256")
     };
   }
 
   const requestKey = asString(record.requestKey, file, "requestKey");
+  const sent = validateSentRow(record, file, common);
 
   if (status === "error") {
     const error = asObject(record.error, file, "error");
     const row: ErrorResultRow = {
-      ...common,
+      ...sent,
       status,
       requestKey,
       error: {
@@ -1023,7 +1210,7 @@ export function validateResultRow(value: unknown, file: string): ResultRow {
 
   if (status === "refusal") {
     return {
-      ...common,
+      ...sent,
       status,
       requestKey,
       refusal: asString(record.refusal, file, "refusal"),
@@ -1037,7 +1224,7 @@ export function validateResultRow(value: unknown, file: string): ResultRow {
   if (!("parsed" in response)) fail(file, "response.parsed", "is missing");
   if (!("raw" in response)) fail(file, "response.raw", "is missing");
   return {
-    ...common,
+    ...sent,
     status,
     requestKey,
     response: { parsed: response.parsed, raw: response.raw },
@@ -1064,6 +1251,11 @@ export interface FixtureExpectation {
   expectDistinctiveInDefaultSummary: boolean;
   defaultSummaryMustSucceed: boolean;
   minimalSummaryMustSucceed: boolean;
+  /**
+   * Why this fixture is expected not to render, when it is not expected to. `import` copies it onto
+   * the manifest entry, so a corpus imported from here knows without anyone hand-editing anything.
+   */
+  expectedRenderFailure?: string;
   notes?: string;
 }
 
@@ -1099,6 +1291,9 @@ export function validateExpectationsFile(value: unknown, file: string): Expectat
         expectation.defaultSummaryMustSucceed, file, `${field}.defaultSummaryMustSucceed`),
       minimalSummaryMustSucceed: asBoolean(
         expectation.minimalSummaryMustSucceed, file, `${field}.minimalSummaryMustSucceed`),
+      expectedRenderFailure: expectation.expectedRenderFailure === undefined
+        ? undefined
+        : asString(expectation.expectedRenderFailure, file, `${field}.expectedRenderFailure`),
       notes: expectation.notes === undefined ? undefined : asString(expectation.notes, file, `${field}.notes`)
     };
   }

--- a/scripts/ai-harness/src/schemas.ts
+++ b/scripts/ai-harness/src/schemas.ts
@@ -1152,6 +1152,18 @@ function validateOriginMeta(value: unknown, file: string): ResponseOriginMeta {
   };
 }
 
+/**
+ * Fields that only a row which sent a request can carry: what was sent, and what came back.
+ *
+ * A skipped row has none of them, and `SkippedResultRow` does not declare them — but a results file
+ * is data on disk, hand-editable and readable by a version of this code that did not write it, so
+ * the type says nothing about what a file actually contains.
+ */
+const kSentOnlyRowFields = [
+  "representation", "promptImageTokensEstimated", "representationWarnings", "textPartOmitted",
+  "response", "refusal", "usage", "cost", "responseOriginMeta", "error"
+] as const;
+
 /** Validates one result row against the schema its `status` selects. */
 export function validateResultRow(value: unknown, file: string): ResultRow {
   const record = asObject(value, file, "result");
@@ -1161,6 +1173,15 @@ export function validateResultRow(value: unknown, file: string): ResultRow {
   if (status === "skipped") {
     if (record.requestKey != null) {
       fail(file, "requestKey", `must be null on a skipped row, got ${describe(record.requestKey)}`);
+    }
+    // Nothing describing a request or a reply belongs here, because there was neither. Refused
+    // rather than dropped, the way `validateSentRow` refuses an image-token estimate on a text row:
+    // a field this row cannot have means the file was written by something that disagrees about
+    // what a skipped row is, and reading past it would file that disagreement as a valid row.
+    const impossible = kSentOnlyRowFields.filter((field) => record[field] !== undefined);
+    if (impossible.length > 0) {
+      fail(file, impossible[0], `cannot appear on a skipped row, which sent no request` +
+        `${impossible.length > 1 ? ` (nor can ${impossible.slice(1).join(", ")})` : ""}`);
     }
     const skipReasons = asArray(record.skipReasons, file, "skipReasons")
       .map((reason, index) => asString(reason, file, `skipReasons[${index}]`));

--- a/scripts/ai-harness/src/schemas.ts
+++ b/scripts/ai-harness/src/schemas.ts
@@ -828,16 +828,6 @@ export function validatePricingConfig(value: unknown, file: string): PricingConf
 export const resultStatuses = ["success", "refusal", "error", "skipped"] as const;
 export type ResultStatus = typeof resultStatuses[number];
 
-/**
- * Which representation a row was produced from, in enough detail to find it again.
- *
- * Both kinds carry `sourceContentSha256`, so a row can always be tied back to the exact document
- * content it describes. The image side carries the whole render target because that is what a
- * screenshot's provenance *is*: the same document rendered against a different CLUE build is a
- * different picture. `runId` alone would lose all of it.
- *
- * This is also the extension point a mixed-message row will need.
- */
 /** What a text-carrying row sends: which variant produced the summary, from which content. */
 export interface TextRepresentation {
   variantId: string;
@@ -858,7 +848,12 @@ export interface ImageRepresentation {
 }
 
 /**
- * Where a row's input came from.
+ * Where a row's input came from, in enough detail to find it again.
+ *
+ * Every kind carries `sourceContentSha256`, so a row can always be tied back to the exact document
+ * content it describes. The image side carries the whole render target because that is what a
+ * screenshot's provenance *is*: the same document rendered against a different CLUE build is a
+ * different picture. `runId` alone would lose all of it.
  *
  * A `mixed` row carries both sides, as the same two shapes the single-representation rows use rather
  * than a third flattened field list — so a reader (and a report) can read either half of a mixed row

--- a/scripts/ai-harness/test/backends.test.ts
+++ b/scripts/ai-harness/test/backends.test.ts
@@ -373,7 +373,8 @@ describe("the puppeteer backend", () => {
 
   it("attaches evidence to a failure that is not a RenderFailed", async () => {
     // A navigation error, a size-limit rejection or a raw protocol error is exactly when the console
-    // output and a picture of the page are most wanted, and these used to arrive with neither.
+    // output and a picture of the page are most wanted, so evidence is attached to any failure and
+    // not only to a RenderFailed.
     const fake = fakeBrowser();
     (fake.browser as any).newPage = async () => {
       const page = await fakeBrowser().browser.newPage();
@@ -533,8 +534,9 @@ describe("the puppeteer backend", () => {
         url: () => "http://localhost:8080/iframe.html",
         evaluate: async (script: unknown) => {
           if (String(script).includes("innerText")) return "marker";
-          // Only once the frame has been resized: this is the settle whose failures used to be
-          // recorded as evidence without failing anything.
+          // Only once the frame has been resized. That is the settle whose failures the check
+          // before the capture exists to catch: a fatal error here, after the resize, would
+          // otherwise reach the evidence file without failing anything.
           if (resized) {
             for (const handler of handlers) {
               handler({ type: () => "error", text: () => "Failed to fetch dynamically imported module: tile.js" });
@@ -558,9 +560,9 @@ describe("the puppeteer backend", () => {
   });
 
   it("spends one timeout budget across every phase, not one per phase", async () => {
-    // The budget used to be handed out fresh to each phase, so a stuck document could burn several
-    // times the documented per-document timeout. One deadline now covers load, readiness and
-    // capture, and the failure names it.
+    // One deadline covers load, readiness and capture together, and the failure names it. A fresh
+    // budget per phase would let a stuck document burn several times the per-document timeout the
+    // CLI documents.
     const started = Date.now();
     const { backend } = makeBackend({ measurement: { contentHeightPx: 0 } }, { timeoutMs: 800 });
     await expect(backend.render({ docId: "slow", content: emptyDocument }))
@@ -676,8 +678,9 @@ describe("how many tiles a document should draw", () => {
   });
 
   it("falls through to the tile map when the rows name nothing", () => {
-    // A present-but-empty `rowMap` used to answer 0, and "at least 0 tiles" is satisfied by any
-    // stable state at all — including a page that has not finished loading, whose picture is blank.
+    // Answering 0 for a present-but-empty `rowMap` would mean waiting for "at least 0 tiles", which
+    // any stable state satisfies — including a page that has not finished loading, whose picture is
+    // blank.
     expect(expectedTileCount({ rowMap: {}, tileMap: { a: {}, b: {} } })).toBe(2);
     expect(expectedTileCount({ rowMap: { r1: { tiles: [] } }, tileMap: { a: {} } })).toBe(1);
   });
@@ -856,9 +859,9 @@ describe("the mode registry", () => {
   });
 
   it("supplies the harness rendering unit for the local mode rather than leaving it unset", () => {
-    // The unit used to be the caller's job, decided by a string comparison repeated in three places
-    // in the CLI. Getting it wrong is silent: CLUE falls back to its default unit and every tile
-    // draws as an unknown tile in a perfectly valid PNG. The mode descriptor now supplies it.
+    // The mode descriptor supplies it, rather than the caller deciding by string comparison in the
+    // CLI. Getting it wrong is silent: CLUE falls back to its default unit and every tile draws as
+    // an unknown tile in a perfectly valid PNG.
     expect(getRenderBackend("puppeteer-full-height", { clueRevision: null }).renderTarget.unit)
       .toBe("harness-render");
     // An explicit unit still wins.

--- a/scripts/ai-harness/test/backends.test.ts
+++ b/scripts/ai-harness/test/backends.test.ts
@@ -9,6 +9,7 @@ import {
   RenderLimitExceeded, checkCaptureSize, checkEncodedSize, isPublicHttpsUrl, redirectDowngradeReason
 } from "../src/backends/types.js";
 import { generateRenderHtml } from "../src/backends/render-html.js";
+import { readPngInfo } from "../src/png.js";
 import { makeTestPng } from "./helpers.js";
 
 // Named to avoid shadowing the DOM `document` global in files that are about browser rendering.
@@ -30,9 +31,12 @@ interface FakeOptions {
   requestFailures?: string[];
   frameUrl?: string | null;
   element?: ElementLike | null;
+  /** The top-level tiles the CLUE frame draws, for the per-tile capture. */
+  tiles?: { tileId: string; widthPx: number; heightPx: number }[];
 }
 
 const settledMeasurement: FrameMeasurement = {
+  documentFailedToLoad: false,
   contentHeightPx: 1420,
   contentRowsHeightPx: 1200,
   totalTiles: 3,
@@ -64,12 +68,31 @@ function fakeBrowser(options: FakeOptions = {}) {
     }
   };
 
+  const tiles = options.tiles ?? [];
   const frame: FrameLike = {
     url: () => options.frameUrl ?? "http://localhost:8080/iframe.html?unit=x&unwrapped&readOnly",
-    // The settle poll asks for the measurement; the post-settle read asks for the document text.
+    // The settle poll asks for the measurement; the post-settle reads ask for the document text and
+    // for the tile ids.
     evaluate: async (script) => (String(script).includes("innerText")
       ? "drawing-fixture-marker"
-      : { ...settledMeasurement, ...options.measurement }) as never
+      : String(script).includes("data-tool-id")
+      ? tiles.map((tile) => tile.tileId)
+      : { ...settledMeasurement, ...options.measurement }) as never,
+    $$: async (selector) => {
+      // Pinned because this fake has no DOM: it returns `tiles` whatever it is asked for, so the
+      // only thing it can say about the selector is what the selector was. The `:not()` is the part
+      // that keeps a Question tile's nested tiles out of the capture, and dropping it would give one
+      // top-level tile several pictures with nothing here noticing. `local-render.integration.ts`
+      // is where that is checked against a real DOM.
+      expect(selector).toBe(".tool-tile:not(.tool-tile .tool-tile)");
+      return tiles.map((tile) => ({
+        boundingBox: async () => ({ x: 0, y: 0, width: tile.widthPx, height: tile.heightPx }),
+        screenshot: async () => {
+          state.screenshots += 1;
+          return makeTestPng(tile.widthPx, tile.heightPx);
+        }
+      }));
+    }
   };
 
   const page: PageLike = {
@@ -144,6 +167,7 @@ const fakePageServer = async () => ({
 function makeBackend(options: FakeOptions = {}, overrides: Record<string, unknown> = {}) {
   const fake = fakeBrowser(options);
   const backend = puppeteerBackend({
+    modeId: "puppeteer-full-height",
     clueUrl: "http://localhost:8080",
     unit: "http://127.0.0.1:5000/content.json",
     clueRevision: "9b53df828",
@@ -316,6 +340,7 @@ describe("the puppeteer backend", () => {
       return page;
     };
     const backend = puppeteerBackend({
+      modeId: "puppeteer-full-height",
       clueUrl: "http://localhost:8080", unit: "harness-render", clueRevision: "r",
       launch: async () => fake.browser, startPageServer: fakePageServer,
       stableForMs: 0, pollIntervalMs: 1, timeoutMs: 600
@@ -337,6 +362,7 @@ describe("the puppeteer backend", () => {
       return page;
     };
     const backend = puppeteerBackend({
+      modeId: "puppeteer-full-height",
       clueUrl: "http://localhost:8080", unit: "harness-render", clueRevision: "r",
       launch: async () => fake.browser, startPageServer: fakePageServer,
       stableForMs: 0, pollIntervalMs: 1, timeoutMs: 600
@@ -370,6 +396,7 @@ describe("the puppeteer backend", () => {
       return page;
     };
     const backend = puppeteerBackend({
+      modeId: "puppeteer-full-height",
       clueUrl: "http://localhost:8080", unit: "harness-render", clueRevision: "r",
       launch: async () => fake.browser, startPageServer: fakePageServer,
       stableForMs: 0, pollIntervalMs: 1
@@ -410,6 +437,7 @@ describe("the puppeteer backend", () => {
     let launches = 0;
     const fake = fakeBrowser();
     const backend = puppeteerBackend({
+      modeId: "puppeteer-full-height",
       clueUrl: "http://localhost:8080", unit: "harness-render", clueRevision: "r",
       launch: async () => {
         launches += 1;
@@ -450,6 +478,7 @@ describe("the puppeteer backend", () => {
     (fake.browser as any).close = async () => { throw new Error("Chromium is gone"); };
     let pageServerClosed = 0;
     const backend = puppeteerBackend({
+      modeId: "puppeteer-full-height",
       clueUrl: "http://localhost:8080", unit: "harness-render", clueRevision: "r",
       launch: async () => fake.browser,
       startPageServer: async () => ({
@@ -462,6 +491,26 @@ describe("the puppeteer backend", () => {
     // The failure still surfaces — it is just no longer allowed to skip the other close.
     await expect(backend.close!()).rejects.toThrow(/Chromium is gone/);
     expect(pageServerClosed).toBe(1);
+  });
+
+  it("fails a document CLUE could not load, rather than photographing its error page", async () => {
+    // CLUE renders its own "Error loading the document" page when it cannot deserialize what it was
+    // handed. That page photographs perfectly well — which is the problem. Two committed fixtures
+    // were storing valid PNGs of an error screen as though they were student work, and nothing
+    // said so, because the only diagnostic anyone checked was the *unknown tile* count.
+    const { backend } = makeBackend({ measurement: { documentFailedToLoad: true } });
+    await expect(backend.render({ docId: "unloadable", content: emptyDocument }))
+      .rejects.toThrow(/CLUE could not load this document and showed its error page instead/);
+  });
+
+  it("fails before resizing, so a document that never loaded costs the cheap path", async () => {
+    const { backend, state } = makeBackend({
+      measurement: { documentFailedToLoad: true, contentRowsHeightPx: 4000 }
+    });
+    await expect(backend.render({ docId: "unloadable", content: emptyDocument })).rejects.toThrow();
+    // No resize, and no capture: the frame was never asked to grow.
+    expect(state.frameHeights).toEqual([]);
+    expect(state.screenshots).toBe(0);
   });
 
   it("fails a render whose page breaks during the settle after the resize", async () => {
@@ -497,6 +546,7 @@ describe("the puppeteer backend", () => {
       return page;
     };
     const backend = puppeteerBackend({
+      modeId: "puppeteer-full-height",
       clueUrl: "http://localhost:8080", unit: "harness-render", clueRevision: "r",
       launch: async () => fake.browser, startPageServer: fakePageServer,
       stableForMs: 0, pollIntervalMs: 1
@@ -545,6 +595,7 @@ describe("the puppeteer backend", () => {
       return page;
     };
     const backend = puppeteerBackend({
+      modeId: "puppeteer-full-height",
       clueUrl: "http://localhost:8080", unit: "harness-render", clueRevision: "r",
       launch: async () => fake.browser, startPageServer: fakePageServer,
       stableForMs: 0, pollIntervalMs: 1
@@ -742,9 +793,10 @@ describe("capture limits", () => {
 });
 
 describe("the mode registry", () => {
-  it("knows exactly three modes, defaulting to the local one", () => {
+  it("knows exactly the modes it can build, defaulting to the local full-document one", () => {
     expect([...renderModeIds]).toEqual([
-      "puppeteer-full-height", "shutterbug-production-current", "shutterbug-parameterized"
+      "puppeteer-full-height", "puppeteer-per-tile",
+      "shutterbug-production-current", "shutterbug-parameterized", "shutterbug-accurate-height"
     ]);
     expect(kDefaultRenderModeId).toBe("puppeteer-full-height");
     expect(isRenderModeId("puppeteer-full-height")).toBe(true);
@@ -824,5 +876,71 @@ describe("the mode registry", () => {
     expect(backend.renderTarget).toMatchObject({
       clueUrl: "http://localhost:8080", unit: "qa", captureHeightPx: 3000
     });
+  });
+});
+
+describe("the per-tile capture", () => {
+  const perTile = (options: FakeOptions = {}, overrides: Record<string, unknown> = {}) =>
+    makeBackend(options, { capture: "per-tile", ...overrides });
+
+  const threeTiles = [
+    { tileId: "tile-a", widthPx: 300, heightPx: 200 },
+    { tileId: "tile-b", widthPx: 480, heightPx: 320 },
+    { tileId: "tile-c", widthPx: 120, heightPx: 90 }
+  ];
+
+  it("takes one picture per top-level tile, tagged with the tile it is a picture of", async () => {
+    const { backend } = perTile({ tiles: threeTiles });
+    const outcome = await backend.render({ docId: "three", content: emptyDocument });
+    expect(outcome.images).toHaveLength(3);
+    expect(outcome.images.map((image) => image.tileId)).toEqual(["tile-a", "tile-b", "tile-c"]);
+    for (const image of outcome.images) {
+      expect(image.purpose).toBe("tile");
+      // A tile picture is a local capture, so it carries bytes and no hosted URL.
+      expect(image.url).toBeNull();
+      expect(image.bytes.length).toBeGreaterThan(0);
+    }
+    // Each picture really is that tile's own size, not the page's.
+    expect(outcome.images.map((image) => readPngInfo(image.bytes, "tile").widthPx))
+      .toEqual([300, 480, 120]);
+  });
+
+  it("records a per-tile capture as its own capture mode", () => {
+    // Not "full-document": the set covers the document, but no single image is the document, and a
+    // freshness check comparing targets has to be able to tell the two renders apart.
+    expect(perTile().backend.renderTarget.captureMode).toBe("per-tile");
+    expect(perTile().backend.renderTarget.captureHeightPx).toBeNull();
+    expect(makeBackend().backend.renderTarget.captureMode).toBe("full-document");
+  });
+
+  it("fails a document that drew no tiles rather than writing an empty envelope", async () => {
+    // An envelope with no images is treated as damaged everywhere else, so producing one here would
+    // be indistinguishable from a broken render.
+    const { backend } = perTile({ tiles: [] });
+    await expect(backend.render({ docId: "bare", content: emptyDocument }))
+      .rejects.toThrow(/drew no tiles, so a per-tile capture would produce no images at all/);
+  });
+
+  it("applies every size bound per image rather than to the set", async () => {
+    const { backend } = perTile(
+      { tiles: [{ tileId: "huge", widthPx: 960, heightPx: 30_000 }] },
+      { limits: { maxHeightPx: 20_000, maxPixels: 40_000_000, maxEncodedBytes: 20 * 1024 * 1024 } });
+    await expect(backend.render({ docId: "huge", content: emptyDocument }))
+      .rejects.toThrow(/30000px tall, over the 20000px limit/);
+  });
+
+  it("records a tile with no id as having none, rather than as an empty one", async () => {
+    // An empty string would be matched against the classification and silently find nothing; null
+    // says outright that this picture cannot be traced back to a tile.
+    const { backend } = perTile({ tiles: [{ tileId: "", widthPx: 100, heightPx: 100 }] });
+    const outcome = await backend.render({ docId: "anonymous", content: emptyDocument });
+    expect(outcome.images[0].tileId).toBeNull();
+  });
+
+  it("still reports what it could see, the same as a full-document capture", async () => {
+    const { backend } = perTile({ tiles: threeTiles, measurement: { totalTiles: 3, unknownTiles: 1 } });
+    const outcome = await backend.render({ docId: "three", content: emptyDocument });
+    expect(outcome.diagnostics)
+      .toMatchObject({ totalTiles: 3, unknownTiles: 1, documentText: "drawing-fixture-marker" });
   });
 });

--- a/scripts/ai-harness/test/execute.test.ts
+++ b/scripts/ai-harness/test/execute.test.ts
@@ -156,6 +156,50 @@ describe("resume identity spans the corpus and the experiment", () => {
     });
     expect(second.resumed).toBe(1);
   });
+
+  // The same three cases for skipped rows, which resume on the content they were decided from rather
+  // than on a request key. Their keys were being rebuilt from the *current* corpus and experiment
+  // while the rows above use their own, so a stored skip carried whatever identity the reading run
+  // happened to have — and suppressed a new skip that only looked the same.
+  const skip = (docId: string) => ({
+    docId, runId: "text-default", run: { id: "text-default", message: "text-only", prompt: "p" } as any,
+    modality: "empty" as const, computedModality: "empty" as const, promptName: "p", promptSha256: "h",
+    skipReasons: ["the document has no student content at all"],
+    decidedFromContentSha256: "e".repeat(64)
+  });
+  const skipWith = async (dataRoot: string, overrides: { corpus?: string; experimentSha256?: string }) =>
+    runTasks({
+      corpus: overrides.corpus ?? "synthetic-corpus",
+      experiment: experiment as any,
+      experimentSha256: overrides.experimentSha256 ?? "hash",
+      tasks: [],
+      skipped: [skip("empty")],
+      outputFile: path.join(dataRoot, "results.jsonl"),
+      ledger: new CostLedger(10),
+      cache: new ResponseCache(path.join(dataRoot, "cache"), { read: false, write: false }),
+      pricing: testPricing,
+      runMeta: testRunMeta,
+      createCompletion: async () => { throw new Error("a skip sends nothing"); },
+      sleep: async () => undefined
+    });
+
+  it.each([
+    ["a different corpus", { corpus: "corpus-b" }],
+    ["a different experiment definition", { experimentSha256: "after-edit" }]
+  ])("does not resume a skipped row written for %s", async (_what, overrides) => {
+    const dataRoot = makeTestDataRoot(`resume-skip-${JSON.stringify(overrides).length}`);
+    const first = await skipWith(dataRoot, {});
+    expect(first.skipped).toBe(1);
+    const second = await skipWith(dataRoot, overrides);
+    expect({ resumed: second.resumed, written: second.skipped }).toEqual({ resumed: 0, written: 1 });
+  });
+
+  it("still resumes a skipped row when corpus and experiment both match", async () => {
+    const dataRoot = makeTestDataRoot("resume-skip-same");
+    await skipWith(dataRoot, {});
+    const second = await skipWith(dataRoot, {});
+    expect({ resumed: second.resumed, written: second.skipped }).toEqual({ resumed: 1, written: 0 });
+  });
 });
 
 describe("a dispatched request that fails is not treated as free", () => {

--- a/scripts/ai-harness/test/experiments.test.ts
+++ b/scripts/ai-harness/test/experiments.test.ts
@@ -141,25 +141,29 @@ describe("the image-token estimate belongs to rows that sent an image", () => {
       },
       sourceContentSha256: "0".repeat(64), imageSha256s: ["a".repeat(64)]
     },
-    prompt: { name: "p", sha256: "s" }, requestKey: "key", runMeta: testRunMeta,
-    status: "skipped", requestKey2: undefined, skipReasons: []
+    prompt: { name: "p", sha256: "s" }, runMeta: testRunMeta,
+    // A row that really did send a request: the rule under test is about those, and a skipped row
+    // carries no representation for it to apply to.
+    status: "success", requestKey: "key", response: { parsed: {}, raw: {} },
+    usage: { promptTokens: 37_000, completionTokens: 40, source: "api" },
+    cost: { modeledUsd: 0.001, incurredThisRunUsd: 0.001 },
+    responseOriginMeta: { date: "d", modelReturned: null, systemFingerprint: null }
   };
 
   it("accepts an image row that carries one", () => {
-    const row = validateResultRow(
-      { ...base, requestKey: null, promptImageTokensEstimated: 36_835 }, "results.jsonl");
+    const row = validateResultRow({ ...base, promptImageTokensEstimated: 36_835 }, "results.jsonl");
+    if (row.status === "skipped") throw new Error("expected a row that sent a request");
     expect(row.promptImageTokensEstimated).toBe(36_835);
   });
 
   it("refuses an image row with no estimate", () => {
-    expect(() => validateResultRow({ ...base, requestKey: null }, "results.jsonl"))
+    expect(() => validateResultRow({ ...base }, "results.jsonl"))
       .toThrow(/promptImageTokensEstimated must be set on a row whose representation is "image"/);
   });
 
   it.each([-5, Number.NaN])("refuses a nonsensical estimate (%p)", (value) => {
     // Reports sum this field, so a negative would quietly subtract from the image-token total.
-    expect(() => validateResultRow(
-      { ...base, requestKey: null, promptImageTokensEstimated: value }, "results.jsonl"))
+    expect(() => validateResultRow({ ...base, promptImageTokensEstimated: value }, "results.jsonl"))
       .toThrow(/promptImageTokensEstimated must (not be negative|be a finite number)/);
   });
 
@@ -167,7 +171,6 @@ describe("the image-token estimate belongs to rows that sent an image", () => {
     // A number in the report's image column that belongs to nothing.
     expect(() => validateResultRow({
       ...base,
-      requestKey: null,
       representation: {
         kind: "text", variantId: "default", variantVersion: 1, sourceContentSha256: "0".repeat(64)
       },

--- a/scripts/ai-harness/test/extras.test.ts
+++ b/scripts/ai-harness/test/extras.test.ts
@@ -1,7 +1,10 @@
 import fs from "node:fs";
 import path from "node:path";
 import { main } from "../harness.js";
-import { buildTasks, kDefaultModel, mixedSendsText, relatedSummariesFor, skipReasonsFor } from "../src/execute.js";
+import {
+  buildTasks, kDefaultModel, mixedSendsText, relatedSummariesFor, skipReasonsFor,
+  variantFindsStudentContentIn
+} from "../src/execute.js";
 import { classifyDocument } from "../src/capability.js";
 import { corpusPaths } from "../src/corpus.js";
 import { loadPricingConfig, pricingFor } from "../src/cost.js";
@@ -103,12 +106,54 @@ describe("which documents a run declines to send", () => {
     expect(skipReasonsFor("mixed", visualOnly)).toEqual([]);
   });
 
+  it("does not skip when the variant finds student content the classifier cannot see", () => {
+    // The classifier asks whether a tile holds text a student wrote. A variant that turns something
+    // else into words -- geometry, for `drawing-text` -- answers a different question, and the
+    // document it exists for is exactly the one the classifier calls empty of text.
+    expect(skipReasonsFor("text-only", visualOnly, undefined, true)).toEqual([]);
+    // Only that branch is overridden: a document with no tiles at all has nothing for any variant
+    // to describe, and still skips.
+    expect(skipReasonsFor("text-only", empty, undefined, true)[0])
+      .toMatch(/no student content at all/);
+  });
+
   it("tells a mixed run when to drop its text half rather than skip the document", () => {
     // The picture still has something to say, so the request goes and the row records the omission.
     expect(mixedSendsText(withText)).toBe(true);
     expect(mixedSendsText(visualOnly)).toBe(false);
   });
+});
 
+describe("which variants find student content the classifier does not", () => {
+  const drawingWith = (objects: unknown[]) => ({
+    rowOrder: ["r"], rowMap: { r: { tiles: [{ tileId: "d" }] } },
+    tileMap: { d: { content: { type: "Drawing", objects } } }
+  });
+  const textRun = (textVariant: string) =>
+    ({ id: "r", message: "text-only", textVariant, prompt: "p" } as any);
+
+  it("drawing-text counts a drawing with shapes, which carries no text at all", () => {
+    expect(variantFindsStudentContentIn(textRun("drawing-text"),
+      drawingWith([{ type: "rectangle", x: 10, y: 10, width: 120, height: 60 }]))).toBe(true);
+  });
+
+  it("but not an empty drawing, whose summary would say only that it is empty", () => {
+    expect(variantFindsStudentContentIn(textRun("drawing-text"), drawingWith([]))).toBe(false);
+  });
+
+  it("and no pass-through variant claims to find anything", () => {
+    for (const variantId of ["default", "minimal", "no-dataset-tables"]) {
+      expect({ variantId, finds: variantFindsStudentContentIn(textRun(variantId),
+        drawingWith([{ type: "rectangle" }])) }).toEqual({ variantId, finds: false });
+    }
+  });
+
+  it("and a run that sends no text is never asked", () => {
+    // `textVariant` is absent on an image-only run, so consulting a variant here would have to
+    // invent one.
+    expect(variantFindsStudentContentIn({ id: "r", message: "image-only", prompt: "p" } as any,
+      drawingWith([{ type: "rectangle" }]))).toBe(false);
+  });
 });
 
 describe("the extras dimension against a real corpus", () => {
@@ -172,7 +217,7 @@ describe("the extras dimension against a real corpus", () => {
   });
 
   it("sends the document its own summary back, twice, for extras-production-current", () => {
-    // What production does today (spike finding 6a). The summary the request is already carrying
+    // What production does today (CLUE-630). The summary the request is already carrying
     // comes back as though two other students had written it.
     const task = tasksFor("extras-production-current").find((entry) => entry.docId === "text")!;
     const messages = task.makeRequest().apiRequest.messages;

--- a/scripts/ai-harness/test/extras.test.ts
+++ b/scripts/ai-harness/test/extras.test.ts
@@ -1,0 +1,240 @@
+import fs from "node:fs";
+import path from "node:path";
+import { main } from "../harness.js";
+import { buildTasks, kDefaultModel, mixedSendsText, relatedSummariesFor, skipReasonsFor } from "../src/execute.js";
+import { classifyDocument } from "../src/capability.js";
+import { corpusPaths } from "../src/corpus.js";
+import { loadPricingConfig, pricingFor } from "../src/cost.js";
+import { harnessRoot } from "../src/files.js";
+import type { ExperimentFile, ExperimentRun, ManifestDocument } from "../src/schemas.js";
+import { makeTestDataRoot } from "./helpers.js";
+
+/**
+ * The extras dimension and the skip rules, which are the two decisions `buildTasks` makes about a
+ * document before it builds anything.
+ */
+const agreements = { yes: [{ content: "Agreed.", tags: [] }] } as never;
+
+const document = (relatedSummaries: unknown[]): ManifestDocument => ({
+  id: "drawing",
+  expectedRenderFailure: null,
+  file: "documents/drawing.json",
+  source: "synthetic",
+  contentSha256: "0".repeat(64),
+  computedModality: "mixed",
+  retrievedAt: null,
+  relatedSummaries
+} as unknown as ManifestDocument);
+
+const run = (extras?: ExperimentRun["extras"]): ExperimentRun => ({
+  id: "r", message: "text-only", textVariant: "default", prompt: "p", ...(extras ? { extras } : {})
+});
+
+describe("what a run puts in the related-summary parts", () => {
+  const entries = [
+    { summary: "The first related document.", agreements },
+    { summary: "The second related document.", agreements }
+  ];
+  const markdown = "# This document\n\nThe student drew a box.";
+
+  it("sends the manifest entries unchanged by default", () => {
+    // `extras-fixed` is the default because it is what the harness has always done, so an
+    // experiment file written before this dimension existed keeps its meaning and its request key.
+    expect(relatedSummariesFor(run(), document(entries), markdown)).toEqual(entries);
+    expect(relatedSummariesFor(run("extras-fixed"), document(entries), markdown)).toEqual(entries);
+  });
+
+  it("sends nothing for no-extras", () => {
+    expect(relatedSummariesFor(run("no-extras"), document(entries), markdown)).toEqual([]);
+  });
+
+  it("reproduces production's bug for extras-production-current", () => {
+    // Production's findRelatedSummaries hands every related entry the *analyzed* document's own
+    // summary, so the model sees the same text several times over and is told other people agreed
+    // with it. Reproduced on purpose, as a named baseline to measure the fix against.
+    const produced = relatedSummariesFor(run("extras-production-current"), document(entries), markdown);
+    expect(produced).toHaveLength(2);
+    for (const entry of produced) expect(entry.summary).toBe(markdown);
+    // The agreements are untouched — only the summary is wrong in production, and copying the bug
+    // faithfully is the whole point.
+    expect(produced.map((entry) => entry.agreements)).toEqual(entries.map((entry) => entry.agreements));
+  });
+
+  it("has nothing to send when the document has no related summaries", () => {
+    for (const extras of ["extras-fixed", "extras-production-current", "no-extras"] as const) {
+      expect(relatedSummariesFor(run(extras), document([]), markdown)).toEqual([]);
+    }
+  });
+});
+
+describe("which documents a run declines to send", () => {
+  const withText = classifyDocument({
+    rowOrder: ["r1"],
+    rowMap: { r1: { tiles: [{ tileId: "t1" }] } },
+    tileMap: { t1: { content: { type: "Text", format: "html", text: "The student wrote this." } } }
+  });
+  const visualOnly = classifyDocument({
+    rowOrder: ["r1"],
+    rowMap: { r1: { tiles: [{ tileId: "t1" }] } },
+    tileMap: { t1: { content: { type: "Geometry" } } }
+  });
+  const empty = classifyDocument({ rowOrder: [], rowMap: {}, tileMap: {} });
+
+  it("sends a document that carries student text to every shape", () => {
+    for (const message of ["text-only", "image-only", "mixed"] as const) {
+      expect(skipReasonsFor(message, withText)).toEqual([]);
+    }
+  });
+
+  it("skips an empty document for every shape, saying it has no content at all", () => {
+    for (const message of ["text-only", "image-only", "mixed"] as const) {
+      const reasons = skipReasonsFor(message, empty);
+      expect(reasons).toHaveLength(1);
+      expect(reasons[0]).toContain("no student content at all");
+      expect(reasons[0]).toContain(message);
+    }
+  });
+
+  it("skips a visual-only document for a text-only run, and sends it to the others", () => {
+    // The summary would carry no student content, which is the thing a text-only run measures.
+    expect(skipReasonsFor("text-only", visualOnly)[0])
+      .toMatch(/no tile carries student-authored text/);
+    expect(skipReasonsFor("image-only", visualOnly)).toEqual([]);
+    expect(skipReasonsFor("mixed", visualOnly)).toEqual([]);
+  });
+
+  it("tells a mixed run when to drop its text half rather than skip the document", () => {
+    // The picture still has something to say, so the request goes and the row records the omission.
+    expect(mixedSendsText(withText)).toBe(true);
+    expect(mixedSendsText(visualOnly)).toBe(false);
+  });
+
+});
+
+describe("the extras dimension against a real corpus", () => {
+  // The committed fixtures carry no `relatedSummaries` — the manifest is generated by `import`, so
+  // there is nowhere in `examples/` to put them. They are injected into the manifest here instead,
+  // which is also how a human would add them: `import` merges hand-edited entries forward across
+  // re-imports. Recorded in the README's corpus section.
+  const dataRoot = makeTestDataRoot("extras-corpus");
+  const paths = corpusPaths(dataRoot, "extras-corpus");
+  const related = [
+    { summary: "A different student's document.", agreements: { yes: [{ content: "Agreed.", tags: [] }] } },
+    { summary: "Another student's document.", agreements: {} }
+  ];
+
+  const tasksFor = (extras?: ExperimentRun["extras"]) => buildTasks({
+    corpusPaths: paths,
+    experiment: {
+      schemaVersion: 1,
+      name: "extras-check",
+      runs: [{
+        id: "text", message: "text-only", textVariant: "default",
+        prompt: "categorize-design-default", ...(extras ? { extras } : {})
+      }]
+    } as ExperimentFile,
+    promptsDir: path.join(harnessRoot, "prompts"),
+    pricing: pricingFor(loadPricingConfig(), kDefaultModel)
+  }).tasks;
+
+  /** The related-summary parts of a task's built message, in order. */
+  const relatedParts = (task: { makeRequest: () => { apiRequest: { messages: unknown[] } } }) =>
+    ((task.makeRequest().apiRequest.messages[1] as any).content as any[])
+      .filter((part) => part.type === "text" &&
+        part.text.startsWith("This is AI generated summary of a similar document:"))
+      .map((part) => part.text);
+
+  beforeAll(async () => {
+    const log = () => undefined;
+    await main(["import", "--from", "examples/synthetic-corpus", "--corpus", "extras-corpus"],
+      { dataRoot, log });
+    await main(["represent", "--corpus", "extras-corpus", "--variants", "default"], { dataRoot, log });
+    // Hand-edited, the way a human would add them.
+    const manifest = JSON.parse(fs.readFileSync(paths.manifest, "utf8"));
+    for (const entry of manifest.documents) {
+      if (entry.id === "text" || entry.id === "table") entry.relatedSummaries = related;
+    }
+    fs.writeFileSync(paths.manifest, JSON.stringify(manifest, null, 2));
+  });
+
+  it("sends the related documents' own summaries by default", () => {
+    const task = tasksFor().find((entry) => entry.docId === "text")!;
+    const parts = relatedParts(task);
+    expect(parts).toHaveLength(2);
+    expect(parts[0]).toContain("A different student's document.");
+    expect(parts[1]).toContain("Another student's document.");
+    // The agreement counts ride along, which is what makes the extras worth sending at all.
+    expect(parts[0]).toContain("yes: 1");
+  });
+
+  it("sends none at all for no-extras", () => {
+    expect(relatedParts(tasksFor("no-extras").find((entry) => entry.docId === "text")!)).toEqual([]);
+  });
+
+  it("sends the document its own summary back, twice, for extras-production-current", () => {
+    // What production does today (spike finding 6a). The summary the request is already carrying
+    // comes back as though two other students had written it.
+    const task = tasksFor("extras-production-current").find((entry) => entry.docId === "text")!;
+    const messages = task.makeRequest().apiRequest.messages;
+    const own = ((messages[1] as any).content as any[])
+      .find((part) => part.text?.startsWith("This is the AI generated summary:")).text
+      .replace("This is the AI generated summary:\n", "");
+    const parts = relatedParts(task);
+    expect(parts).toHaveLength(2);
+    for (const part of parts) expect(part).toContain(own);
+    expect(parts[0]).toContain("yes: 1");
+  });
+
+  it("gives each setting a different request key, so they are separate measurements", () => {
+    const keyFor = (extras?: ExperimentRun["extras"]) =>
+      tasksFor(extras).find((entry) => entry.docId === "text")!.requestKey;
+    const keys = [keyFor(), keyFor("no-extras"), keyFor("extras-production-current")];
+    expect(new Set(keys).size).toBe(3);
+    // And the default really is what an experiment file written before this dimension existed got.
+    expect(keyFor("extras-fixed")).toBe(keyFor());
+  });
+
+  it("changes nothing for a document with no related summaries", () => {
+    const keyFor = (extras?: ExperimentRun["extras"]) =>
+      tasksFor(extras).find((entry) => entry.docId === "question")!.requestKey;
+    expect(new Set([keyFor(), keyFor("no-extras"), keyFor("extras-production-current")]).size).toBe(1);
+  });
+});
+
+describe("a document the corpus says cannot be rendered", () => {
+  const classification = classifyDocument({
+    rowOrder: ["r1"],
+    rowMap: { r1: { tiles: [{ tileId: "t1" }] } },
+    tileMap: { t1: { content: { type: "Geometry" } } }
+  });
+  const unrenderable = {
+    ...document([]),
+    expectedRenderFailure: "the ErrorTest tile throws during render on purpose"
+  } as ManifestDocument;
+
+  it("is skipped by an image-carrying run, with the reason the corpus gave", () => {
+    // Not a hard error about a missing render: that is what a document somebody simply forgot to
+    // render gets, and the two must stay distinguishable.
+    for (const message of ["image-only", "mixed"] as const) {
+      const reasons = skipReasonsFor(message, classification, unrenderable);
+      expect(reasons).toHaveLength(1);
+      expect(reasons[0]).toContain("cannot be rendered");
+      expect(reasons[0]).toContain("throws during render on purpose");
+    }
+  });
+
+  it("is still sent to a text-only run, which needs no picture", () => {
+    // The summary comes from the document's JSON and never opens a browser, so an unrenderable
+    // document measures perfectly well as text.
+    const withText = classifyDocument({
+      rowOrder: ["r1"],
+      rowMap: { r1: { tiles: [{ tileId: "t1" }] } },
+      tileMap: { t1: { content: { type: "Text", format: "html", text: "Student wrote this." } } }
+    });
+    expect(skipReasonsFor("text-only", withText, unrenderable)).toEqual([]);
+  });
+
+  it("changes nothing for a document with no such marker", () => {
+    expect(skipReasonsFor("image-only", classification, document([]))).toEqual([]);
+  });
+});

--- a/scripts/ai-harness/test/files.test.ts
+++ b/scripts/ai-harness/test/files.test.ts
@@ -43,7 +43,7 @@ describe("writing a file atomically", () => {
   });
 
   it("gives every write its own temporary name", () => {
-    // The name used to be `<file>.<pid>.tmp`, which is not unique within a process: two concurrent
+    // A name built from the process id alone is not unique within that process: two concurrent
     // writes to one path would share it, and each would rename the other's half-written bytes into
     // place.
     const file = path.join(dataRoot, "unique", "value.json");

--- a/scripts/ai-harness/test/fixtures.test.ts
+++ b/scripts/ai-harness/test/fixtures.test.ts
@@ -98,3 +98,67 @@ describe.each(docIds)("fixture %s", (docId) => {
     expect(textVariants.minimal.render(content).length).toBeGreaterThan(0);
   });
 });
+
+describe("the no-dataset-tables variant", () => {
+  // The table fixture is the one with a data set behind it, so it is the one this variant changes.
+  const tableContent = JSON.parse(fs.readFileSync(
+    path.join(harnessRoot, "examples", "synthetic-corpus", "documents", "table.json"), "utf8"));
+
+  it("keeps the data set's shape and drops its rows", () => {
+    const full = textVariants.default.render(tableContent);
+    const schemaOnly = textVariants["no-dataset-tables"].render(tableContent);
+    expect(full).toContain("shown below in a Markdown table");
+    expect(schemaOnly).not.toContain("shown below in a Markdown table");
+    // The reader still learns what the data set is and how big it is.
+    expect(schemaOnly).toContain("Data Sets");
+    expect(schemaOnly).toMatch(/There are \d+ cases? in this data set\./);
+    expect(schemaOnly.length).toBeLessThan(full.length);
+  });
+
+  it("leaves a document with no data set exactly as `default` renders it", () => {
+    // The variant is about data sets; for everything else it must not be a second `default` with a
+    // different name, or a comparison between them would measure noise.
+    for (const docId of ["drawing", "text", "empty"]) {
+      const content = JSON.parse(fs.readFileSync(
+        path.join(harnessRoot, "examples", "synthetic-corpus", "documents", `${docId}.json`), "utf8"));
+      const same = textVariants["no-dataset-tables"].render(content) === textVariants.default.render(content);
+      expect({ docId, same }).toEqual({ docId, same: true });
+    }
+  });
+});
+
+describe("the drawing-text variant", () => {
+  const load = (docId: string) => JSON.parse(fs.readFileSync(
+    path.join(harnessRoot, "examples", "synthetic-corpus", "documents", `${docId}.json`), "utf8"));
+
+  it("describes what the student drew, where `default` only says a drawing is there", () => {
+    const summary = textVariants["drawing-text"].render(load("drawing"));
+    expect(textVariants.default.render(load("drawing"))).toContain("This tile contains a drawing.");
+    // The fixture is a rectangle and an ellipse; the variant says so, with their geometry.
+    expect(summary).toContain("2 objects (1 rectangle, 1 ellipse)");
+    expect(summary).toContain("- rectangle at (10, 10), 120×60");
+    expect(summary).toContain("- ellipse at (160, 40), radii 30×20");
+  });
+
+  it("carries a drawing's text objects, which the default summary loses entirely", () => {
+    // The `mixed` fixture has a Drawing holding a text object. A text-only run against `default`
+    // never sees those words at all.
+    const summary = textVariants["drawing-text"].render(load("mixed"));
+    const fallback = textVariants.default.render(load("mixed"));
+    const drawnText = JSON.parse(fs.readFileSync(
+      path.join(harnessRoot, "examples", "synthetic-corpus", "documents", "mixed.json"), "utf8"))
+      .tileMap["mixed-drawing-tile"].content.objects.find((object: any) => object.type === "text").text;
+    expect(summary).toContain(drawnText);
+    expect(fallback).not.toContain(drawnText);
+  });
+
+  it("leaves every other tile type exactly as `default` renders it", () => {
+    // The variant swaps one handler. If it changed anything else, a comparison against `default`
+    // would measure the difference between two summarizers rather than between two drawing
+    // serializers.
+    for (const docId of ["text", "table", "geometry", "empty"]) {
+      const same = textVariants["drawing-text"].render(load(docId)) === textVariants.default.render(load(docId));
+      expect({ docId, same }).toEqual({ docId, same: true });
+    }
+  });
+});

--- a/scripts/ai-harness/test/fixtures.test.ts
+++ b/scripts/ai-harness/test/fixtures.test.ts
@@ -32,8 +32,8 @@ describe("the committed synthetic corpus", () => {
   it("covers every registered tile type, plus a mixed and an empty document", () => {
     const covered = new Set(Object.values(expectations.documents).flatMap((entry) => entry.tileTypes));
     // "Unknown" is deliberately not in `covered`: it is the registration for a type this build does
-    // not know, so the fixture standing in for it declares a made-up type instead. Asserting that is
-    // what the old `covered.add("Unknown")` gave away — adding the string made this unfailable.
+    // not know, so the fixture standing in for it declares a made-up type instead. It is skipped below
+    // rather than added to `covered`, which would satisfy the assertion by writing the answer into it.
     for (const tileType of tileTypes) {
       if (tileType === "Unknown") continue;
       expect([...covered]).toContain(tileType);

--- a/scripts/ai-harness/test/helpers.ts
+++ b/scripts/ai-harness/test/helpers.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import zlib from "node:zlib";
 import { harnessRoot } from "../src/corpus.js";
+import { classifyDocument } from "../src/capability.js";
 import type { RunTask } from "../src/execute.js";
 import { HarnessRequest, InputImageAccounting, requestKeyFor } from "../src/messages.js";
 import { kRetries } from "../src/cost.js";
@@ -164,6 +165,9 @@ export function makeTask(docId: string, runId: string, text: string, worstCase =
       kind: "text", variantId: "default", variantVersion: 1, sourceContentSha256: "0".repeat(64)
     },
     imageTokensEstimated: 0,
+    imageCount: 0,
+    textPartOmitted: false,
+    representationWarnings: [],
     hostedImages: []
   };
 }
@@ -206,4 +210,46 @@ export const testRunsRoot = path.join(harnessRoot, "data", "test-runs");
 
 export function readLines(file: string): unknown[] {
   return fs.readFileSync(file, "utf8").split("\n").filter((line) => line.length > 0).map((line) => JSON.parse(line));
+}
+
+/**
+ * How the committed synthetic corpus classifies, so tests can derive counts rather than pin them.
+ *
+ * Skip-empty makes "runs × documents" wrong as a call count: a text-only run sends only the
+ * documents that carry student-authored text, and no shape sends an empty one. Adding a fixture
+ * should move these numbers without editing an assertion.
+ */
+export function syntheticCorpusShape(): {
+  documents: string[];
+  withStudentText: string[];
+  empty: string[];
+  /** Documents the corpus says cannot be rendered, so no image-carrying run can send them. */
+  unrenderable: string[];
+  /** Documents an image-carrying run sends: everything with content that can be rendered. */
+  withContent: string[];
+} {
+  const corpus = path.join(harnessRoot, "examples", "synthetic-corpus");
+  const expectations = JSON.parse(fs.readFileSync(path.join(corpus, "expectations.json"), "utf8"));
+  const unrenderable = Object.entries(expectations.documents as Record<string, any>)
+    .filter(([, entry]) => entry.expectedRenderFailure !== undefined)
+    .map(([docId]) => docId);
+  const directory = path.join(corpus, "documents");
+  const documents: string[] = [];
+  const withStudentText: string[] = [];
+  const empty: string[] = [];
+  for (const name of fs.readdirSync(directory).filter((file) => file.endsWith(".json")).sort()) {
+    const docId = name.replace(/\.json$/, "");
+    documents.push(docId);
+    const classification = classifyDocument(JSON.parse(fs.readFileSync(path.join(directory, name), "utf8")));
+    if (classification.tiles.some((tile) => tile.hasStudentText)) withStudentText.push(docId);
+    if (classification.computedModality === "empty") empty.push(docId);
+  }
+  return {
+    documents,
+    withStudentText,
+    empty,
+    unrenderable,
+    withContent: documents.filter((docId) =>
+      !empty.includes(docId) && !unrenderable.includes(docId))
+  };
 }

--- a/scripts/ai-harness/test/hosted-images.test.ts
+++ b/scripts/ai-harness/test/hosted-images.test.ts
@@ -15,8 +15,7 @@ function hostedTask(docId: string, url: string, sha256 = kSha): RunTask {
     model: "gpt-4o-mini",
     aiPrompt: defaultAiPrompt,
     message: "image-only",
-    imageUrl: url,
-    accounting: { sha256, widthPx: 960, heightPx: 1420 },
+    images: [{ imageUrl: url, accounting: { sha256, widthPx: 960, heightPx: 1420 } }],
     generationSettings: { max_completion_tokens: 1024 }
   });
   return {
@@ -51,6 +50,9 @@ function hostedTask(docId: string, url: string, sha256 = kSha): RunTask {
       imageSha256s: [sha256]
     },
     imageTokensEstimated: 36_835,
+    imageCount: 1,
+    textPartOmitted: false,
+    representationWarnings: [],
     hostedImages: [{ url, sha256 }]
   };
 }

--- a/scripts/ai-harness/test/image-cost.test.ts
+++ b/scripts/ai-harness/test/image-cost.test.ts
@@ -133,8 +133,7 @@ describe("accounting data never leaves the process", () => {
     model: "gpt-4o-mini",
     aiPrompt: defaultAiPrompt,
     message: "image-only",
-    imageUrl: dataUrlFor(bytes),
-    accounting: { sha256: "b".repeat(64), widthPx: 20, heightPx: 30 },
+    images: [{ imageUrl: dataUrlFor(bytes), accounting: { sha256: "b".repeat(64), widthPx: 20, heightPx: 30 } }],
     generationSettings: { max_completion_tokens: 1024 }
   });
 

--- a/scripts/ai-harness/test/image-messages.test.ts
+++ b/scripts/ai-harness/test/image-messages.test.ts
@@ -1,7 +1,11 @@
 import { estimateInputTokens } from "../src/cost.js";
-import { buildImageRequest, buildRequest, detailOfSingleImage, requestKeyFor } from "../src/messages.js";
+import {
+  buildImageRequest, buildMixedRequest, buildRequest, detailsOfImages, requestKeyFor
+} from "../src/messages.js";
 import { dataUrlFor } from "../src/represent-image.js";
-import { buildImageMessages, defaultAiPrompt } from "../../../shared/ai-analysis-messages.js";
+import {
+  buildImageMessages, buildMixedMessages, defaultAiPrompt
+} from "../../../shared/ai-analysis-messages.js";
 import { makeImageRequest, makeTestPng, testPricing } from "./helpers.js";
 
 const bytes = makeTestPng(960, 1420);
@@ -13,8 +17,7 @@ function build(imageUrl: string, overrides: Partial<Parameters<typeof buildImage
     model: "gpt-4o-mini",
     aiPrompt: defaultAiPrompt,
     message: "image-only",
-    imageUrl,
-    accounting,
+    images: [{ imageUrl, accounting }],
     generationSettings: { max_completion_tokens: 1024 },
     ...overrides
   });
@@ -96,7 +99,8 @@ describe("what changes an image request's identity", () => {
   it("two documents with different pixels get different keys", () => {
     const other = { ...accounting, sha256: "e".repeat(64) };
     expect(requestKeyFor(build("https://x.test/a.png")))
-      .not.toBe(requestKeyFor(build("https://x.test/a.png", { accounting: other })));
+      .not.toBe(requestKeyFor(build("https://x.test/a.png",
+        { images: [{ imageUrl: "https://x.test/a.png", accounting: other }] })));
   });
 
   it("the same pixels served from two URLs get different keys", () => {
@@ -115,8 +119,9 @@ describe("a detail that disagrees with what is sent cannot be built", () => {
     // the flat rate and under-reserve by an order of magnitude. The type says `detail` does not
     // belong here, but TypeScript only enforces that on a fresh object literal — a spread or a named
     // const carries it through — so it is refused at runtime too.
-    expect(() => build("https://x.test/a.png", { accounting: { ...accounting, detail: "low" } as never }))
-      .toThrow(/derives `detail` from the message it builds/);
+    expect(() => build("https://x.test/a.png", {
+      images: [{ imageUrl: "https://x.test/a.png", accounting: { ...accounting, detail: "low" } as never }]
+    })).toThrow(/Image accounting describes the file, not the request/);
   });
 
   it("still catches a mismatch in a request assembled some other way", () => {
@@ -129,29 +134,148 @@ describe("a detail that disagrees with what is sent cannot be built", () => {
       .toThrow(/sent with detail "auto" but accounted for as "low"/);
   });
 
-  it("refuses a message list the shared builder would never produce", () => {
-    // Two image parts, or none, means the builder's contract changed underneath us. Guessing at the
-    // right number to reserve for is the one thing that must not happen.
-    expect(() => detailOfSingleImage([])).toThrow(/exactly one image part, got 0/);
-    expect(() => detailOfSingleImage([{
+  it("reads back a detail per image part, in the order they are sent", () => {
+    expect(detailsOfImages([])).toEqual([]);
+    expect(detailsOfImages([{
       role: "user",
       content: [
-        { type: "image_url", image_url: { url: "https://x.test/a.png" } },
-        { type: "image_url", image_url: { url: "https://x.test/b.png" } }
+        { type: "image_url", image_url: { url: "https://x.test/a.png", detail: "high" } },
+        { type: "image_url", image_url: { url: "https://x.test/b.png", detail: "low" } }
       ]
-    }] as never)).toThrow(/exactly one image part, got 2/);
+    }] as never)).toEqual(["high", "low"]);
+  });
+
+  it("pairs each image's file facts with the detail sent at the same position", () => {
+    // The pairing is positional, so a two-image request must not attribute the first file's pixels
+    // to the second part. This is what the cost model reserves from.
+    const first = { ...accounting, sha256: "1".repeat(64) };
+    const second = { ...accounting, sha256: "2".repeat(64), widthPx: 480, heightPx: 700 };
+    const request = build("unused", {
+      images: [
+        { imageUrl: "https://x.test/a.png", accounting: first },
+        { imageUrl: "https://x.test/b.png", accounting: second }
+      ],
+      detail: "high"
+    });
+    expect(request.inputAccounting.images).toEqual([
+      { ...first, detail: "high" },
+      { ...second, detail: "high" }
+    ]);
+    const content = request.apiRequest.messages[1].content as any[];
+    expect(content.slice(1).map((part: any) => part.image_url.url))
+      .toEqual(["https://x.test/a.png", "https://x.test/b.png"]);
+  });
+
+  it("refuses an image request with no image at all", () => {
+    expect(() => build("unused", { images: [] })).toThrow(/needs at least one image/);
   });
 
   it("treats an absent detail as the provider's own default", () => {
     // `auto` is both the provider's default and the conservative branch of the cost model.
-    expect(detailOfSingleImage([{
+    expect(detailsOfImages([{
       role: "user", content: [{ type: "image_url", image_url: { url: "https://x.test/a.png" } }]
-    }] as never)).toBe("auto");
+    }] as never)).toEqual(["auto"]);
   });
 
   it("refuses a detail it does not recognise", () => {
-    expect(() => detailOfSingleImage([{
+    expect(() => detailsOfImages([{
       role: "user", content: [{ type: "image_url", image_url: { url: "https://x.test/a.png", detail: "ultra" } }]
     }] as never)).toThrow(/unrecognised detail "ultra"/);
+  });
+});
+
+describe("mixed requests are built by the shared production builder", () => {
+  const related = [{
+    summary: "A related document's summary.",
+    agreements: { yes: [{ content: "Agreed.", tags: [] }] } as never
+  }];
+
+  const buildMixed = (overrides: Partial<Parameters<typeof buildMixedRequest>[0]> = {}) =>
+    buildMixedRequest({
+      model: "gpt-4o-mini",
+      aiPrompt: defaultAiPrompt,
+      message: "mixed",
+      markdown: "The student drew a box.",
+      relatedSummaries: related,
+      images: [{ imageUrl: "https://x.test/doc.png", accounting }],
+      generationSettings: { max_completion_tokens: 1024 },
+      ...overrides
+    });
+
+  it("produces exactly what buildMixedMessages produces, unmodified", () => {
+    // The parity rule, for the third shape: a representation can never win by being formatted
+    // differently from the one it is being compared against.
+    expect(buildMixed().apiRequest.messages).toEqual(buildMixedMessages(
+      defaultAiPrompt, "The student drew a box.", related, [{ url: "https://x.test/doc.png" }], {}));
+  });
+
+  it("is the text-only message with the picture appended", () => {
+    // Read against `buildRequest` rather than a literal, so the two shapes cannot drift apart
+    // without this failing.
+    const textOnly = buildRequest({
+      model: "gpt-4o-mini",
+      aiPrompt: defaultAiPrompt,
+      message: "text-only",
+      markdown: "The student drew a box.",
+      relatedSummaries: related,
+      generationSettings: { max_completion_tokens: 1024 }
+    });
+    const textParts = textOnly.apiRequest.messages[1].content as any[];
+    const mixedParts = buildMixed().apiRequest.messages[1].content as any[];
+    expect(mixedParts.slice(0, textParts.length)).toEqual(textParts);
+    expect(mixedParts.slice(textParts.length))
+      .toEqual([{ type: "image_url", image_url: { url: "https://x.test/doc.png", detail: "auto" } }]);
+  });
+
+  it("sends only the pictures when the document has no student text", () => {
+    const content = buildMixed({ markdown: null }).apiRequest.messages[1].content as any[];
+    expect(content.map((part: any) => part.type)).toEqual(["text", "image_url"]);
+    expect(content[0].text).toBe(defaultAiPrompt.mainPrompt);
+  });
+
+  it("accounts for every picture it sends", () => {
+    const second = { ...accounting, sha256: "9".repeat(64) };
+    const request = buildMixed({
+      images: [
+        { imageUrl: "https://x.test/a.png", accounting },
+        { imageUrl: "https://x.test/b.png", accounting: second }
+      ],
+      detail: "low"
+    });
+    expect(request.inputAccounting.images)
+      .toEqual([{ ...accounting, detail: "low" }, { ...second, detail: "low" }]);
+  });
+
+  it("refuses the wrong message shape, and a mixed request with no picture", () => {
+    expect(() => buildMixed({ message: "text-only" }))
+      .toThrow(/builds mixed messages; got message shape "text-only"/);
+    expect(() => buildMixed({ images: [] })).toThrow(/needs at least one image/);
+  });
+});
+
+describe("a run configured the way it was before these dimensions existed keeps its key", () => {
+  // The request key is the cache key and the resume key. New experiment dimensions change the built
+  // messages, so they change the key on their own — but a run that asks for none of them has to
+  // produce the key it always did, or every cache entry and every resumable row silently
+  // invalidates.
+  //
+  // These two values were read off the pre-milestone-3 code (`CLUE-371` at b0ef0a19) by building the
+  // same requests there, so they pin the key against what actually shipped rather than against
+  // whatever this branch happens to produce.
+  it("a text-only request's key does not move", () => {
+    const request = buildRequest({
+      model: "gpt-4o-mini",
+      aiPrompt: defaultAiPrompt,
+      message: "text-only",
+      markdown: "The student drew a box.",
+      generationSettings: { max_completion_tokens: 1024 }
+    });
+    expect(requestKeyFor(request))
+      .toBe("997fbcf6dd3b2481da739b499d5094109a5e66fbf69700d96415e7067585f7af");
+  });
+
+  it("an image-only request's key does not move", () => {
+    expect(requestKeyFor(build("https://images.example.test/shot.png")))
+      .toBe("cf5465f23060eb90c645bd14edb5695404905ffb7c29681562f87a65cafbeb88");
   });
 });

--- a/scripts/ai-harness/test/image-messages.test.ts
+++ b/scripts/ai-harness/test/image-messages.test.ts
@@ -259,9 +259,9 @@ describe("a run configured the way it was before these dimensions existed keeps 
   // produce the key it always did, or every cache entry and every resumable row silently
   // invalidates.
   //
-  // These two values were read off the pre-milestone-3 code (`CLUE-371` at b0ef0a19) by building the
-  // same requests there, so they pin the key against what actually shipped rather than against
-  // whatever this branch happens to produce.
+  // These two values were read off commit b0ef0a19, before this milestone, by building the same
+  // requests there — so they pin the key against what actually shipped rather than against whatever
+  // this branch happens to produce.
   it("a text-only request's key does not move", () => {
     const request = buildRequest({
       model: "gpt-4o-mini",

--- a/scripts/ai-harness/test/local-render.integration.ts
+++ b/scripts/ai-harness/test/local-render.integration.ts
@@ -83,80 +83,85 @@ async function main(): Promise<void> {
     clueRevision: "integration-check"
   });
   const failures: string[] = [];
-
-  await backend.open?.();
+  // Everything from here runs inside this, so the listening socket comes down whatever happens:
+  // a fixture that will not parse, or a browser that will not launch, would otherwise leave it
+  // holding the process open and `npm run test:render` would never return.
   try {
-    for (const fixture of fixtures) {
-      const file = path.join(harnessRoot, "examples", "synthetic-corpus", "documents", `${fixture.docId}.json`);
-      const content = JSON.parse(fs.readFileSync(file, "utf8"));
-      try {
-        const outcome = await backend.render({ docId: fixture.docId, content });
-        const image = outcome.images[0];
-        const info = readPngInfo(image.bytes, fixture.docId);
-        const { totalTiles, unknownTiles } = outcome.diagnostics;
+    try {
+      await backend.open?.();
+      for (const fixture of fixtures) {
+        const file = path.join(harnessRoot, "examples", "synthetic-corpus", "documents", `${fixture.docId}.json`);
+        const content = JSON.parse(fs.readFileSync(file, "utf8"));
+        try {
+          const outcome = await backend.render({ docId: fixture.docId, content });
+          const image = outcome.images[0];
+          const info = readPngInfo(image.bytes, fixture.docId);
+          const { totalTiles, unknownTiles } = outcome.diagnostics;
 
-        const problems: string[] = [];
-        if (info.widthPx > kDefaultViewportWidthPx) {
-          problems.push(`width ${info.widthPx} exceeds the ${kDefaultViewportWidthPx}px viewport`);
-        }
-        if (info.heightPx <= 0) problems.push(`height ${info.heightPx}`);
-        if (fixture.minHeightPx !== undefined && info.heightPx <= fixture.minHeightPx) {
-          problems.push(`height ${info.heightPx} is not past the ${fixture.minHeightPx}px the frame ` +
-            "starts at, so this fixture did not exercise the resize");
-        }
-        if ((totalTiles ?? -1) < fixture.minTiles) {
-          problems.push(`counted ${totalTiles} tiles, expected at least ${fixture.minTiles}`);
-        }
-        if (unknownTiles !== fixture.expectUnknownTiles) {
-          problems.push(`counted ${unknownTiles} unknown tiles, expected ${fixture.expectUnknownTiles}`);
-        }
+          const problems: string[] = [];
+          if (info.widthPx > kDefaultViewportWidthPx) {
+            problems.push(`width ${info.widthPx} exceeds the ${kDefaultViewportWidthPx}px viewport`);
+          }
+          if (info.heightPx <= 0) problems.push(`height ${info.heightPx}`);
+          if (fixture.minHeightPx !== undefined && info.heightPx <= fixture.minHeightPx) {
+            problems.push(`height ${info.heightPx} is not past the ${fixture.minHeightPx}px the frame ` +
+              "starts at, so this fixture did not exercise the resize");
+          }
+          if ((totalTiles ?? -1) < fixture.minTiles) {
+            problems.push(`counted ${totalTiles} tiles, expected at least ${fixture.minTiles}`);
+          }
+          if (unknownTiles !== fixture.expectUnknownTiles) {
+            problems.push(`counted ${unknownTiles} unknown tiles, expected ${fixture.expectUnknownTiles}`);
+          }
 
-        const status = problems.length === 0 ? "ok  " : "FAIL";
-        console.log(`${status} ${fixture.docId.padEnd(10)} ${info.widthPx}×${String(info.heightPx).padEnd(5)} ` +
-          `${String(image.bytes.length).padStart(7)} bytes  tiles=${totalTiles} unknown=${unknownTiles}` +
-          (problems.length ? `\n       ${problems.join("; ")}` : ""));
-        if (problems.length) failures.push(`${fixture.docId}: ${problems.join("; ")}`);
-      } catch (error) {
-        console.log(`FAIL ${fixture.docId.padEnd(10)} ${(error as Error).message}`);
-        failures.push(`${fixture.docId}: ${(error as Error).message}`);
+          const status = problems.length === 0 ? "ok  " : "FAIL";
+          console.log(`${status} ${fixture.docId.padEnd(10)} ${info.widthPx}×${String(info.heightPx).padEnd(5)} ` +
+            `${String(image.bytes.length).padStart(7)} bytes  tiles=${totalTiles} unknown=${unknownTiles}` +
+            (problems.length ? `\n       ${problems.join("; ")}` : ""));
+          if (problems.length) failures.push(`${fixture.docId}: ${problems.join("; ")}`);
+        } catch (error) {
+          console.log(`FAIL ${fixture.docId.padEnd(10)} ${(error as Error).message}`);
+          failures.push(`${fixture.docId}: ${(error as Error).message}`);
+        }
       }
+    } finally {
+      await backend.close?.();
+    }
+
+    const perTile = puppeteerBackend({
+      modeId: "puppeteer-per-tile",
+      clueUrl: kClueUrl,
+      unit: "harness-render",
+      unitUrl: unitServer.unitUrl,
+      clueRevision: "integration-check",
+      capture: "per-tile"
+    });
+    try {
+      await perTile.open?.();
+      for (const fixture of perTileFixtures) {
+        const file = path.join(harnessRoot, "examples", "synthetic-corpus", "documents", `${fixture.docId}.json`);
+        const content = JSON.parse(fs.readFileSync(file, "utf8"));
+        try {
+          const outcome = await perTile.render({ docId: fixture.docId, content });
+          const tileIds = outcome.images.map((image) => image.tileId ?? "?");
+          const problems: string[] = [];
+          if (outcome.images.length !== fixture.expectImages) {
+            problems.push(`captured ${outcome.images.length} tile(s), expected ${fixture.expectImages} ` +
+              `(${tileIds.join(", ")})`);
+          }
+          const status = problems.length === 0 ? "ok  " : "FAIL";
+          console.log(`${status} ${fixture.docId.padEnd(10)} per-tile: ${outcome.images.length} image(s) ` +
+            `[${tileIds.join(", ")}]` + (problems.length ? `\n       ${problems.join("; ")}` : ""));
+          if (problems.length) failures.push(`${fixture.docId} (per-tile): ${problems.join("; ")}`);
+        } catch (error) {
+          console.log(`FAIL ${fixture.docId.padEnd(10)} per-tile: ${(error as Error).message}`);
+          failures.push(`${fixture.docId} (per-tile): ${(error as Error).message}`);
+        }
+      }
+    } finally {
+      await perTile.close?.();
     }
   } finally {
-    await backend.close?.();
-  }
-
-  const perTile = puppeteerBackend({
-    modeId: "puppeteer-per-tile",
-    clueUrl: kClueUrl,
-    unit: "harness-render",
-    unitUrl: unitServer.unitUrl,
-    clueRevision: "integration-check",
-    capture: "per-tile"
-  });
-  await perTile.open?.();
-  try {
-    for (const fixture of perTileFixtures) {
-      const file = path.join(harnessRoot, "examples", "synthetic-corpus", "documents", `${fixture.docId}.json`);
-      const content = JSON.parse(fs.readFileSync(file, "utf8"));
-      try {
-        const outcome = await perTile.render({ docId: fixture.docId, content });
-        const tileIds = outcome.images.map((image) => image.tileId ?? "?");
-        const problems: string[] = [];
-        if (outcome.images.length !== fixture.expectImages) {
-          problems.push(`captured ${outcome.images.length} tile(s), expected ${fixture.expectImages} ` +
-            `(${tileIds.join(", ")})`);
-        }
-        const status = problems.length === 0 ? "ok  " : "FAIL";
-        console.log(`${status} ${fixture.docId.padEnd(10)} per-tile: ${outcome.images.length} image(s) ` +
-          `[${tileIds.join(", ")}]` + (problems.length ? `\n       ${problems.join("; ")}` : ""));
-        if (problems.length) failures.push(`${fixture.docId} (per-tile): ${problems.join("; ")}`);
-      } catch (error) {
-        console.log(`FAIL ${fixture.docId.padEnd(10)} per-tile: ${(error as Error).message}`);
-        failures.push(`${fixture.docId} (per-tile): ${(error as Error).message}`);
-      }
-    }
-  } finally {
-    await perTile.close?.();
     await unitServer.close();
   }
 

--- a/scripts/ai-harness/test/local-render.integration.ts
+++ b/scripts/ai-harness/test/local-render.integration.ts
@@ -16,7 +16,9 @@
 import fs from "node:fs";
 import path from "node:path";
 import { harnessRoot } from "../src/corpus.js";
-import { puppeteerBackend, kDefaultViewportWidthPx } from "../src/backends/puppeteer.js";
+import {
+  kDefaultViewportWidthPx, kInitialFrameHeightPx, puppeteerBackend
+} from "../src/backends/puppeteer.js";
 import { startRenderUnitServer } from "../src/backends/render-unit.js";
 import { readPngInfo } from "../src/png.js";
 
@@ -27,7 +29,9 @@ const kClueUrl = process.env.CLUE_URL ?? "http://localhost:8080";
  * a plain tile, a visual one, two tiles at once, an empty document, and the two fixtures whose
  * unknown-tile status is the point.
  */
-const fixtures: { docId: string; expectUnknownTiles: number; minTiles: number }[] = [
+const fixtures: {
+  docId: string; expectUnknownTiles: number; minTiles: number; minHeightPx?: number;
+}[] = [
   { docId: "drawing", expectUnknownTiles: 0, minTiles: 1 },
   { docId: "table", expectUnknownTiles: 0, minTiles: 1 },
   { docId: "geometry", expectUnknownTiles: 0, minTiles: 1 },
@@ -38,7 +42,28 @@ const fixtures: { docId: string; expectUnknownTiles: number; minTiles: number }[
   { docId: "unknown", expectUnknownTiles: 1, minTiles: 1 },
   // AI is one of the two types the QA unit does not register, and the harness unit adds. If the
   // rendering unit regresses, this is where it shows up.
-  { docId: "ai", expectUnknownTiles: 0, minTiles: 1 }
+  { docId: "ai", expectUnknownTiles: 0, minTiles: 1 },
+  // Taller than the 500px the generated page starts at, so a real browser exercises the frame
+  // resize. Every other fixture is short enough that the resize never fires, which left the one
+  // mechanism that keeps `captureMode: "full-document"` honest covered only by fake browsers.
+  { docId: "tall", expectUnknownTiles: 0, minTiles: 10, minHeightPx: kInitialFrameHeightPx }
+];
+
+/**
+ * Documents rendered a second time, per tile, with the number of pictures they must produce.
+ *
+ * Only a real browser can answer this. The fake in `smoke-image.test.ts` returns a fixed list of
+ * elements whatever selector it is handed, so it has no DOM and cannot represent one tile inside
+ * another — which is exactly the case this checks.
+ *
+ * `question` is the case: one top-level tile in the document's rows, and two more in its tile map
+ * that it draws inside itself. A per-tile capture must produce one picture, not three.
+ */
+const perTileFixtures: { docId: string; expectImages: number }[] = [
+  { docId: "question", expectImages: 1 },
+  // Two top-level tiles, neither nested, so this is the control: the same code path must still
+  // produce one picture each rather than being made blind by the rule above.
+  { docId: "mixed", expectImages: 2 }
 ];
 
 async function main(): Promise<void> {
@@ -51,6 +76,7 @@ async function main(): Promise<void> {
 
   const unitServer = await startRenderUnitServer({ clueUrl: kClueUrl });
   const backend = puppeteerBackend({
+    modeId: "puppeteer-full-height",
     clueUrl: kClueUrl,
     unit: "harness-render",
     unitUrl: unitServer.unitUrl,
@@ -74,6 +100,10 @@ async function main(): Promise<void> {
           problems.push(`width ${info.widthPx} exceeds the ${kDefaultViewportWidthPx}px viewport`);
         }
         if (info.heightPx <= 0) problems.push(`height ${info.heightPx}`);
+        if (fixture.minHeightPx !== undefined && info.heightPx <= fixture.minHeightPx) {
+          problems.push(`height ${info.heightPx} is not past the ${fixture.minHeightPx}px the frame ` +
+            "starts at, so this fixture did not exercise the resize");
+        }
         if ((totalTiles ?? -1) < fixture.minTiles) {
           problems.push(`counted ${totalTiles} tiles, expected at least ${fixture.minTiles}`);
         }
@@ -93,15 +123,53 @@ async function main(): Promise<void> {
     }
   } finally {
     await backend.close?.();
+  }
+
+  const perTile = puppeteerBackend({
+    modeId: "puppeteer-per-tile",
+    clueUrl: kClueUrl,
+    unit: "harness-render",
+    unitUrl: unitServer.unitUrl,
+    clueRevision: "integration-check",
+    capture: "per-tile"
+  });
+  await perTile.open?.();
+  try {
+    for (const fixture of perTileFixtures) {
+      const file = path.join(harnessRoot, "examples", "synthetic-corpus", "documents", `${fixture.docId}.json`);
+      const content = JSON.parse(fs.readFileSync(file, "utf8"));
+      try {
+        const outcome = await perTile.render({ docId: fixture.docId, content });
+        const tileIds = outcome.images.map((image) => image.tileId ?? "?");
+        const problems: string[] = [];
+        if (outcome.images.length !== fixture.expectImages) {
+          problems.push(`captured ${outcome.images.length} tile(s), expected ${fixture.expectImages} ` +
+            `(${tileIds.join(", ")})`);
+        }
+        const status = problems.length === 0 ? "ok  " : "FAIL";
+        console.log(`${status} ${fixture.docId.padEnd(10)} per-tile: ${outcome.images.length} image(s) ` +
+          `[${tileIds.join(", ")}]` + (problems.length ? `\n       ${problems.join("; ")}` : ""));
+        if (problems.length) failures.push(`${fixture.docId} (per-tile): ${problems.join("; ")}`);
+      } catch (error) {
+        console.log(`FAIL ${fixture.docId.padEnd(10)} per-tile: ${(error as Error).message}`);
+        failures.push(`${fixture.docId} (per-tile): ${(error as Error).message}`);
+      }
+    }
+  } finally {
+    await perTile.close?.();
     await unitServer.close();
   }
 
+  // Both passes, or the line understates what ran and a per-tile failure would be reported against
+  // a total that never included it.
+  const checks = fixtures.length + perTileFixtures.length;
   if (failures.length > 0) {
-    console.error(`\n${failures.length} of ${fixtures.length} fixture(s) failed the local render check.`);
+    console.error(`\n${failures.length} of ${checks} check(s) failed the local render check.`);
     process.exitCode = 1;
     return;
   }
-  console.log(`\nAll ${fixtures.length} fixtures rendered against ${kClueUrl}.`);
+  console.log(`\nAll ${checks} checks passed against ${kClueUrl} ` +
+    `(${fixtures.length} full-document, ${perTileFixtures.length} per-tile).`);
 }
 
 // Caught, or a throw becomes an unhandled rejection rather than the message and exit code above.

--- a/scripts/ai-harness/test/modality-override.test.ts
+++ b/scripts/ai-harness/test/modality-override.test.ts
@@ -147,3 +147,100 @@ describe("averages are blank on a row that spans more than one message shape", (
     expect(column(printed, "img tok est")[textIndex]).toBe("-");
   });
 });
+
+describe("a report reads a mixed run the way it reads the two it sits between", () => {
+  const mixedRow = (docId: string, textPartOmitted?: true): ResultRow => ({
+    ...base,
+    docId,
+    runId: "mixed",
+    message: "mixed",
+    modality: "mixed",
+    computedModality: "mixed",
+    representation: {
+      kind: "mixed",
+      text: { variantId: "default", variantVersion: 1, sourceContentSha256: "0".repeat(64) },
+      image: {
+        modeId: "puppeteer-full-height",
+        backendId: "puppeteer",
+        backendVersion: 2,
+        renderTarget: {
+          clueUrl: "http://localhost:8080", unit: "harness-render", clueRevision: "r",
+          shutterbugUrl: null, viewportWidthPx: 960, captureMode: "full-document", captureHeightPx: null
+        },
+        sourceContentSha256: "0".repeat(64),
+        imageSha256s: ["a".repeat(64)],
+        imageSet: "full-document"
+      }
+    },
+    promptImageTokensEstimated: 14_399,
+    usage: { promptTokens: 15_000, completionTokens: 30, source: "api" },
+    requestKey: `key-mixed-${docId}`,
+    ...(textPartOmitted ? { textPartOmitted } : {})
+  });
+
+  const skippedRow = (docId: string): ResultRow => {
+    const { representation, promptImageTokensEstimated, ...rest } = base as never as Record<string, unknown>;
+    return {
+      ...rest,
+      docId,
+      runId: "mixed",
+      message: "mixed",
+      modality: "empty",
+      computedModality: "empty",
+      status: "skipped",
+      requestKey: null,
+      skipReasons: ["mixed run: the document has no student content at all"],
+      decidedFromContentSha256: "0".repeat(64)
+    } as unknown as ResultRow;
+  };
+
+  const printed = () => formatSummaryTable(summarizeResults(
+    [mixedRow("a"), mixedRow("b", true), skippedRow("c")],
+    "results.jsonl", new Date("2026-08-17T00:00:00.000Z")));
+
+  it("gives a mixed run its own group rather than folding it into either baseline", () => {
+    const summary = summarizeResults(
+      [mixedRow("a"), row("d", "text-only", "text-only")],
+      "results.jsonl", new Date("2026-08-17T00:00:00.000Z"));
+    const shapes = new Set(summary.groups.map((group) => group.message));
+    expect(shapes).toEqual(new Set(["mixed", "text-only", "all"]));
+  });
+
+  it("counts the image tokens of a mixed row, the way it does for an image row", () => {
+    const table = printed();
+    const mixedIndex = column(table, "message").indexOf("mixed");
+    expect(column(table, "img tok est")[mixedIndex]).toBe(String(14_399 * 2));
+  });
+
+  it("averages a mixed group, because one shape is one population", () => {
+    // `mixed` is a shape, not a mixture of shapes: the means are comparable and are shown.
+    const table = printed();
+    const mixedIndex = column(table, "message").indexOf("mixed");
+    expect(column(table, "in mean")[mixedIndex]).toBe("15000");
+  });
+
+  it("counts the rows that went without their text half, and blanks the count where none did", () => {
+    const table = printed();
+    const messages = column(table, "message");
+    const noText = column(table, "no text");
+    expect(noText[messages.indexOf("mixed")]).toBe("1");
+    // A group where it never happened reads "-", not 0, so it cannot be mistaken for a measurement.
+    const summary = summarizeResults(
+      [row("d", "text-only", "text-only")], "results.jsonl", new Date("2026-08-17T00:00:00.000Z"));
+    expect(column(formatSummaryTable(summary), "no text").every((cell) => cell === "-")).toBe(true);
+  });
+
+  it("counts a skipped mixed row as skipped, and not as a document that answered", () => {
+    // Read off the run's all-modality row: a skipped document is classified `empty`, so it lands in
+    // a different per-modality group from the ones that answered.
+    const summary = summarizeResults(
+      [mixedRow("a"), mixedRow("b", true), skippedRow("c")],
+      "results.jsonl", new Date("2026-08-17T00:00:00.000Z"));
+    const run = summary.groups.find((group) =>
+      group.runId === "mixed" && group.message === "mixed" && group.modality === "all")!;
+    expect(run.statuses).toMatchObject({ success: 2, skipped: 1, error: 0, refusal: 0 });
+    // Every document is represented, sent or not: that is what makes a skip readable as a decision.
+    expect(run.docs).toBe(3);
+    expect(run.textPartOmitted).toBe(1);
+  });
+});

--- a/scripts/ai-harness/test/paths.test.ts
+++ b/scripts/ai-harness/test/paths.test.ts
@@ -64,7 +64,7 @@ describe("containment survives a symlinked data root", () => {
     fs.symlinkSync(outside, escape);
     try {
       const candidate = path.join(escape, "x.jsonl");
-      // Lexically it looks contained — this is what the old check saw.
+      // Lexically it looks contained, which is all a string comparison can see.
       expect(path.relative(dataRoot, path.resolve(candidate)).startsWith("..")).toBe(false);
       // Resolved through the symlink, it is not.
       expect(isContainedBy(candidate, dataRoot)).toBe(false);

--- a/scripts/ai-harness/test/prompt.test.ts
+++ b/scripts/ai-harness/test/prompt.test.ts
@@ -4,7 +4,37 @@ import { defaultAiPrompt } from "../../../shared/ai-analysis-messages.js";
 import { harnessRoot } from "../src/corpus.js";
 import { sha256Canonical, validatePromptFile } from "../src/schemas.js";
 
-const promptFile = path.join(harnessRoot, "prompts", "categorize-design-default.json");
+const promptsDir = path.join(harnessRoot, "prompts");
+const promptFile = path.join(promptsDir, "categorize-design-default.json");
+
+/**
+ * Every committed prompt, not just the one below.
+ *
+ * `validatePromptFile` checks each file's declared `aiPromptSha256` against its own `aiPrompt`, and
+ * `buildTasks` loads prompts through it — so a file that fails this aborts `plan` and `run` before a
+ * single task is built. Nothing exercised any prompt but `categorize-design-default`, and a reworded
+ * `categorize-design-mixed` shipped with a stale hash and a green suite: the only experiment that
+ * covers mixed, detail, imageSet and extras could not run at all.
+ *
+ * Filtered and sorted for the same reasons as the experiment-file block in experiments.test.ts:
+ * readdir order is the filesystem's, and a stray non-JSON file should be skipped rather than throw.
+ */
+describe("every committed prompt file", () => {
+  const promptFiles = fs.readdirSync(promptsDir).filter((name) => name.endsWith(".json")).sort();
+
+  // A glob that matches nothing passes every case it is given, so the count is asserted first.
+  it("finds the prompts to check", () => {
+    expect(promptFiles.length).toBeGreaterThan(1);
+  });
+
+  it.each(promptFiles)("%s validates, hash included", (name) => {
+    const file = path.join(promptsDir, name);
+    const prompt = validatePromptFile(JSON.parse(fs.readFileSync(file, "utf8")), file);
+    // The name is what an experiment's `prompt` field names, and the filename is how it is found —
+    // so a copy-paste that leaves them disagreeing makes a prompt unreachable under its own name.
+    expect(prompt.name).toBe(path.basename(name, ".json"));
+  });
+});
 
 /**
  * The committed prompt is a copy of production's built-in default, and this

--- a/scripts/ai-harness/test/render-command.test.ts
+++ b/scripts/ai-harness/test/render-command.test.ts
@@ -165,8 +165,8 @@ describe("a document that fails to render", () => {
 
 describe("a failure that is not a RenderFailed still leaves evidence", () => {
   it("writes the console output and a screenshot for a navigation error", async () => {
-    // These used to arrive with neither: the CLI only wrote them for RenderFailed, and a raw
-    // puppeteer error carried no context at all.
+    // Written for any failure, not only for a RenderFailed: a raw puppeteer error carries no context
+    // of its own, and that is exactly when a picture of the page is worth having.
     const { dataRoot, paths, order } = setUp("render-nav-failure");
     const output: string[] = [];
     const browser = browserThatFails(new Set(), order);
@@ -297,8 +297,8 @@ describe("render refuses what it cannot do", () => {
   });
 
   it("does not let a failing unit server close replace the error already in flight", async () => {
-    // The unit server comes down after the backend and used to do so unguarded, which is the same
-    // masking the backend's own close is wrapped to avoid.
+    // The unit server comes down after the backend, and unguarded it would mask whatever error was
+    // already in flight — the same thing the backend's own close is wrapped to avoid.
     const { dataRoot, order } = setUp("render-unit-close-failure");
     const output: string[] = [];
     const browser = browserThatFails(new Set(["drawing"]), order);

--- a/scripts/ai-harness/test/render-command.test.ts
+++ b/scripts/ai-harness/test/render-command.test.ts
@@ -8,6 +8,11 @@ import {
 import { readPngInfo } from "../src/png.js";
 import { makeTestDataRoot, makeTestPng } from "./helpers.js";
 
+/** A response body that streams, the way `fetch` delivers one. */
+const bodyOf = (bytes: Buffer) => ({
+  async *[Symbol.asyncIterator]() { yield bytes; }
+});
+
 /**
  * A browser whose pages fail for the documents named in `failFor`.
  *
@@ -46,12 +51,24 @@ function browserThatFails(failFor: Set<string>, order: string[], contentRowsHeig
         }),
         frames: () => [{
           url: () => "http://localhost:8080/iframe.html?unwrapped&readOnly",
-          evaluate: async () => ({
-            // High enough to satisfy any fixture's expected tile count; this fake renders every document
-            // in the committed corpus, and a count below the document's own would never settle.
-            contentHeightPx: 1000, contentRowsHeightPx, totalTiles: 99, unknownTiles: 0,
-            fontsReady: true, documentText: "x"
-          }) as never
+          // Two top-level tiles, so the per-tile mode has something to photograph. The
+          // full-document mode never asks.
+          $$: async () => [
+            { boundingBox: async () => ({ x: 0, y: 0, width: 300, height: 200 }),
+              screenshot: async () => makeTestPng(300, 200) },
+            { boundingBox: async () => ({ x: 0, y: 0, width: 400, height: 260 }),
+              screenshot: async () => makeTestPng(400, 260) }
+          ],
+          evaluate: async (script: unknown) => (String(script).includes("data-tool-id")
+            ? ["tile-one", "tile-two"]
+            : {
+              // High enough to satisfy any fixture's expected tile count; this fake renders every
+              // document in the committed corpus, and a count below the document's own would never
+              // settle.
+              documentFailedToLoad: false,
+              contentHeightPx: 1000, contentRowsHeightPx, totalTiles: 99, unknownTiles: 0,
+              fontsReady: true, documentText: "x"
+            }) as never
         }],
         on: () => undefined,
         close: async () => undefined
@@ -314,5 +331,310 @@ describe("render refuses what it cannot do", () => {
       renderModeOptions: { ...base.renderModeOptions, clueRevision: null }
     });
     expect(output.join("\n")).toMatch(/CLUE revision behind .* could not be established/);
+  });
+});
+
+describe("a mode whose height is measured needs a local render to measure from", () => {
+  it("refuses the whole corpus up front, naming the documents and the fix", async () => {
+    // Checked before anything is posted: failing document by document would leave a half-rendered
+    // corpus and a bill for the part that worked.
+    const { dataRoot } = setUp("accurate-height-missing");
+    const output: string[] = [];
+    await expect(main(["render", "--corpus", "render-corpus", "--mode", "shutterbug-accurate-height"],
+      deps(dataRoot, null, output)))
+      .rejects.toThrow(/captures each document at its own measured height/);
+    await expect(main(["render", "--corpus", "render-corpus", "--mode", "shutterbug-accurate-height"],
+      deps(dataRoot, null, output)))
+      .rejects.toThrow(/have no usable puppeteer-full-height render/);
+    await expect(main(["render", "--corpus", "render-corpus", "--mode", "shutterbug-accurate-height"],
+      deps(dataRoot, null, output)))
+      .rejects.toThrow(/Render locally first: harness\.ts render --corpus <name> --mode puppeteer-full-height/);
+    // Nothing was posted, so nothing was written.
+    expect(output.join("\n")).not.toMatch(/Rendered \d+ document/);
+  });
+
+  it("does not demand a height for a document that is expected not to render", async () => {
+    // The fixture that cannot render has no local render to measure, and never will, so requiring
+    // one refused every corpus that contains one — which the committed example corpus does. It is
+    // skipped rather than captured, because an absent height reaches the backend as the fixed
+    // production height and would be filed as a capture at the document's own measured one.
+    const { dataRoot, paths, order } = setUp("accurate-height-expected-failure");
+    const output: string[] = [];
+    await main(["render", "--corpus", "render-corpus", "--mode", "puppeteer-full-height"],
+      deps(dataRoot, browserThatFails(new Set(), order, 900), output));
+    // Drop the local render for `error-test`, which is what a real run has: it never rendered.
+    const marked = "error-test";
+    fs.rmSync(imageRepresentationPath(paths, "puppeteer-full-height", marked), { force: true });
+    const manifestFile = path.join(paths.root, "manifest.json");
+    const manifest = JSON.parse(fs.readFileSync(manifestFile, "utf8"));
+    expect(manifest.documents.find((entry: { id: string }) => entry.id === marked).expectedRenderFailure)
+      .toEqual(expect.any(String));
+
+    // A fake Shutterbug, so the whole command runs without a network. The posted body carries the
+    // document, so the marker in `error-test` says whether it was sent.
+    const png = makeTestPng(960, 980);
+    const posted: string[] = [];
+    const fetchImpl = async (url: string, init?: RequestInit): Promise<Response> => {
+      if (init?.method === "POST") {
+        posted.push(String(JSON.parse(String(init.body)).content));
+        return {
+          ok: true, status: 200, statusText: "OK",
+          body: bodyOf(Buffer.from(JSON.stringify({ url: "https://images.test/shot.png" })))
+        } as unknown as Response;
+      }
+      return {
+        ok: true, status: 200, statusText: "OK", url: "https://images.test/shot.png",
+        headers: new Headers({ "content-type": "image/png" }), body: bodyOf(png)
+      } as unknown as Response;
+    };
+
+    output.length = 0;
+    await main(["render", "--corpus", "render-corpus", "--mode", "shutterbug-accurate-height"], {
+      ...deps(dataRoot, null, output),
+      renderConcurrency: 1,
+      renderModeOptions: { clueRevision: "test-revision", fetchImpl }
+    });
+
+    // The corpus rendered rather than being refused whole, and the marked document was not posted.
+    expect(output.join("\n")).toMatch(new RegExp(`skipped ${marked}: it is expected not to render`));
+    expect(output.join("\n")).toMatch(/Rendered \d+ document\(s\)/);
+    expect(posted).toHaveLength(order.length - 1);
+    expect(posted.some((body) => body.includes("ErrorTest"))).toBe(false);
+    expect(fs.existsSync(imageRepresentationPath(paths, "shutterbug-accurate-height", marked))).toBe(false);
+  });
+
+  it("posts each document at the height its own local render measured", async () => {
+    const { dataRoot, paths, order } = setUp("accurate-height-present");
+    const output: string[] = [];
+    await main(["render", "--corpus", "render-corpus", "--mode", "puppeteer-full-height"],
+      deps(dataRoot, browserThatFails(new Set(), order, 900), output));
+    const heights = new Map(order.map((docId) => [
+      docId,
+      readImageEnvelope(imageRepresentationPath(paths, "puppeteer-full-height", docId)).images[0].heightPx
+    ]));
+
+    // A fake Shutterbug, so the whole command runs without a network.
+    const posted: { height: number }[] = [];
+    const png = makeTestPng(960, 980);
+    const fetchImpl = async (url: string, init?: RequestInit): Promise<Response> => {
+      if (init?.method === "POST") {
+        posted.push({ height: JSON.parse(String(init.body)).height });
+        return {
+          ok: true, status: 200, statusText: "OK",
+          body: bodyOf(Buffer.from(JSON.stringify({ url: "https://images.test/shot.png" })))
+        } as unknown as Response;
+      }
+      return {
+        ok: true, status: 200, statusText: "OK", url: "https://images.test/shot.png",
+        headers: new Headers({ "content-type": "image/png" }), body: bodyOf(png)
+      } as unknown as Response;
+    };
+
+    output.length = 0;
+    await main(["render", "--corpus", "render-corpus", "--mode", "shutterbug-accurate-height"], {
+      ...deps(dataRoot, null, output),
+      renderConcurrency: 1,
+      renderModeOptions: { clueRevision: "test-revision", fetchImpl }
+    });
+
+    // Every document was posted at its own measured height, not one height for all of them.
+    expect(posted.map((call) => call.height)).toEqual(order.map((docId) => heights.get(docId)));
+    // And the envelope records the height the picture was actually taken at, so freshness compares
+    // against that rather than the mode's nominal 1500.
+    for (const docId of order) {
+      const envelope = readImageEnvelope(imageRepresentationPath(paths, "shutterbug-accurate-height", docId));
+      expect({ docId, height: envelope.renderTarget.captureHeightPx })
+        .toEqual({ docId, height: heights.get(docId) });
+      expect(envelope.renderTarget.captureMode).toBe("fixed-height");
+    }
+  });
+});
+
+describe("a document that renders nothing", () => {
+  it("warns when a document declares tiles but drew none", async () => {
+    // Not fatal: `empty` is a real fixture with no tiles. But for a document whose content declares
+    // some, a capture that drew none is a picture of the wrong thing, and until now only *unknown*
+    // tiles were ever mentioned.
+    const { dataRoot, order } = setUp("render-drew-nothing");
+    const output: string[] = [];
+    const browser = browserThatFails(new Set(), order);
+    const original = browser.newPage;
+    browser.newPage = async () => {
+      const page = await original();
+      (page as any).frames = () => [{
+        url: () => "http://localhost:8080/iframe.html",
+        $$: async () => [],
+        evaluate: async (script: unknown) => (String(script).includes("innerText") ? "" : {
+          documentFailedToLoad: false, contentHeightPx: 500, contentRowsHeightPx: 100,
+          totalTiles: 0, unknownTiles: 0, fontsReady: true
+        }) as never
+      }];
+      return page;
+    };
+    await main(["render", "--corpus", "render-corpus", "--mode", "puppeteer-full-height"],
+      deps(dataRoot, browser, output));
+    expect(output.join("\n")).toMatch(/declares \d+ tile\(s\) but drew none/);
+  });
+
+  it("skips a document with no tiles for a per-tile mode, without calling it a failure", async () => {
+    // A per-tile mode cannot represent a document whose content declares no tiles. That is a fact
+    // about the document, not a failure of the render, and a run skips it for the same reason.
+    const { dataRoot, order } = setUp("render-per-tile-empty");
+    const output: string[] = [];
+    await main(["render", "--corpus", "render-corpus", "--mode", "puppeteer-per-tile"],
+      deps(dataRoot, browserThatFails(new Set(), order), output));
+    const printed = output.join("\n");
+    expect(printed).toMatch(/skipped empty: its content declares no tiles/);
+    expect(printed).toMatch(/with nothing to capture/);
+    // Not counted as a failure, so the command still succeeds.
+    expect(printed).not.toMatch(/failed to render/);
+  });
+
+  it("clears the pictures a document leaves behind when it stops having tiles", async () => {
+    // A document that had tiles and then has none is stale rather than absent, so it lands in
+    // `pending` and the skip above takes over. Nothing else would ever clear what it left: `render`
+    // only overwrites what it re-renders, and `--prune` only reaches documents that have left the
+    // manifest. Those files are pictures of a document that no longer looks like that, and once a
+    // corpus is real they are pictures of student work.
+    const { dataRoot, paths, order } = setUp("render-per-tile-emptied");
+    const output: string[] = [];
+    await main(["render", "--corpus", "render-corpus", "--mode", "puppeteer-per-tile"],
+      deps(dataRoot, browserThatFails(new Set(), order), output));
+
+    const docId = "drawing";
+    const envelopeFile = imageRepresentationPath(paths, "puppeteer-per-tile", docId);
+    const pngs = readImageEnvelope(envelopeFile).images
+      .map((image) => resolveImageFile(envelopeFile, image));
+    expect(pngs.length).toBeGreaterThan(0);
+    expect(pngs.every((png) => fs.existsSync(png))).toBe(true);
+
+    // Empty the document, which is what makes its existing render stale.
+    const documentFile = path.join(paths.root, "documents", `${docId}.json`);
+    fs.writeFileSync(documentFile, JSON.stringify({ rowOrder: [], rowMap: {}, tileMap: {} }), "utf8");
+    await main(["import", "--from", path.join(paths.root, "documents"), "--corpus", "render-corpus"],
+      { dataRoot, log: () => undefined });
+
+    output.length = 0;
+    await main(["render", "--corpus", "render-corpus", "--mode", "puppeteer-per-tile"],
+      deps(dataRoot, browserThatFails(new Set(), order), output));
+    expect(output.join("\n")).toMatch(new RegExp(`skipped ${docId}: its content declares no tiles`));
+    expect(output.join("\n")).toMatch(/removed \d+ stale file\(s\)/);
+    expect(fs.existsSync(envelopeFile)).toBe(false);
+    expect(pngs.filter((png) => fs.existsSync(png))).toEqual([]);
+  });
+});
+
+describe("a document the corpus says cannot be rendered", () => {
+  it("is reported apart from real failures, and does not fail the command", async () => {
+    // A corpus that always exits non-zero is a corpus nobody checks, which is how a picture of an
+    // error page survived a whole milestone.
+    const { dataRoot, paths, order } = setUp("render-expected-failure");
+    const output: string[] = [];
+    const manifest = JSON.parse(fs.readFileSync(paths.manifest, "utf8"));
+    for (const entry of manifest.documents) {
+      if (entry.id === "drawing") entry.expectedRenderFailure = "this fixture throws on purpose";
+    }
+    fs.writeFileSync(paths.manifest, JSON.stringify(manifest, null, 2));
+
+    await main(["render", "--corpus", "render-corpus", "--mode", "puppeteer-full-height"],
+      deps(dataRoot, browserThatFails(new Set(["drawing"]), order), output));
+
+    const printed = output.join("\n");
+    expect(printed).toMatch(/expected failure: drawing \(this fixture throws on purpose\)/);
+    expect(printed).toMatch(/1 expected to fail/);
+    // Not counted among the failures, so the command succeeded rather than throwing.
+    expect(printed).toMatch(/0 failed/);
+    // And no envelope was written for it, exactly as for any other failure.
+    expect(fs.existsSync(imageRepresentationPath(paths, "puppeteer-full-height", "drawing"))).toBe(false);
+    // Evidence is kept too. A document expected to fail one way and failing another is exactly the
+    // case a screenshot is for, and the failure message points the reader at it.
+    const evidence = renderErrorDir(paths, "puppeteer-full-height", "drawing");
+    expect(fs.existsSync(path.join(evidence, "error.txt"))).toBe(true);
+    expect(printed).toContain(`evidence written to ${evidence}`);
+  });
+
+  it("warns when a document it expected to fail renders after all", async () => {
+    // A stale expectation is worse than none: it would go on hiding a real failure the day this
+    // document breaks again.
+    const { dataRoot, paths, order } = setUp("render-expectation-stale");
+    const output: string[] = [];
+    const manifest = JSON.parse(fs.readFileSync(paths.manifest, "utf8"));
+    for (const entry of manifest.documents) {
+      if (entry.id === "drawing") entry.expectedRenderFailure = "this used to throw";
+    }
+    fs.writeFileSync(paths.manifest, JSON.stringify(manifest, null, 2));
+
+    await main(["render", "--corpus", "render-corpus", "--mode", "puppeteer-full-height"],
+      deps(dataRoot, browserThatFails(new Set(), order), output));
+    expect(output.join("\n"))
+      .toMatch(/drawing rendered, but the manifest says it should not.*Clear expectedRenderFailure/s);
+  });
+});
+
+describe("--concurrency and --timeout-ms", () => {
+  it("refuses anything that is not a positive whole number", async () => {
+    const { dataRoot } = setUp("render-bad-limits");
+    for (const [flag, value] of [["--concurrency", "0"], ["--concurrency", "2.5"],
+      ["--timeout-ms", "-1"], ["--timeout-ms", "abc"]] as const) {
+      await expect(main(["render", "--corpus", "render-corpus", "--mode", "puppeteer-full-height",
+        flag, value], deps(dataRoot, null, [])))
+        .rejects.toThrow(new RegExp(`\\${flag} must be a positive whole number`));
+    }
+  });
+
+  it("renders one page at a time when asked, instead of four", async () => {
+    // Asserted through the fake browser rather than by timing: a timing assertion would be a
+    // stopwatch on somebody else's machine.
+    const { dataRoot, order } = setUp("render-concurrency-1");
+    const output: string[] = [];
+    let open = 0;
+    let peak = 0;
+    const browser = browserThatFails(new Set(), order);
+    const original = browser.newPage;
+    browser.newPage = async () => {
+      const page = await original();
+      open += 1;
+      peak = Math.max(peak, open);
+      const close = page.close;
+      (page as any).close = async () => {
+        open -= 1;
+        return close();
+      };
+      return page;
+    };
+    await main(["render", "--corpus", "render-corpus", "--mode", "puppeteer-full-height",
+      "--concurrency", "1"], {
+      dataRoot,
+      log: (message: string) => output.push(message),
+      now: () => new Date("2026-08-13T00:00:00.000Z"),
+      // No renderConcurrency here: the flag is the thing under test, and a dep would mask it.
+      renderModeOptions: {
+        clueRevision: "test-revision", launch: async () => browser as never,
+        stableForMs: 0, pollIntervalMs: 1
+      }
+    });
+    expect(peak).toBe(1);
+    // The settings a run used are in its own output, not only in the shell history of whoever ran it.
+    expect(output.join("\n")).toMatch(/\(1 at a time, 30000ms per document\.\)/);
+  });
+
+  it("hands the per-document budget to the backend, and says which one it used", async () => {
+    const { dataRoot, order } = setUp("render-timeout");
+    const output: string[] = [];
+    // A budget this small cannot survive the fake's own settle loop, so the documents fail — which
+    // is the observable proof the flag reached the backend rather than being parsed and dropped.
+    await expect(main(["render", "--corpus", "render-corpus", "--mode", "puppeteer-full-height",
+      "--timeout-ms", "1"], {
+      dataRoot,
+      log: (message: string) => output.push(message),
+      now: () => new Date("2026-08-13T00:00:00.000Z"),
+      renderConcurrency: 1,
+      renderModeOptions: {
+        clueRevision: "test-revision", launch: async () => browserThatFails(new Set(), order) as never,
+        stableForMs: 0, pollIntervalMs: 1
+      }
+    })).rejects.toThrow(/failed to render/);
+    expect(output.join("\n")).toMatch(/1ms budget for this document/);
+    expect(output.join("\n")).toMatch(/\(1 at a time, 1ms per document\.\)/);
   });
 });

--- a/scripts/ai-harness/test/report.test.ts
+++ b/scripts/ai-harness/test/report.test.ts
@@ -22,6 +22,9 @@ const base = {
 };
 const origin = { date: "2026-08-11T00:00:00.000Z", modelReturned: "gpt-4o-mini", systemFingerprint: null };
 
+/** `base` without the fields only a row that sent a request carries. */
+const { representation: _representation, ...skippedBase } = base;
+
 const rows: ResultRow[] = [
   { ...base, docId: "text", modality: "text-only", requestKey: "k1", status: "success",
     response: { parsed: { category: "form" }, raw: {} },
@@ -37,8 +40,11 @@ const rows: ResultRow[] = [
     cost: { modeledUsd: 0.0005, incurredThisRunUsd: 0.0005 }, responseOriginMeta: origin },
   { ...base, docId: "image", modality: "visual-only", requestKey: "k4", status: "error",
     error: { type: "APIError", message: "boom", attempts: 3 } },
-  { ...base, docId: "empty", modality: "empty", requestKey: null, status: "skipped",
-    skipReasons: ["no student content"] }
+  // A skipped row carries no representation — nothing was represented — and records the content it
+  // was decided from, so a rerun can tell whether the decision still applies.
+  { ...skippedBase, docId: "empty", modality: "empty", requestKey: null,
+    status: "skipped", skipReasons: ["text-only run: no tile carries student-authored text"],
+    decidedFromContentSha256: "0".repeat(64) }
 ];
 
 describe("summarizeResults", () => {

--- a/scripts/ai-harness/test/represent-image.test.ts
+++ b/scripts/ai-harness/test/represent-image.test.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { corpusPaths } from "../src/corpus.js";
 import {
   imageRepresentationDir, imageRepresentationFreshness, imageRepresentationPath, readImageEnvelope,
-  removeImageRepresentation, renderErrorDir, resolveImageFile, sha256Bytes, singleImageOf,
+  imagesForSet, removeImageRepresentation, renderErrorDir, resolveImageFile, sha256Bytes,
   writeImageRepresentation
 } from "../src/represent-image.js";
 import { ImageEnvelope, RenderTarget, validateImageEnvelope } from "../src/schemas.js";
@@ -312,20 +312,78 @@ describe("containment", () => {
   });
 });
 
-describe("building a request from an envelope", () => {
-  it("takes the one image when there is exactly one", () => {
-    const { envelopeFile, envelope } = writeOne("single");
-    expect(singleImageOf(envelope, envelopeFile).file).toBe("single-1.png");
+describe("choosing which of an envelope's images a run sends", () => {
+  const tile = (tileId: string | null, file: string) => ({
+    file, sha256: "a".repeat(64), mimeType: "image/png", widthPx: 100, heightPx: 100,
+    bytes: 10, url: null, tileId, purpose: "tile" as const
   });
 
-  // The message names the unbuilt feature, which is deliberate: it is guidance to whoever hit it.
-  it.each([0, 2])("refuses an envelope with %i images, and says why", (count) => {
+  it("takes the one full-document image for a full-document run", () => {
+    const { envelopeFile, envelope } = writeOne("single");
+    const { images, warnings } = imagesForSet(envelope, envelopeFile, "full-document");
+    expect(images.map((image) => image.file)).toEqual(["single-1.png"]);
+    expect(warnings).toEqual([]);
+  });
+
+  it.each([0, 2])("refuses %i full-document images, rather than picking one", (count) => {
+    // Picking whatever is there would produce a row that looks like an ordinary full-document run
+    // and is not.
     const { envelopeFile, envelope } = writeOne("counted");
     const images = count === 0
       ? []
       : [envelope.images[0], { ...envelope.images[0], file: "counted-2.png" }];
-    expect(() => singleImageOf({ ...envelope, images }, envelopeFile))
-      .toThrow(/records \d+ images.*milestone 3/s);
+    expect(() => imagesForSet({ ...envelope, images }, envelopeFile, "full-document"))
+      .toThrow(new RegExp(`records ${count} full-document image\\(s\\)`));
+  });
+
+  it("takes every tile image, in envelope order, for a per-tile run", () => {
+    const { envelopeFile, envelope } = writeOne("tiles");
+    const withTiles = {
+      ...envelope,
+      images: [tile("t1", "tiles-1.png"), tile("t2", "tiles-2.png"), tile("t3", "tiles-3.png")]
+    };
+    expect(imagesForSet(withTiles, envelopeFile, "per-tile").images.map((image) => image.tileId))
+      .toEqual(["t1", "t2", "t3"]);
+  });
+
+  it("tells the caller to render per-tile first when the envelope has no tile images", () => {
+    const { envelopeFile, envelope } = writeOne("no-tiles");
+    for (const imageSet of ["per-tile", "visual-tiles-only"] as const) {
+      expect(() => imagesForSet(envelope, envelopeFile, imageSet, new Set()))
+        .toThrow(/records no per-tile images.*--mode puppeteer-per-tile/s);
+    }
+  });
+
+  it("keeps only the tiles the classification says need a picture", () => {
+    const { envelopeFile, envelope } = writeOne("visual");
+    const withTiles = {
+      ...envelope,
+      images: [tile("text-tile", "visual-1.png"), tile("drawing-tile", "visual-2.png")]
+    };
+    const { images, warnings } = imagesForSet(
+      withTiles, envelopeFile, "visual-tiles-only", new Set(["drawing-tile"]));
+    expect(images.map((image) => image.tileId)).toEqual(["drawing-tile"]);
+    expect(warnings).toEqual([]);
+  });
+
+  it("warns, rather than fails, when a visual tile has no capture of its own", () => {
+    // Classification walks into Question tiles; the per-tile capture photographs top-level tiles
+    // only. The images that exist are still the right ones to send.
+    const { envelopeFile, envelope } = writeOne("nested");
+    const withTiles = { ...envelope, images: [tile("outer", "nested-1.png")] };
+    const { images, warnings } = imagesForSet(
+      withTiles, envelopeFile, "visual-tiles-only", new Set(["outer", "inside-a-question"]));
+    expect(images.map((image) => image.tileId)).toEqual(["outer"]);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("inside-a-question");
+    expect(warnings[0]).toContain("nested inside a Question");
+  });
+
+  it("selects nothing when no captured tile needs a picture", () => {
+    // The caller turns this into a skipped row: it is a fact about the document, not a failure.
+    const { envelopeFile, envelope } = writeOne("all-text");
+    const withTiles = { ...envelope, images: [tile("text-tile", "all-text-1.png")] };
+    expect(imagesForSet(withTiles, envelopeFile, "visual-tiles-only", new Set()).images).toEqual([]);
   });
 });
 

--- a/scripts/ai-harness/test/run-reporting.test.ts
+++ b/scripts/ai-harness/test/run-reporting.test.ts
@@ -124,6 +124,44 @@ describe("cache hits are not double-counted against the skipped total", () => {
   });
 });
 
+describe("skipped rows are not counted as dispatched work", () => {
+  it("still reports the work a ceiling left behind when the run also skipped a pair", async () => {
+    // `pending` holds request tasks; `written` counts every row, skipped ones included — and those
+    // are written before dispatch for pairs that were never in `pending`. Subtracting one from the
+    // other therefore cancelled a skip against an undispatched task: one of each gave 0, and the
+    // CLI then said nothing about a request it never sent.
+    const dataRoot = makeTestDataRoot("nd-skips");
+    const expensive = async () => ({
+      ...(await ok()), usage: { promptTokens: 4_000_000, completionTokens: 1024 }
+    });
+    const summary = await runTasks({
+      corpus: "c",
+      experiment: experiment as any,
+      experimentSha256: "hash",
+      tasks: [makeTask("sendable", "r", "s", 0.02)],
+      skipped: [{
+        docId: "empty", runId: "r", run: { id: "r", message: "text-only", prompt: "p" } as any,
+        modality: "empty", computedModality: "empty", promptName: "p", promptSha256: "h",
+        skipReasons: ["the document has no student content at all"],
+        decidedFromContentSha256: "e".repeat(64)
+      }],
+      outputFile: path.join(dataRoot, "out.jsonl"),
+      ledger: new CostLedger(0.0001),
+      cache: new ResponseCache(path.join(dataRoot, "cache")),
+      pricing: testPricing,
+      runMeta: testRunMeta,
+      createCompletion: expensive,
+      sleep: async () => undefined
+    });
+
+    expect(summary.skipped).toBe(1);
+    expect(summary.written).toBe(1);
+    expect(summary.stoppedOnCeiling).toBe(true);
+    // One request task, never dispatched. The skipped row is not a substitute for having sent it.
+    expect(summary.notDispatched).toBe(1);
+  });
+});
+
 describe("the two overshoots are reported separately", () => {
   it("keeps committed overshoot distinct from incurred overshoot", async () => {
     // A run that stops on the ceiling has usually committed more than it spent — reservations are

--- a/scripts/ai-harness/test/schemas.test.ts
+++ b/scripts/ai-harness/test/schemas.test.ts
@@ -274,6 +274,45 @@ describe("result rows are a discriminated union on status", () => {
       .toThrow(/requestKey must be null on a skipped row/);
   });
 
+  it.each([
+    ["representation", { kind: "text", variantId: "default", variantVersion: 1, sourceContentSha256: "c".repeat(64) }],
+    ["promptImageTokensEstimated", 14_399],
+    ["representationWarnings", ["a warning"]],
+    ["textPartOmitted", true],
+    ["response", { parsed: {}, raw: {} }],
+    ["refusal", "no"],
+    ["usage", { promptTokens: 1, completionTokens: 1, source: "api" }],
+    ["cost", { modeledUsd: 0.01, incurredThisRunUsd: 0.01 }],
+    ["responseOriginMeta", { date: "2026-08-19T00:00:00.000Z", modelReturned: null, systemFingerprint: null }],
+    ["error", { type: "APIError", message: "boom", attempts: 1 }]
+  ])("refuses a skipped row carrying %s, which only a sent row can have", (field, value) => {
+    // Dropped silently, these made a row that disagrees with itself validate cleanly: nothing was
+    // sent, and the row describes a request or a reply anyway. `validateSentRow` already refuses the
+    // mirror image — an image-token estimate on a text row — so this is the same rule facing the
+    // other way.
+    const { representation, ...skippable } = common;
+    const skipped = {
+      ...skippable, status: "skipped", requestKey: null,
+      skipReasons: ["empty document"], decidedFromContentSha256: "b".repeat(64)
+    };
+    expect(() => validateResultRow({ ...skipped, [field]: value }, "results.jsonl"))
+      .toThrow(new RegExp(`${field} cannot appear on a skipped row`));
+  });
+
+  it("still accepts the skipped rows the harness actually writes", () => {
+    // The guard above lists fields by name, so it can only be as right as that list. This reads a
+    // real row back rather than a hand-built one.
+    const written = {
+      schemaVersion: 2, experiment: "e", experimentSha256: "h", runId: "r", corpus: "c",
+      docId: "empty", modality: "empty", computedModality: "empty", message: "text-only",
+      prompt: { name: "p", sha256: "d" }, requestKey: null,
+      runMeta: { date: "2026-08-19T00:00:00.000Z", openaiSdkVersion: "6", gitCommit: null, gitDirty: false },
+      status: "skipped", skipReasons: ["the document has no student content at all"],
+      decidedFromContentSha256: "b".repeat(64)
+    };
+    expect(validateResultRow(written, "results.jsonl").status).toBe("skipped");
+  });
+
   it("refuses a skipped row that does not say why, or cannot say what it decided from", () => {
     // A document that simply does not appear in the results is indistinguishable from a bug; a row
     // with no reasons is the same problem wearing a status.

--- a/scripts/ai-harness/test/schemas.test.ts
+++ b/scripts/ai-harness/test/schemas.test.ts
@@ -95,10 +95,93 @@ describe("experiment validation", () => {
     expect(experiment.runs).toHaveLength(1);
   });
 
-  it("rejects a message shape nothing can run yet", () => {
+  it("rejects a message shape it does not know", () => {
     expect(() => validateExperimentFile(
-      { schemaVersion: 1, name: "x", runs: [{ ...run, message: "mixed" }] }, "experiment.json", context))
-      .toThrow(/runs\[0\]\.message must be one of text-only/);
+      { schemaVersion: 1, name: "x", runs: [{ ...run, message: "picture-and-a-song" }] },
+      "experiment.json", context))
+      .toThrow(/runs\[0\]\.message must be one of text-only, image-only, mixed/);
+  });
+
+  const validate = (overrides: Record<string, unknown>) => () => validateExperimentFile(
+    { schemaVersion: 1, name: "x", runs: [{ ...run, ...overrides }] }, "experiment.json", context);
+
+  describe("a mixed run names both representations", () => {
+    const mixed = {
+      id: "mixed", message: "mixed", textVariant: "default",
+      imageMode: "puppeteer-full-height", prompt: "categorize-design-default"
+    };
+
+    it("accepts one that names both", () => {
+      const experiment = validateExperimentFile(
+        { schemaVersion: 1, name: "x", runs: [mixed] }, "experiment.json", context);
+      expect(experiment.runs[0])
+        .toEqual({ ...mixed, message: "mixed", textVariant: "default", imageMode: "puppeteer-full-height" });
+    });
+
+    it("refuses one missing either half", () => {
+      const { textVariant, ...noText } = mixed;
+      const { imageMode, ...noImage } = mixed;
+      expect(() => validateExperimentFile(
+        { schemaVersion: 1, name: "x", runs: [noText] }, "experiment.json", context))
+        .toThrow(/runs\[0\]\.textVariant must be a string/);
+      expect(() => validateExperimentFile(
+        { schemaVersion: 1, name: "x", runs: [noImage] }, "experiment.json", context))
+        .toThrow(/runs\[0\]\.imageMode must be a string/);
+    });
+
+    it("validates both against the known lists", () => {
+      expect(() => validateExperimentFile(
+        { schemaVersion: 1, name: "x", runs: [{ ...mixed, imageMode: "screenshot" }] },
+        "experiment.json", context)).toThrow(/runs\[0\]\.imageMode must be one of/);
+    });
+  });
+
+  describe("a dimension a shape cannot use is refused rather than ignored", () => {
+    // Silently dropping one produces a result table that looks fine and answers a different
+    // question, which is the whole reason these are refusals.
+    it("refuses detail and imageSet on a text-only run", () => {
+      expect(validate({ detail: "low" })).toThrow(/detail must not be set on a "text-only" run/);
+      expect(validate({ imageSet: "per-tile" })).toThrow(/imageSet must not be set on a "text-only" run/);
+    });
+
+    it("refuses extras on an image-only run", () => {
+      expect(validate({
+        message: "image-only", textVariant: undefined, imageMode: "puppeteer-full-height",
+        extras: "no-extras"
+      })).toThrow(/extras must not be set on an "image-only" run: extras ride the summary/);
+    });
+
+    it("accepts all three on a mixed run", () => {
+      const experiment = validateExperimentFile({
+        schemaVersion: 1,
+        name: "x",
+        runs: [{
+          id: "mixed", message: "mixed", textVariant: "default", imageMode: "puppeteer-full-height",
+          detail: "high", imageSet: "per-tile", extras: "no-extras", prompt: "categorize-design-default"
+        }]
+      }, "experiment.json", context);
+      expect(experiment.runs[0])
+        .toMatchObject({ detail: "high", imageSet: "per-tile", extras: "no-extras" });
+    });
+
+    it("refuses values outside each list", () => {
+      expect(validate({ message: "image-only", textVariant: undefined,
+        imageMode: "puppeteer-full-height", detail: "ultra" }))
+        .toThrow(/detail must be one of low, high, auto/);
+      expect(validate({ message: "image-only", textVariant: undefined,
+        imageMode: "puppeteer-full-height", imageSet: "every-other-tile" }))
+        .toThrow(/imageSet must be one of full-document, per-tile, visual-tiles-only/);
+      expect(validate({ extras: "extras-improved" }))
+        .toThrow(/extras must be one of extras-fixed, extras-production-current, no-extras/);
+    });
+
+    it("leaves an unset dimension unset, so defaults stay the caller's business", () => {
+      const experiment = validateExperimentFile(
+        { schemaVersion: 1, name: "x", runs: [run] }, "experiment.json", context);
+      expect(experiment.runs[0]).not.toHaveProperty("extras");
+      expect(experiment.runs[0]).not.toHaveProperty("detail");
+      expect(experiment.runs[0]).not.toHaveProperty("imageSet");
+    });
   });
 
   it("rejects an unknown text variant", () => {
@@ -174,12 +257,37 @@ describe("result rows are a discriminated union on status", () => {
   });
 
   it("validates a skipped row and requires a null requestKey", () => {
-    const row = validateResultRow(
-      { ...common, status: "skipped", requestKey: null, skipReasons: ["empty document"] }, "results.jsonl");
+    // A skipped row carries no representation and no request key, and records the content its
+    // decision was made from so a rerun can tell whether that decision still applies.
+    const { representation, ...skippable } = common;
+    const skipped = {
+      ...skippable,
+      status: "skipped",
+      requestKey: null,
+      skipReasons: ["empty document"],
+      decidedFromContentSha256: "b".repeat(64)
+    };
+    const row = validateResultRow(skipped, "results.jsonl");
     expect(row.status).toBe("skipped");
     expect(row.requestKey).toBeNull();
-    expect(() => validateResultRow({ ...common, status: "skipped", skipReasons: [] }, "results.jsonl"))
+    expect(() => validateResultRow({ ...skipped, requestKey: "k" }, "results.jsonl"))
       .toThrow(/requestKey must be null on a skipped row/);
+  });
+
+  it("refuses a skipped row that does not say why, or cannot say what it decided from", () => {
+    // A document that simply does not appear in the results is indistinguishable from a bug; a row
+    // with no reasons is the same problem wearing a status.
+    const { representation, ...skippable } = common;
+    const skipped = {
+      ...skippable, status: "skipped", requestKey: null,
+      skipReasons: ["empty document"], decidedFromContentSha256: "b".repeat(64)
+    };
+    expect(() => validateResultRow({ ...skipped, skipReasons: [] }, "results.jsonl"))
+      .toThrow(/skipReasons must name at least one reason/);
+    expect(() => validateResultRow({ ...skipped, decidedFromContentSha256: undefined }, "results.jsonl"))
+      .toThrow(/decidedFromContentSha256 must be a string/);
+    expect(() => validateResultRow({ ...skipped, decidedFromContentSha256: "nope" }, "results.jsonl"))
+      .toThrow(/decidedFromContentSha256 must be a 64-character hex sha256/);
   });
 
   it("rejects a success row that is missing the fields its status requires", () => {

--- a/scripts/ai-harness/test/shutterbug.test.ts
+++ b/scripts/ai-harness/test/shutterbug.test.ts
@@ -2,8 +2,9 @@ import http from "node:http";
 import { AddressInfo } from "node:net";
 import {
   kProductionCaptureHeightPx, kProductionClueUrl, kProductionShutterbugUrl, kProductionUnit,
-  shutterbugParameterized, shutterbugProductionCurrent, shutterbugRequestBody
+  shutterbugAccurateHeight, shutterbugParameterized, shutterbugProductionCurrent, shutterbugRequestBody
 } from "../src/backends/shutterbug.js";
+import { getRenderBackend } from "../src/backends/index.js";
 import { RenderLimitExceeded } from "../src/backends/types.js";
 import { makeTestPng } from "./helpers.js";
 
@@ -391,5 +392,100 @@ describe("a redirected POST against a real server", () => {
       .then(() => null, (error: Error) => error);
     expect(delivered).toEqual([]);
     expect(String(outcome)).toMatch(new RegExp(`answered 307 redirecting to ${target}/collect`));
+  });
+});
+
+describe("the accurate-height mode", () => {
+  // The prototype for the production fix: production posts a hardcoded height: 1500 for every
+  // document, so a shorter one is padded and a longer one is silently clipped.
+  const heightIn = (calls: Call[]) => JSON.parse(String(calls[0].init!.body)).height;
+
+  it("captures a document at the height it is given, not the configured one", async () => {
+    const calls: Call[] = [];
+    const backend = shutterbugAccurateHeight({ fetchImpl: fakeFetch({ calls }), sleep: noSleep });
+    await backend.render({ docId: "doc", content: emptyDocument, captureHeightPx: 1180 });
+    expect(heightIn(calls)).toBe(1180);
+  });
+
+  it("records the height it actually used on that render, not the mode's nominal one", async () => {
+    const backend = shutterbugAccurateHeight({ fetchImpl: fakeFetch(), sleep: noSleep });
+    const outcome = await backend.render({ docId: "doc", content: emptyDocument, captureHeightPx: 640 });
+    // Without this the envelope would claim 1500 and freshness would compare against a height the
+    // picture was never taken at.
+    expect(outcome.renderTarget?.captureHeightPx).toBe(640);
+    expect(outcome.renderTarget?.captureMode).toBe("fixed-height");
+    expect(backend.renderTarget.captureHeightPx).toBe(kProductionCaptureHeightPx);
+  });
+
+  it("falls back to production's height for a document it was given none for", async () => {
+    // No better than production, rather than better in a way nobody asked for.
+    const calls: Call[] = [];
+    const backend = shutterbugAccurateHeight({ fetchImpl: fakeFetch({ calls }), sleep: noSleep });
+    const outcome = await backend.render({ docId: "doc", content: emptyDocument });
+    expect(heightIn(calls)).toBe(kProductionCaptureHeightPx);
+    // And it says nothing special about its target, because nothing was special about it.
+    expect(outcome.renderTarget).toBeUndefined();
+  });
+
+  it("refuses a measured height that is not a positive whole number of pixels", async () => {
+    const backend = shutterbugAccurateHeight({ fetchImpl: fakeFetch(), sleep: noSleep });
+    for (const captureHeightPx of [0, -20, 12.5]) {
+      await expect(backend.render({ docId: "doc", content: emptyDocument, captureHeightPx }))
+        .rejects.toThrow(/not a positive whole number of pixels/);
+    }
+  });
+
+  it("refuses a measured height beyond the limits, before posting the document", async () => {
+    const calls: Call[] = [];
+    const backend = shutterbugAccurateHeight({ fetchImpl: fakeFetch({ calls }), sleep: noSleep });
+    await expect(backend.render({ docId: "tall", content: emptyDocument, captureHeightPx: 30_000 }))
+      .rejects.toThrow(/30000px tall, over the 20000px limit/);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("otherwise posts exactly what the parameterized mode posts", async () => {
+    // Same envelope, same target — only the height differs, which is the whole experiment.
+    const accurate: Call[] = [];
+    const parameterized: Call[] = [];
+    await shutterbugAccurateHeight({ fetchImpl: fakeFetch({ calls: accurate }), sleep: noSleep })
+      .render({ docId: "doc", content: emptyDocument, captureHeightPx: kProductionCaptureHeightPx });
+    await shutterbugParameterized({ fetchImpl: fakeFetch({ calls: parameterized }), sleep: noSleep })
+      .render({ docId: "doc", content: emptyDocument });
+    expect(accurate[0].url).toBe(parameterized[0].url);
+    expect(JSON.parse(String(accurate[0].init!.body)))
+      .toEqual(JSON.parse(String(parameterized[0].init!.body)));
+  });
+
+  it("cannot be given a capture height on the command line", () => {
+    // The height is measured, not chosen: accepting one would answer a different question.
+    expect(() => getRenderBackend("shutterbug-accurate-height", { captureHeightPx: 900 }))
+      .toThrow(/--capture-height is not configurable for --mode shutterbug-accurate-height/);
+  });
+});
+
+describe("the per-document timeout belongs to the modes that keep one", () => {
+  // A hosted mode bounds its request and its download separately, with retries around them, and has
+  // no whole-document deadline to hand a budget to. Accepting `--timeout-ms` and dropping it meant
+  // the CLI printed a per-document limit that nothing enforced.
+  it.each(["shutterbug-production-current", "shutterbug-parameterized", "shutterbug-accurate-height"])(
+    "refuses --timeout-ms for %s", (modeId) => {
+      expect(() => getRenderBackend(modeId, { timeoutMs: 5000 }))
+        .toThrow(/--timeout-ms is not configurable for --mode/);
+    });
+
+  it("does not offer the parameterized mode as a remedy for a timeout", () => {
+    // That advice is about where a render is taken, and says nothing to someone who asked for
+    // longer. It is still given for the flags it does answer.
+    expect(() => getRenderBackend("shutterbug-parameterized", { timeoutMs: 5000 }))
+      .toThrow(/not configurable for --mode shutterbug-parameterized\.$/);
+    expect(() => getRenderBackend("shutterbug-production-current", { clueUrl: "http://x.test" }))
+      .toThrow(/Use --mode shutterbug-parameterized to change the render target\./);
+  });
+
+  it("still accepts it for the local modes, which do keep one", () => {
+    expect(() => getRenderBackend("puppeteer-full-height", { timeoutMs: 5000, unit: "harness-render" }))
+      .not.toThrow();
+    expect(() => getRenderBackend("puppeteer-per-tile", { timeoutMs: 5000, unit: "harness-render" }))
+      .not.toThrow();
   });
 });

--- a/scripts/ai-harness/test/smoke-image.test.ts
+++ b/scripts/ai-harness/test/smoke-image.test.ts
@@ -247,8 +247,8 @@ describe("end-to-end image-only run against the synthetic corpus", () => {
     // carries student text, and no shape sends an empty document.
     const sent = shape.withStudentText.length * 2 + shape.withContent.length;
     expect(printed).toContain(
-      `3 run(s) × ${documentIds().length} document(s) = ${sent} call(s), ` +
-      `${documentIds().length * 3 - sent} skipped.`);
+      `3 run(s) × ${documentIds().length} document(s) = ${documentIds().length * 3} pair(s); ` +
+      `${sent} call(s), ${documentIds().length * 3 - sent} skipped.`);
     expect(printed).toContain("[image-only, --mode puppeteer-full-height");
     // Each shape is described by what it actually sends. The old two-way label predated `mixed` and
     // called it "text-only" while printing its images underneath.

--- a/scripts/ai-harness/test/smoke-image.test.ts
+++ b/scripts/ai-harness/test/smoke-image.test.ts
@@ -12,8 +12,11 @@ import { ReportSummary } from "../src/report.js";
 import { ExperimentFile, ResultRow } from "../src/schemas.js";
 import { harnessRoot, isContainedBy } from "../src/files.js";
 import {
-  listFilesUnder, makeTestDataRoot, makeTestPng, readLines, testRunsRoot
+  listFilesUnder, makeTestDataRoot, makeTestPng, readLines, syntheticCorpusShape, testRunsRoot
 } from "./helpers.js";
+
+/** Derived from the committed fixtures, so adding one moves the counts instead of breaking them. */
+const shape = syntheticCorpusShape();
 
 /**
  * The mocked end-to-end path extended through an `image-only` run, with no browser and no network.
@@ -96,13 +99,22 @@ describe("end-to-end image-only run against the synthetic corpus", () => {
       }),
       frames: () => [{
         url: () => "http://localhost:8080/iframe.html?unit=harness-render&unwrapped&readOnly",
-        evaluate: async () => ({
-          // High enough for any fixture in the committed corpus — see render-command.test.ts.
-          // Without `contentRowsHeightPx` the backend compares against `undefined`, skips the
-          // resize, and skips the guard that keeps `captureMode: "full-document"` honest.
-          contentHeightPx: 1420, contentRowsHeightPx, totalTiles: 99, unknownTiles: 0,
-          fontsReady: true, documentText: "marker"
-        }) as never
+        // Two top-level tiles, for the per-tile mode. The full-height mode never asks.
+        $$: async () => [
+          { boundingBox: async () => ({ x: 0, y: 0, width: 300, height: 200 }),
+            screenshot: async () => makeTestPng(300, 200) },
+          { boundingBox: async () => ({ x: 0, y: 0, width: 400, height: 260 }),
+            screenshot: async () => makeTestPng(400, 260) }
+        ],
+        // High enough for any fixture in the committed corpus — see render-command.test.ts.
+        // Without `contentRowsHeightPx` the backend compares against `undefined`, skips the
+        // resize, and skips the guard that keeps `captureMode: "full-document"` honest.
+        evaluate: async (script: unknown) => (String(script).includes("data-tool-id")
+          ? ["tile-one", "tile-two"]
+          : {
+            contentHeightPx: 1420, contentRowsHeightPx, totalTiles: 99, unknownTiles: 0,
+            fontsReady: true, documentText: "marker"
+          }) as never
       }],
       on: () => undefined,
       close: async () => undefined
@@ -231,9 +243,16 @@ describe("end-to-end image-only run against the synthetic corpus", () => {
     output.length = 0;
     await main(["plan", "--corpus", "image-corpus", "--experiment", "experiments/image-vs-text.json"], deps);
     const printed = output.join("\n");
-    const documents = documentIds().length;
-    expect(printed).toContain(`3 run(s) × ${documents} document(s) = ${documents * 3} call(s)`);
+    // Skip-empty means the call count is no longer runs × documents: the text runs send only what
+    // carries student text, and no shape sends an empty document.
+    const sent = shape.withStudentText.length * 2 + shape.withContent.length;
+    expect(printed).toContain(
+      `3 run(s) × ${documentIds().length} document(s) = ${sent} call(s), ` +
+      `${documentIds().length * 3 - sent} skipped.`);
     expect(printed).toContain("[image-only, --mode puppeteer-full-height");
+    // Each shape is described by what it actually sends. The old two-way label predated `mixed` and
+    // called it "text-only" while printing its images underneath.
+    expect(printed).toContain("[text-only, default]");
     // Where the pictures came from, resolved rather than described. Every render target value has a
     // default, and a default nobody states is one nobody checks.
     expect(printed).toMatch(/renders against: http:\/\/localhost:8080 \(--clue-url\), unit harness-render/);
@@ -246,11 +265,22 @@ describe("end-to-end image-only run against the synthetic corpus", () => {
     await main(["run", "--corpus", "image-corpus", "--experiment", "experiments/image-vs-text.json",
       "--max-cost", "2.00"], deps);
     const rows = readLines(resultsFile) as ResultRow[];
+    // One row per (run, document) pair, sent or skipped.
     expect(rows).toHaveLength(documentIds().length * 3);
 
-    const imageRows = rows.filter((row) => row.message === "image-only");
-    expect(imageRows).toHaveLength(documentIds().length);
+    // An image run sends every document it can: the empty ones show nothing in a picture, and the
+    // unrenderable ones have no picture to send at all.
+    const imageRows = rows.filter((row) => row.message === "image-only" && row.status !== "skipped");
+    expect(imageRows).toHaveLength(shape.withContent.length);
+    const skippedImages = rows.filter((row) => row.message === "image-only" && row.status === "skipped");
+    expect(skippedImages.map((row) => row.docId).sort())
+      .toEqual([...shape.empty, ...shape.unrenderable].sort());
+    // Each says which of the two it was, in terms a reader can act on.
+    expect(skippedImages.filter((row) =>
+      row.status === "skipped" && row.skipReasons.join(" ").includes("cannot be rendered")))
+      .toHaveLength(shape.unrenderable.length);
     for (const row of imageRows) {
+      if (row.status === "skipped") continue;
       expect(row.representation.kind).toBe("image");
       if (row.representation.kind === "image") {
         expect(row.representation.modeId).toBe("puppeteer-full-height");
@@ -260,7 +290,8 @@ describe("end-to-end image-only run against the synthetic corpus", () => {
       expect(row.promptImageTokensEstimated).toBeGreaterThan(10_000);
     }
     // A text row has a text descriptor and no image estimate at all.
-    const textRow = rows.find((row) => row.runId === "text-default")!;
+    const textRow = rows.find((row) => row.runId === "text-default" && row.status !== "skipped")!;
+    if (textRow.status === "skipped") throw new Error("expected text-default to have sent a request");
     expect(textRow.representation.kind).toBe("text");
     expect(textRow.promptImageTokensEstimated).toBeUndefined();
   });
@@ -321,6 +352,77 @@ describe("end-to-end image-only run against the synthetic corpus", () => {
     expect(JSON.stringify(task.makeRequest().apiRequest.messages)).toContain(dataUrlFor(original));
   });
 
+  it("runs a mixed message, dropping the text half only where there is no student text", async () => {
+    // The milestone's headline shape: both representations of the same document in one request.
+    const experiment = path.join(dataRoot, "mixed.json");
+    fs.writeFileSync(experiment, JSON.stringify({
+      schemaVersion: 1,
+      name: "mixed-check",
+      runs: [{
+        id: "mixed", message: "mixed", textVariant: "default",
+        imageMode: "puppeteer-full-height", prompt: "categorize-design-default"
+      }]
+    }, null, 2));
+    output.length = 0;
+    // `plan` is the record of what a run was about to do, so its label has to name the shape that
+    // will actually run. The old two-way label predated `mixed` and filed it under "text-only"
+    // while printing its images underneath.
+    await main(["plan", "--corpus", "image-corpus", "--experiment", experiment], deps);
+    expect(output.join("\n"))
+      .toContain("[mixed, default, --mode puppeteer-full-height");
+
+    output.length = 0;
+    requests.length = 0;
+    const mixedResults = path.join(dataRoot, "results", "mixed.jsonl");
+    await main(["run", "--corpus", "image-corpus", "--experiment", experiment,
+      "--max-cost", "2.00", "--output", mixedResults], deps);
+
+    const rows = readLines(mixedResults) as ResultRow[];
+    expect(rows).toHaveLength(documentIds().length);
+    const sent = rows.filter((row) => row.status !== "skipped");
+    // A mixed run sends everything it has a picture for, and skips the rest.
+    expect(sent).toHaveLength(shape.withContent.length);
+    expect(rows.filter((row) => row.status === "skipped"))
+      .toHaveLength(shape.empty.length + shape.unrenderable.length);
+
+    // Both halves are recorded, and the two shapes are the ones the single-representation rows use.
+    for (const row of sent) {
+      expect(row.representation.kind).toBe("mixed");
+      if (row.representation.kind !== "mixed") continue;
+      expect(row.representation.text.variantId).toBe("default");
+      expect(row.representation.image.modeId).toBe("puppeteer-full-height");
+      expect(row.representation.image.imageSet).toBe("full-document");
+      expect(row.promptImageTokensEstimated).toBeGreaterThan(10_000);
+    }
+
+    // The text half is dropped exactly for the documents that carry no student text — and those
+    // rows are sent, not skipped, because the picture still has something to say.
+    const omitted = sent.filter((row) => row.textPartOmitted).map((row) => row.docId).sort();
+    const expectedOmitted = shape.withContent
+      .filter((docId) => !shape.withStudentText.includes(docId)).sort();
+    expect(omitted).toEqual(expectedOmitted);
+    expect(omitted.length).toBeGreaterThan(0);
+
+    // A dropped text half really means prompt-plus-picture and nothing else — which is exactly an
+    // image-only message. So those rows share the image-only run's request key, and this run served
+    // them from its cache rather than paying for them again. Asserted rather than worked around:
+    // that identity is the cache doing precisely what it is for.
+    const imageOnlyKeys = new Map((readLines(resultsFile) as ResultRow[])
+      .filter((row) => row.runId === "image-puppeteer" && row.status !== "skipped")
+      .map((row) => [row.docId, row.requestKey]));
+    for (const row of sent) {
+      const imageOnlyKey = imageOnlyKeys.get(row.docId);
+      expect({ docId: row.docId, sameAsImageOnly: row.requestKey === imageOnlyKey })
+        .toEqual({ docId: row.docId, sameAsImageOnly: Boolean(row.textPartOmitted) });
+    }
+    // And the dispatched calls were only the ones carrying a summary; the rest were cache hits.
+    expect(requests).toHaveLength(shape.withStudentText.length);
+    for (const request of requests) {
+      expect((request.messages[1].content as any[]).map((part: any) => part.type))
+        .toEqual(["text", "text", "image_url"]);
+    }
+  });
+
   it("reports image-only and text-only side by side rather than summed", async () => {
     output.length = 0;
     await main(["report", "--results", resultsFile], deps);
@@ -335,39 +437,53 @@ describe("end-to-end image-only run against the synthetic corpus", () => {
       group.runId === "(all runs)" && group.message === "image-only" && group.modality === "all")!;
     const textAll = summary.groups.find((group) =>
       group.runId === "(all runs)" && group.message === "text-only" && group.modality === "all")!;
+    // Both groups still cover every document — a skipped pair is a row in its group, not an absence.
     expect(imageAll.docs).toBe(documentIds().length);
     expect(textAll.docs).toBe(documentIds().length);
+    expect(imageAll.statuses.skipped).toBe(shape.empty.length + shape.unrenderable.length);
     // The whole point of splitting by shape: the two totals are separate numbers.
     expect(imageAll.tokens.imageEstimatedTotal).toBeGreaterThan(0);
     expect(textAll.tokens.imageEstimatedTotal).toBe(0);
     expect(imageAll.tokens.promptTotal).not.toBe(textAll.tokens.promptTotal);
   });
 
-  it("refuses an envelope with two images rather than sending the first", async () => {
-    // A genuine second image — real file, real hash, real byte count — so the envelope is entirely
-    // valid and the only thing wrong with it is that nothing here knows which one to send.
-    // The first is never silently selected.
+  it("chooses by purpose when an envelope holds a tile picture as well", async () => {
+    // A genuine second image — real file, real hash, real byte count — with `purpose: "tile"`. A
+    // full-document run sends the full-document picture and ignores the tile, rather than picking
+    // whichever came first.
     const file = imageRepresentationPath(paths, "puppeteer-full-height", "drawing");
     const envelope = readImageEnvelope(file);
     const second = makeTestPng(480, 500);
     fs.writeFileSync(path.join(path.dirname(file), "drawing-2.png"), second);
-    fs.writeFileSync(file, JSON.stringify({
-      ...envelope,
-      images: [envelope.images[0], {
-        ...envelope.images[0],
-        file: "drawing-2.png",
-        sha256: sha256Bytes(second),
-        bytes: second.length,
-        widthPx: 480,
-        heightPx: 500,
-        purpose: "tile",
-        tileId: "tile-1"
-      }]
-    }, null, 2));
-    await expect(main(["plan", "--corpus", "image-corpus", "--experiment",
-      "experiments/image-vs-text.json"], deps)).rejects.toThrow(/records 2 images[\s\S]*milestone 3/);
-    fs.writeFileSync(file, JSON.stringify(envelope, null, 2));
-    fs.rmSync(path.join(path.dirname(file), "drawing-2.png"));
+    const tile = {
+      ...envelope.images[0],
+      file: "drawing-2.png",
+      sha256: sha256Bytes(second),
+      bytes: second.length,
+      widthPx: 480,
+      heightPx: 500,
+      purpose: "tile",
+      tileId: "tile-1"
+    };
+    fs.writeFileSync(file, JSON.stringify({ ...envelope, images: [envelope.images[0], tile] }, null, 2));
+    try {
+      output.length = 0;
+      await main(["plan", "--corpus", "image-corpus", "--experiment",
+        "experiments/image-vs-text.json"], deps);
+      // Still one image per document, and it is the full-document one.
+      expect(output.join("\n"))
+        .toMatch(new RegExp(`${shape.withContent.length} image\\(s\\) across ` +
+          `${shape.withContent.length} call\\(s\\)`));
+
+      // And an envelope holding *only* tiles refuses a full-document run outright, naming the fix.
+      fs.writeFileSync(file, JSON.stringify({ ...envelope, images: [tile] }, null, 2));
+      await expect(main(["plan", "--corpus", "image-corpus", "--experiment",
+        "experiments/image-vs-text.json"], deps))
+        .rejects.toThrow(/records 0 full-document image\(s\) out of 1[\s\S]*set imageSet on the run/);
+    } finally {
+      fs.writeFileSync(file, JSON.stringify(envelope, null, 2));
+      fs.rmSync(path.join(path.dirname(file), "drawing-2.png"));
+    }
   });
 
   it("refuses an envelope with no images at all", async () => {
@@ -412,5 +528,112 @@ describe("end-to-end image-only run against the synthetic corpus", () => {
     for (const file of appeared) {
       expect({ file, inside: isContainedBy(file, dataDir) }).toEqual({ file, inside: true });
     }
+  });
+});
+
+describe("a per-tile render, and the sets a run can send from it", () => {
+  const dataRoot = makeTestDataRoot("per-tile");
+  const paths = corpusPaths(dataRoot, "tile-corpus");
+  const output: string[] = [];
+  /** Two top-level tiles per document: one the classification calls visual, one it does not. */
+  const tiles = [
+    { tileId: "text-tile", widthPx: 300, heightPx: 200 },
+    { tileId: "drawing-tile", widthPx: 400, heightPx: 260 }
+  ];
+
+  const fakeBrowser = () => ({
+    newPage: async () => ({
+      setViewport: async () => undefined,
+      screenshot: async () => makeTestPng(40, 40),
+      goto: async () => undefined,
+      evaluate: async () => undefined as never,
+      waitForFunction: async () => true,
+      $: async () => ({
+        boundingBox: async () => ({ x: 0, y: 0, width: 960, height: 1420 }),
+        screenshot: async () => makeTestPng(960, 1420)
+      }),
+      frames: () => [{
+        url: () => "http://localhost:8080/iframe.html?unit=harness-render&unwrapped&readOnly",
+        $$: async () => tiles.map((tile) => ({
+          boundingBox: async () => ({ x: 0, y: 0, width: tile.widthPx, height: tile.heightPx }),
+          screenshot: async () => makeTestPng(tile.widthPx, tile.heightPx)
+        })),
+        evaluate: async (script: unknown) => (String(script).includes("data-tool-id")
+          ? tiles.map((tile) => tile.tileId)
+          : {
+            contentHeightPx: 1420, contentRowsHeightPx: 1340, totalTiles: 99, unknownTiles: 0,
+            fontsReady: true, documentText: "marker"
+          }) as never
+      }],
+      on: () => undefined,
+      close: async () => undefined
+    }),
+    close: async () => undefined
+  });
+
+  const deps = {
+    dataRoot,
+    log: (message: string) => output.push(message),
+    now: () => new Date("2026-08-13T00:00:00.000Z"),
+    renderConcurrency: 1,
+    renderModeOptions: {
+      clueRevision: "tile-revision",
+      launch: async () => fakeBrowser() as never,
+      stableForMs: 0,
+      pollIntervalMs: 1
+    },
+    startUnitServer: async () => ({
+      unitUrl: "http://127.0.0.1:5000/harness-render/content.json",
+      close: async () => undefined
+    })
+  };
+
+  it("writes one image per tile, each tagged with the tile it is a picture of", async () => {
+    await main(["import", "--from", "examples/synthetic-corpus", "--corpus", "tile-corpus"], deps);
+    await main(["represent", "--corpus", "tile-corpus", "--variants", "default"], deps);
+    output.length = 0;
+    await main(["render", "--corpus", "tile-corpus", "--mode", "puppeteer-per-tile"], deps);
+    expect(output.join("\n")).toMatch(/Rendered \d+ document\(s\) with --mode puppeteer-per-tile/);
+
+    const envelope = readImageEnvelope(imageRepresentationPath(paths, "puppeteer-per-tile", "drawing"));
+    expect(envelope.images).toHaveLength(2);
+    expect(envelope.images.map((image) => image.tileId)).toEqual(["text-tile", "drawing-tile"]);
+    for (const image of envelope.images) expect(image.purpose).toBe("tile");
+    // Its own capture mode, so a freshness check can tell the two renders apart.
+    expect(envelope.renderTarget.captureMode).toBe("per-tile");
+    // The full-document render is filed separately and is unaffected.
+    expect(fs.existsSync(imageRepresentationPath(paths, "puppeteer-full-height", "drawing"))).toBe(false);
+  });
+
+  it("sends every tile for a per-tile run, and prices each one separately", async () => {
+    const experiment = path.join(dataRoot, "per-tile.json");
+    fs.writeFileSync(experiment, JSON.stringify({
+      schemaVersion: 1,
+      name: "per-tile-set",
+      runs: [{
+        id: "tiles", message: "image-only", imageMode: "puppeteer-per-tile",
+        imageSet: "per-tile", prompt: "categorize-design-default"
+      }]
+    }, null, 2));
+    output.length = 0;
+    await main(["plan", "--corpus", "tile-corpus", "--experiment", experiment], deps);
+    const printed = output.join("\n");
+    // Two images per call is the thing to see before paying for it: each carries the base charge.
+    expect(printed).toMatch(/\d+ image\(s\) across \d+ call\(s\) \(2\.0 per document, imageSet per-tile\)/);
+    expect(printed).toMatch(/image tokens \(estimated, auto priced at the high rate\): \d+/);
+  });
+
+  it("refuses a full-document run against a per-tile render, naming the fix", async () => {
+    const experiment = path.join(dataRoot, "full.json");
+    fs.writeFileSync(experiment, JSON.stringify({
+      schemaVersion: 1,
+      name: "wrong-set",
+      runs: [{
+        id: "full", message: "image-only", imageMode: "puppeteer-per-tile",
+        prompt: "categorize-design-default"
+      }]
+    }, null, 2));
+    await expect(main(["plan", "--corpus", "tile-corpus", "--experiment", experiment], deps))
+      .rejects.toThrow(/records 0 full-document image\(s\)[\s\S]*set imageSet on the run/);
   });
 });

--- a/scripts/ai-harness/test/smoke-image.test.ts
+++ b/scripts/ai-harness/test/smoke-image.test.ts
@@ -162,8 +162,8 @@ describe("end-to-end image-only run against the synthetic corpus", () => {
     await main(["import", "--from", "examples/synthetic-corpus", "--corpus", "image-corpus"], deps);
     await main(["represent", "--corpus", "image-corpus", "--variants", "default,minimal"], deps);
     expect(fs.existsSync(paths.manifest)).toBe(true);
-    // The name says both variants were written, so both are checked — this used to assert only that
-    // the manifest existed, which the import alone would satisfy.
+    // The name says both variants were written, so both are checked. Asserting only that the
+    // manifest exists would be satisfied by the import alone.
     expect(documentIds().length).toBeGreaterThan(0);
     for (const variantId of ["default", "minimal"]) {
       for (const docId of documentIds()) {

--- a/scripts/ai-harness/test/smoke.test.ts
+++ b/scripts/ai-harness/test/smoke.test.ts
@@ -28,8 +28,8 @@ describe("end-to-end smoke run against the synthetic corpus", () => {
       maxCompletionTokens: request.apiRequest.generationSettings.max_completion_tokens
     });
     // One refusal so the report exercises more than the success path. Triggered on the first
-    // request rather than on a particular document's text: the document it used to key off is
-    // empty, and skip-empty means no run sends it any more.
+    // request rather than on a particular document's text: the one that would carry it is empty, and
+    // skip-empty means no run sends an empty document at all.
     if (refusalsRemaining > 0) {
       refusalsRemaining -= 1;
       return {

--- a/scripts/ai-harness/test/smoke.test.ts
+++ b/scripts/ai-harness/test/smoke.test.ts
@@ -92,8 +92,11 @@ describe("end-to-end smoke run against the synthetic corpus", () => {
     const printed = output.join("\n");
     // Not runs × documents: a text-only run sends only the documents that carry student-authored
     // text, and says so about the rest rather than leaving them out of the results.
+    // The product is of runs and documents, and the two figures after it add back up to it — which
+    // `= N call(s)` did not, on any corpus with a skip.
     expect(printed).toContain(
-      `2 run(s) × ${shape.documents.length} document(s) = ${shape.withStudentText.length * 2} call(s), ` +
+      `2 run(s) × ${shape.documents.length} document(s) = ${shape.documents.length * 2} pair(s); ` +
+      `${shape.withStudentText.length * 2} call(s), ` +
       `${(shape.documents.length - shape.withStudentText.length) * 2} skipped.`);
     expect(printed).toContain("max_completion_tokens 1024");
     expect(printed).toMatch(/Worst-case total \(retries included\): \$\d+\.\d+/);

--- a/scripts/ai-harness/test/smoke.test.ts
+++ b/scripts/ai-harness/test/smoke.test.ts
@@ -6,12 +6,15 @@ import { corpusPaths, readRepresentation, representationPath } from "../src/corp
 import { CompletionRequest, CompletionResult } from "../src/execute.js";
 import { ReportSummary } from "../src/report.js";
 import { ResultRow } from "../src/schemas.js";
-import { makeTestDataRoot, readLines } from "./helpers.js";
+import { makeTestDataRoot, readLines, syntheticCorpusShape } from "./helpers.js";
 
 /**
  * import -> represent -> plan -> run -> report, driven through the same argv parsing the CLI uses,
  * with the OpenAI backend replaced by a mock. No network, no API key.
  */
+/** Derived from the committed fixtures, so adding one moves the counts instead of breaking them. */
+const shape = syntheticCorpusShape();
+
 describe("end-to-end smoke run against the synthetic corpus", () => {
   const dataRoot = makeTestDataRoot("smoke");
   const output: string[] = [];
@@ -24,8 +27,10 @@ describe("end-to-end smoke run against the synthetic corpus", () => {
       messages: request.apiRequest.messages,
       maxCompletionTokens: request.apiRequest.generationSettings.max_completion_tokens
     });
-    // One refusal so the report exercises more than the success path.
-    if (refusalsRemaining > 0 && String(JSON.stringify(request.apiRequest.messages)).includes("empty CLUE document")) {
+    // One refusal so the report exercises more than the success path. Triggered on the first
+    // request rather than on a particular document's text: the document it used to key off is
+    // empty, and skip-empty means no run sends it any more.
+    if (refusalsRemaining > 0) {
       refusalsRemaining -= 1;
       return {
         parsed: null,
@@ -60,8 +65,8 @@ describe("end-to-end smoke run against the synthetic corpus", () => {
     await main(["import", "--from", "examples/synthetic-corpus", "--corpus", "smoke-corpus"], deps);
     const manifest = JSON.parse(fs.readFileSync(paths.manifest, "utf8"));
     expect(manifest.schemaVersion).toBe(1);
-    expect(manifest.documents.length).toBe(25);
-    expect(output.join("\n")).toContain("Imported 25 document(s)");
+    expect(manifest.documents.length).toBe(shape.documents.length);
+    expect(output.join("\n")).toContain(`Imported ${shape.documents.length} document(s)`);
   });
 
   it("writes representation envelopes for both text variants", async () => {
@@ -76,35 +81,67 @@ describe("end-to-end smoke run against the synthetic corpus", () => {
   it("reuses fresh representations instead of regenerating them", async () => {
     output.length = 0;
     await main(["represent", "--corpus", "smoke-corpus", "--variants", "default,minimal"], deps);
-    expect(output.join("\n")).toContain("Wrote 0 representation(s), reused 50");
+    // Two variants per document, all of them already fresh.
+    expect(output.join("\n"))
+      .toContain(`Wrote 0 representation(s), reused ${shape.documents.length * 2}`);
   });
 
   it("plans the run without touching the network", async () => {
     output.length = 0;
     await main(["plan", "--corpus", "smoke-corpus", "--experiment", "experiments/text-baselines.json"], deps);
     const printed = output.join("\n");
-    expect(printed).toContain("2 run(s) × 25 document(s) = 50 call(s)");
+    // Not runs × documents: a text-only run sends only the documents that carry student-authored
+    // text, and says so about the rest rather than leaving them out of the results.
+    expect(printed).toContain(
+      `2 run(s) × ${shape.documents.length} document(s) = ${shape.withStudentText.length * 2} call(s), ` +
+      `${(shape.documents.length - shape.withStudentText.length) * 2} skipped.`);
     expect(printed).toContain("max_completion_tokens 1024");
     expect(printed).toMatch(/Worst-case total \(retries included\): \$\d+\.\d+/);
     expect(requests).toHaveLength(0);
   });
 
-  it("runs every pair and writes one JSONL row each", async () => {
+  it("writes one row per pair, sent or skipped, and never leaves a document out", async () => {
     output.length = 0;
     await main(["run", "--corpus", "smoke-corpus", "--experiment", "experiments/text-baselines.json",
       "--max-cost", "1.00"], deps);
     const rows = readLines(resultsFile) as ResultRow[];
-    expect(rows).toHaveLength(50);
-    expect(new Set(rows.map((row) => `${row.docId} ${row.runId}`)).size).toBe(50);
+    // Every (run, document) pair appears exactly once, whether or not it was sent: a document that
+    // simply did not appear would be indistinguishable from a bug.
+    const pairs = shape.documents.length * 2;
+    expect(rows).toHaveLength(pairs);
+    expect(new Set(rows.map((row) => `${row.docId} ${row.runId}`)).size).toBe(pairs);
 
-    // 49, not 50: the image tile contributes nothing to a `minimal` summary, so the image document's
-    // minimal representation is identical to the empty document's — same messages, same request key,
-    // so the second one is served from the cache. That is the cache doing its job.
-    const distinctRequests = new Set(rows.map((row) => row.requestKey));
-    expect(distinctRequests.size).toBe(49);
+    const sent = rows.filter((row) => row.status !== "skipped");
+    const skipped = rows.filter((row) => row.status === "skipped");
+    expect(sent).toHaveLength(shape.withStudentText.length * 2);
+    expect(skipped).toHaveLength((shape.documents.length - shape.withStudentText.length) * 2);
+    // Every skip says why, in terms a reader can act on.
+    for (const row of skipped) {
+      expect(row.status === "skipped" && row.skipReasons.join(" "))
+        .toMatch(/no student content at all|no tile carries student-authored text/);
+    }
+    expect(new Set(sent.map((row) => row.docId))).toEqual(new Set(shape.withStudentText));
+
+    const distinctRequests = new Set(sent.map((row) => row.requestKey));
     expect(requests.length).toBeGreaterThanOrEqual(distinctRequests.size);
-    expect(requests.length).toBeLessThanOrEqual(50);
+    expect(requests.length).toBeLessThanOrEqual(sent.length);
     expect(output.join("\n")).toMatch(/from cache, \d+ API call\(s\)/);
+  });
+
+  it("skips the empty documents for every shape, and says so once per run", async () => {
+    // Acceptance: an empty document is skipped by every message shape, and a visual-only one by a
+    // text-only run. Both classes are present in the committed corpus.
+    const rows = readLines(resultsFile) as ResultRow[];
+    for (const docId of shape.empty) {
+      const forDoc = rows.filter((row) => row.docId === docId);
+      expect(forDoc).toHaveLength(2);
+      for (const row of forDoc) expect(row.status).toBe("skipped");
+    }
+    const visualOnly = shape.withContent.filter((docId) => !shape.withStudentText.includes(docId));
+    expect(visualOnly.length).toBeGreaterThan(0);
+    for (const docId of visualOnly) {
+      expect(rows.filter((row) => row.docId === docId).every((row) => row.status === "skipped")).toBe(true);
+    }
   });
 
   it("builds its messages with the shared production builders", () => {
@@ -125,7 +162,8 @@ describe("end-to-end smoke run against the synthetic corpus", () => {
     await main(["run", "--corpus", "smoke-corpus", "--experiment", "experiments/text-baselines.json",
       "--max-cost", "1.00"], deps);
     expect(requests).toHaveLength(before);
-    expect(output.join("\n")).toContain("50 already complete");
+    // Every pair the first run wrote is resumed, sent and skipped alike.
+    expect(output.join("\n")).toContain(`${shape.documents.length * 2} already complete`);
   });
 
   it("refuses --refresh-cache and --no-cache when resume would silently skip everything", async () => {
@@ -144,7 +182,13 @@ describe("end-to-end smoke run against the synthetic corpus", () => {
     const stale = path.join(dataRoot, "results", "stale-keys.jsonl");
     fs.writeFileSync(stale, fs.readFileSync(resultsFile, "utf8")
       .split("\n").filter((line) => line.length > 0)
-      .map((line) => JSON.stringify({ ...JSON.parse(line), requestKey: `stale-${JSON.parse(line).docId}` }))
+      .map((line) => {
+        const row = JSON.parse(line);
+        // A skipped row has no request key to make stale, and must not be given one.
+        return JSON.stringify(row.status === "skipped"
+          ? row
+          : { ...row, requestKey: `stale-${row.docId}` });
+      })
       .join("\n") + "\n");
     const beforeStale = requests.length;
     await main(["run", "--corpus", "smoke-corpus", "--experiment", "experiments/text-baselines.json",
@@ -179,13 +223,18 @@ describe("end-to-end smoke run against the synthetic corpus", () => {
       fs.readFileSync(path.join(dataRoot, "results", "smoke-corpus__text-baselines.summary.json"), "utf8"),
     ) as ReportSummary;
     expect(fs.existsSync(resultsFile)).toBe(true);
-    expect(summary.rows).toBe(50);
-    const overall = summary.groups.find((group) => group.runId === "(all runs)" && group.modality === "all")!;
-    expect(overall.docs).toBe(25);
-    expect(overall.statuses.success + overall.statuses.refusal).toBe(50);
+    const pairs = shape.documents.length * 2;
+    const sentPairs = shape.withStudentText.length * 2;
+    expect(summary.rows).toBe(pairs);
+    const overall = summary.groups.find((group) =>
+      group.runId === "(all runs)" && group.message === "all" && group.modality === "all")!;
+    expect(overall.docs).toBe(shape.documents.length);
+    // Skipped rows are counted, not dropped: the three statuses account for every pair.
+    expect(overall.statuses.success + overall.statuses.refusal).toBe(sentPairs);
+    expect(overall.statuses.skipped).toBe(pairs - sentPairs);
     expect(overall.statuses.refusal).toBe(1);
     expect(overall.statuses.error).toBe(0);
-    expect(overall.categories.form).toBe(49);
+    expect(overall.categories.form).toBe(sentPairs - 1);
     expect(overall.cost.incurredUsd).toBeGreaterThan(0);
     expect(overall.tokens.total).toBeGreaterThan(0);
 

--- a/shared/ai-analysis-messages.test.ts
+++ b/shared/ai-analysis-messages.test.ts
@@ -1,7 +1,7 @@
 import { ZodArray, ZodEnum, ZodString } from "zod";
 import {
-  Agreements, IAiPrompt, RelatedSummary, buildImageMessages, buildSummaryMessages, buildZodResponseSchema,
-  defaultAiPrompt
+  Agreements, IAiPrompt, RelatedSummary, buildImageMessages, buildMixedMessages, buildSummaryMessages,
+  buildZodResponseSchema, defaultAiPrompt
 } from "./ai-analysis-messages";
 
 const fullPrompt: IAiPrompt = {
@@ -144,6 +144,104 @@ describe("ai-analysis-messages", () => {
         type: "text",
         text: "This is AI generated summary of a similar document:\nFirst related summary."
       });
+    });
+  });
+
+  describe("buildImageMessages with the new optional arguments", () => {
+    it("sends the same message for a bare URL as it did before they existed", () => {
+      // The production call site passes two arguments and nothing else. Its message has to be what
+      // it always was, or every cached analysis is invalidated for no reason.
+      expect(buildImageMessages(fullPrompt, "https://example.com/image.png")).toEqual([
+        { role: "system", content: "You are a master teacher." },
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "Evaluate and categorize this." },
+            { type: "image_url", image_url: { url: "https://example.com/image.png", detail: "auto" } }
+          ]
+        }
+      ]);
+    });
+
+    it("applies a request-wide detail to a bare URL", () => {
+      const content = buildImageMessages(fullPrompt, "https://example.com/a.png", { detail: "low" })[1]
+        .content as any[];
+      expect(content[1].image_url).toEqual({ url: "https://example.com/a.png", detail: "low" });
+    });
+
+    it("sends one part per image, in the order given", () => {
+      const content = buildImageMessages(fullPrompt, [
+        { url: "https://example.com/tile-1.png" },
+        { url: "https://example.com/tile-2.png", detail: "high" }
+      ])[1].content as any[];
+      expect(content).toHaveLength(3);
+      expect(content[1].image_url).toEqual({ url: "https://example.com/tile-1.png", detail: "auto" });
+      expect(content[2].image_url).toEqual({ url: "https://example.com/tile-2.png", detail: "high" });
+    });
+
+    it("lets an image's own detail win over the request-wide one", () => {
+      const content = buildImageMessages(
+        fullPrompt,
+        [{ url: "https://example.com/a.png", detail: "high" }, { url: "https://example.com/b.png" }],
+        { detail: "low" }
+      )[1].content as any[];
+      expect(content.slice(1).map((part: any) => part.image_url.detail)).toEqual(["high", "low"]);
+    });
+
+    it("sends the same message for a one-element array as for that URL alone", () => {
+      expect(buildImageMessages(fullPrompt, [{ url: "https://example.com/a.png" }]))
+        .toEqual(buildImageMessages(fullPrompt, "https://example.com/a.png"));
+    });
+  });
+
+  describe("buildMixedMessages", () => {
+    const related = [makeRelatedSummary("A related summary.", { yes: [{ content: "Agreed.", tags: [] }] })];
+
+    it("is a summary message with the image parts appended", () => {
+      // Stated as a relationship rather than a copy of the expected parts: a mixed message that
+      // worded the text side differently would measure the wording, not the representation.
+      const summaryOnly = buildSummaryMessages(fullPrompt, "The student drew a box.", related);
+      const mixed = buildMixedMessages(
+        fullPrompt, "The student drew a box.", related, "https://example.com/doc.png");
+
+      expect(mixed[0]).toEqual(summaryOnly[0]);
+      const textParts = (summaryOnly[1].content as any[]);
+      const mixedParts = (mixed[1].content as any[]);
+      expect(mixedParts.slice(0, textParts.length)).toEqual(textParts);
+      expect(mixedParts.slice(textParts.length)).toEqual([
+        { type: "image_url", image_url: { url: "https://example.com/doc.png", detail: "auto" } }
+      ]);
+    });
+
+    it("drops the summary and the related summaries when there is no text to send", () => {
+      // A related summary is context for a summary that is not being sent, so it goes too. The
+      // pictures remain, which is the entire reason to ask about such a document.
+      const content = buildMixedMessages(fullPrompt, null, related, "https://example.com/doc.png")[1]
+        .content as any[];
+      expect(content).toEqual([
+        { type: "text", text: "Evaluate and categorize this." },
+        { type: "image_url", image_url: { url: "https://example.com/doc.png", detail: "auto" } }
+      ]);
+    });
+
+    it("appends one image part per image, after the text parts", () => {
+      const content = buildMixedMessages(fullPrompt, "A summary.", [], [
+        { url: "https://example.com/tile-1.png" },
+        { url: "https://example.com/tile-2.png" }
+      ], { detail: "low" })[1].content as any[];
+      expect(content.map((part: any) => part.type))
+        .toEqual(["text", "text", "image_url", "image_url"]);
+      expect(content.slice(2).map((part: any) => part.image_url.detail)).toEqual(["low", "low"]);
+    });
+
+    it("invents no prose about the pictures", () => {
+      const content = buildMixedMessages(
+        fullPrompt, "A summary.", [], "https://example.com/doc.png")[1].content as any[];
+      const texts = content.filter((part: any) => part.type === "text").map((part: any) => part.text);
+      expect(texts).toEqual([
+        "Evaluate and categorize this.",
+        "This is the AI generated summary:\nA summary."
+      ]);
     });
   });
 

--- a/shared/ai-analysis-messages.ts
+++ b/shared/ai-analysis-messages.ts
@@ -65,7 +65,84 @@ export function buildZodResponseSchema(aiPrompt: IAiPrompt) {
   return schema;
 }
 
-export function buildImageMessages(aiPrompt: IAiPrompt, url: string): ChatCompletionMessageParam[] {
+/** How much of an image the provider is asked to look at. `auto` is what it uses when unasked. */
+export type ImageDetail = "low" | "high" | "auto";
+
+/** One image in a request: where to fetch it, and optionally how closely to look at it. */
+export interface ImageInput {
+  url: string;
+  detail?: ImageDetail;
+}
+
+/**
+ * A request-wide default for `detail`, for callers that pass a bare URL.
+ *
+ * An image's own `detail` wins over this, and an absent value on both means `"auto"` — which is what
+ * every caller sent before there was anything to configure, so their messages are unchanged.
+ */
+export interface ImageMessageOptions {
+  detail?: ImageDetail;
+}
+
+/** One `image_url` part per image, in the order given. */
+function imageContentParts(
+  images: string | ImageInput[], options: ImageMessageOptions
+): ChatCompletionContentPart[] {
+  const list = typeof images === "string" ? [{ url: images }] : images;
+  return list.map((image) => ({
+    type: "image_url" as const,
+    image_url: {
+      url: image.url,
+      detail: image.detail ?? options.detail ?? "auto",
+    },
+  }));
+}
+
+/**
+ * The summary part, plus one part per related summary.
+ *
+ * Shared by `buildSummaryMessages` and `buildMixedMessages` so the two cannot drift: a mixed message
+ * has to be a summary message with pictures added, or comparing them measures the wording as much as
+ * the representation.
+ */
+function summaryContentParts(
+  summary: string, relatedSummaries: RelatedSummary[]
+): ChatCompletionContentPart[] {
+  const parts: ChatCompletionContentPart[] = [
+    {
+      type: "text",
+      text: `This is the AI generated summary:\n${summary}`,
+    },
+  ];
+
+  relatedSummaries.forEach((related) => {
+    let text = `This is AI generated summary of a similar document:\n${related.summary}`;
+    const agreementCounts = Object.entries(related.agreements)
+      .map(([value, info]) => `${value}: ${info.length}`)
+      .join(", ");
+    if (agreementCounts.length > 0) {
+      text += `\n\nOther users agreed with this summary as follows: ${agreementCounts}`;
+    }
+    parts.push({
+      type: "text",
+      text,
+    });
+  });
+
+  return parts;
+}
+
+/**
+ * A picture-only request: the prompt, then one part per image.
+ *
+ * `images` may be a single URL, which is how every caller before multi-image capture used it, or an
+ * array. `options.detail` sets a default for images that do not carry their own.
+ */
+export function buildImageMessages(
+  aiPrompt: IAiPrompt,
+  images: string | ImageInput[],
+  options: ImageMessageOptions = {}
+): ChatCompletionMessageParam[] {
   return [
     {
       role: "system",
@@ -78,46 +155,13 @@ export function buildImageMessages(aiPrompt: IAiPrompt, url: string): ChatComple
           type: "text",
           text: aiPrompt.mainPrompt,
         },
-        {
-          type: "image_url",
-          image_url: {
-            url,
-            detail: "auto", // auto, low, high
-          },
-        },
+        ...imageContentParts(images, options),
       ],
     },
   ];
 }
 
 export function buildSummaryMessages(aiPrompt: IAiPrompt, summary: string, relatedSummaries: RelatedSummary[]): ChatCompletionMessageParam[] {
-  const userContent: ChatCompletionContentPart[] = [
-    {
-      type: "text",
-      text: aiPrompt.mainPrompt,
-    },
-    {
-      type: "text",
-      text: `This is the AI generated summary:\n${summary}`,
-    },
-  ];
-
-  if (relatedSummaries.length > 0) {
-    relatedSummaries.forEach((related) => {
-      let text = `This is AI generated summary of a similar document:\n${related.summary}`;
-      const agreementCounts = Object.entries(related.agreements)
-        .map(([value, info]) => `${value}: ${info.length}`)
-        .join(", ");
-      if (agreementCounts.length > 0) {
-        text += `\n\nOther users agreed with this summary as follows: ${agreementCounts}`;
-      }
-      userContent.push({
-        type: "text",
-        text,
-      });
-    });
-  }
-
   return [
     {
       role: "system",
@@ -125,7 +169,50 @@ export function buildSummaryMessages(aiPrompt: IAiPrompt, summary: string, relat
     },
     {
       role: "user",
-      content: userContent,
+      content: [
+        {
+          type: "text",
+          text: aiPrompt.mainPrompt,
+        },
+        ...summaryContentParts(summary, relatedSummaries),
+      ],
+    },
+  ];
+}
+
+/**
+ * Text and pictures in one request: exactly `buildSummaryMessages`, with image parts appended.
+ *
+ * Nothing is said about the images in prose — the message carries the prompt's own parts and the
+ * pictures, and that is all. Anything else would be the harness inventing wording that production
+ * would then have to match.
+ *
+ * `summary` may be `null` for a document with no student-authored text. The summary part and the
+ * related-summary parts both go with it, since a related summary is context for a summary that is
+ * not being sent; the images remain, which is the whole point of asking about such a document.
+ */
+export function buildMixedMessages(
+  aiPrompt: IAiPrompt,
+  summary: string | null,
+  relatedSummaries: RelatedSummary[],
+  images: string | ImageInput[],
+  options: ImageMessageOptions = {}
+): ChatCompletionMessageParam[] {
+  return [
+    {
+      role: "system",
+      content: aiPrompt.systemPrompt,
+    },
+    {
+      role: "user",
+      content: [
+        {
+          type: "text",
+          text: aiPrompt.mainPrompt,
+        },
+        ...(summary === null ? [] : summaryContentParts(summary, relatedSummaries)),
+        ...imageContentParts(images, options),
+      ],
     },
   ];
 }

--- a/shared/ai-summarizer/ai-summarizer-types.ts
+++ b/shared/ai-summarizer/ai-summarizer-types.ts
@@ -83,4 +83,14 @@ export interface AiSummarizerOptions {
   includeModel?: boolean; // If true, include the full JSON model in the output
   minimal?: boolean;      // If true, skip all boilerplate and headers and just return the text content
   tileHandlers?: TileHandler[];
+  /**
+   * How much of each data set to write out.
+   *
+   * `full` (the default, and what every caller got before this existed) describes the data set and
+   * then prints every case as a markdown table. `schema-only` keeps the heading, the attributes
+   * table, the formulas and the case count, and leaves the case data out — the shape of the data
+   * without the data itself. A large table can be most of a document's summary, and whether the
+   * model needs the rows to categorize a design is exactly the sort of thing worth measuring.
+   */
+  dataSetTables?: "full" | "schema-only";
 }

--- a/shared/ai-summarizer/ai-summarizer.test.ts
+++ b/shared/ai-summarizer/ai-summarizer.test.ts
@@ -525,6 +525,68 @@ describe('ai-summarizer', () => {
         expect(result).toContain('1 data set');
       });
 
+      describe('the dataSetTables option', () => {
+        const withData = {
+          rowOrder: ['row1'],
+          rowMap: { row1: { tiles: [{ tileId: 'tile1' }], isSectionHeader: false } },
+          tileMap: { tile1: { id: 'tile1', content: { type: 'Table' } } },
+          sharedModelMap: {
+            dataSet1: {
+              sharedModel: {
+                type: 'SharedDataSet',
+                providerId: 'provider1',
+                dataSet: {
+                  name: 'Sample Data',
+                  attributes: [
+                    { name: 'Name', values: ['Alice', 'Bob'] },
+                    { name: 'Age', values: ['25', '30'] }
+                  ],
+                  cases: [
+                    { Name: 'Alice', Age: '25' },
+                    { Name: 'Bob', Age: '30' }
+                  ]
+                }
+              },
+              tiles: ['tile1']
+            }
+          }
+        };
+
+        it('defaults to the full table, byte for byte what it produced before the option existed', () => {
+          // The option is new; every existing caller passes nothing. If these two ever differ, every
+          // stored summary and every cached analysis built from one is invalidated for no reason.
+          expect(documentSummarizer(withData, { dataSetTables: 'full' }))
+            .toBe(documentSummarizer(withData, {}));
+        });
+
+        it('keeps the schema and the case count but drops the case data', () => {
+          const schemaOnly = documentSummarizer(withData, { dataSetTables: 'schema-only' });
+          // The shape of the data survives: heading, attributes table, and how many cases there are.
+          expect(schemaOnly).toContain('Sample Data');
+          expect(schemaOnly).toContain('| Name |');
+          expect(schemaOnly).toContain('There are 2 cases in this data set.');
+          // The data itself does not.
+          expect(schemaOnly).not.toContain('Alice');
+          expect(schemaOnly).not.toContain('Bob');
+          expect(schemaOnly).not.toContain('shown below in a Markdown table');
+        });
+
+        it('is shorter than the full summary, which is the point of having it', () => {
+          expect(documentSummarizer(withData, { dataSetTables: 'schema-only' }).length)
+            .toBeLessThan(documentSummarizer(withData, {}).length);
+        });
+
+        it('changes nothing for a document with no data sets', () => {
+          const noData = {
+            rowOrder: ['row1'],
+            rowMap: { row1: { tiles: [{ tileId: 'tile1' }], isSectionHeader: false } },
+            tileMap: { tile1: { id: 'tile1', content: { type: 'Table' } } }
+          };
+          expect(documentSummarizer(noData, { dataSetTables: 'schema-only' }))
+            .toBe(documentSummarizer(noData, {}));
+        });
+      });
+
       it('should handle table tiles without shared data sets', () => {
         const content = {
           rowOrder: ['row1'],

--- a/shared/ai-summarizer/ai-summarizer.ts
+++ b/shared/ai-summarizer/ai-summarizer.ts
@@ -295,13 +295,18 @@ export function documentSummary(preamble: string, dataSets: NormalizedDataSet[],
         const tileWord = pluralize(dataSet.tileIds.length, "tile", "tiles");
         const attributeWord = pluralize(dataSet.attributes.length, "attribute", "attributes");
         const caseWord = pluralize(dataSet.numCases, "case", "cases");
+        // `schema-only` stops after the case count: the shape of the data without the data. Every
+        // other caller gets the table, exactly as before.
+        const caseData = options.dataSetTables === "schema-only"
+          ? `There are ${dataSet.numCases} ${caseWord} in this data set.\n`
+          : `There are ${dataSet.numCases} ${caseWord} in this data set, shown below in a Markdown table.\n\n` +
+            `${generateMarkdownTable(dataSet.attributes.map(a => a.name), dataSet.data)}\n`;
         return heading(headingLevel + 2, dataSet.name) +
           `This data set has an id of ${dataSet.id} and is used in ${dataSet.tileIds.length} ${tileWord}.\n` +
           `It contains ${dataSet.attributes.length} ${attributeWord}, described in the following Markdown table.\n\n` +
           `${generateAttributesMarkdownTable(dataSet.attributes)}\n\n` +
           formulaSummary +
-          `There are ${dataSet.numCases} ${caseWord} in this data set, shown below in a Markdown table.\n\n` +
-          `${generateMarkdownTable(dataSet.attributes.map(a => a.name), dataSet.data)}\n`;
+          caseData;
       }).join("\n\n")
     : "";
   const variablsSummary = summary.length > 0 && variables.length > 0

--- a/shared/ai-summarizer/tile-summarizers/handle-drawing-tile-text.test.ts
+++ b/shared/ai-summarizer/tile-summarizers/handle-drawing-tile-text.test.ts
@@ -1,0 +1,111 @@
+import { handleDrawingTileText } from "./handle-drawing-tile-text";
+import { TileHandlerParams } from "../ai-summarizer-types";
+
+/** The handler only reads `tile.model.content`, so a snapshot is all a test needs to supply. */
+const describeDrawing = (content: unknown) =>
+  handleDrawingTileText({ tile: { model: { content } } } as unknown as TileHandlerParams);
+
+describe("handle-drawing-tile-text", () => {
+  it("ignores tiles that are not drawings", () => {
+    expect(describeDrawing({ type: "Text", text: "hello" })).toBeUndefined();
+  });
+
+  it("counts the objects by type and lists each one's geometry", () => {
+    const summary = describeDrawing({
+      type: "Drawing",
+      objects: [
+        { type: "rectangle", x: 10, y: 10, width: 120, height: 60 },
+        { type: "rectangle", x: 20, y: 90, width: 40, height: 40 },
+        { type: "ellipse", x: 160, y: 40, rx: 30, ry: 20 }
+      ]
+    });
+    expect(summary).toContain("3 objects (2 rectangles, 1 ellipse)");
+    expect(summary).toContain("- rectangle at (10, 10), 120×60");
+    expect(summary).toContain("- rectangle at (20, 90), 40×40");
+    // An ellipse carries radii rather than a bounding box, and saying "30×20" would be wrong.
+    expect(summary).toContain("- ellipse at (160, 40), radii 30×20");
+  });
+
+  it("carries a text object's own text, quoted", () => {
+    const summary = describeDrawing({
+      type: "Drawing",
+      objects: [{ type: "text", x: 5, y: 5, width: 100, height: 20, text: "Latch: v2" }]
+    });
+    expect(summary).toContain(`- text at (5, 5), 100×20: "Latch: v2"`);
+  });
+
+  it("describes a vector by its displacement and a line by its point count", () => {
+    const summary = describeDrawing({
+      type: "Drawing",
+      objects: [
+        { type: "vector", x: 0, y: 0, dx: 50, dy: -20 },
+        { type: "line", x: 1, y: 2, deltaPoints: [{ dx: 3, dy: 4 }, { dx: 5, dy: 6 }] }
+      ]
+    });
+    expect(summary).toContain("- vector at (0, 0), 50×-20 from its start");
+    // Three points: the object's own origin, then one per delta.
+    expect(summary).toContain("- line at (1, 2), 3 points");
+  });
+
+  it("says how many objects a group holds", () => {
+    const summary = describeDrawing({
+      type: "Drawing",
+      objects: [{ type: "group", x: 0, y: 0, objects: [{ type: "rectangle" }, { type: "ellipse" }] }]
+    });
+    expect(summary).toContain("- group at (0, 0) containing 2 objects");
+  });
+
+  it("says a drawing is empty rather than describing nothing", () => {
+    expect(describeDrawing({ type: "Drawing", objects: [] }))
+      .toBe("This tile contains a drawing, which is empty.");
+    expect(describeDrawing({ type: "Drawing" }))
+      .toBe("This tile contains a drawing, which is empty.");
+  });
+
+  it("produces the same text every time for the same drawing", () => {
+    // Ordering follows the objects array, so nothing about the description is incidental.
+    const content = {
+      type: "Drawing",
+      objects: [
+        { type: "ellipse", x: 1, y: 1, rx: 2, ry: 3 },
+        { type: "rectangle", x: 4, y: 5, width: 6, height: 7 }
+      ]
+    };
+    expect(describeDrawing(content)).toBe(describeDrawing(JSON.parse(JSON.stringify(content))));
+    // First-appearance order, so the counts read the same way too.
+    expect(describeDrawing(content)).toContain("(1 ellipse, 1 rectangle)");
+  });
+
+  it("survives a snapshot with missing or unexpected fields", () => {
+    // The content is stored data, and a drawing authored by an older build may not carry everything.
+    const summary = describeDrawing({
+      type: "Drawing",
+      objects: [{}, { type: "rectangle" }, { type: "text", x: "no", y: null, text: "" }]
+    });
+    expect(summary).toContain("3 objects");
+    expect(summary).toContain("- object");
+    expect(summary).toContain("- rectangle");
+    // No position it can trust, and no text worth quoting.
+    expect(summary).not.toContain('""');
+  });
+
+  it("rounds sub-pixel positions, which are drag noise", () => {
+    const summary = describeDrawing({
+      type: "Drawing",
+      objects: [{ type: "rectangle", x: 10.4, y: 10.6, width: 120.2, height: 59.7 }]
+    });
+    expect(summary).toContain("- rectangle at (10, 11), 120×60");
+  });
+
+  it("interprets nothing", () => {
+    // The model is the thing being measured on its ability to read a picture. A serializer that
+    // volunteered "a robot arm" would be answering the question instead of asking it.
+    const summary = describeDrawing({
+      type: "Drawing",
+      objects: [{ type: "rectangle", x: 0, y: 0, width: 10, height: 10 }]
+    })!;
+    for (const word of ["looks", "appears", "seems", "probably", "shows a"]) {
+      expect(summary).not.toContain(word);
+    }
+  });
+});

--- a/shared/ai-summarizer/tile-summarizers/handle-drawing-tile-text.ts
+++ b/shared/ai-summarizer/tile-summarizers/handle-drawing-tile-text.ts
@@ -1,0 +1,96 @@
+/**
+ * A text description of a Drawing tile's geometry.
+ *
+ * The default handler says only "This tile contains a drawing", which tells a model nothing about
+ * what the student drew. The other alternative, `documentSummarizerWithDrawings`, renders real SVG
+ * — but it imports `src/plugins/drawing`, which pulls in `.svg` assets that only a bundler can load,
+ * so it cannot run in a Firebase function or under `tsx`. This one is pure: it reads the tile's
+ * content snapshot and nothing else, so it runs everywhere the summarizer does.
+ *
+ * It describes and does not interpret. "A rectangle at (10, 10), 120×60" is a fact about the
+ * snapshot; "a robot arm" is a reading of the picture, and the model is the thing being measured on
+ * its ability to do that. Ordering follows the objects array, so the same document always produces
+ * the same text.
+ *
+ * This is a measurement prototype, not a good description — the point is to have an honest baseline
+ * that a better serializer can be compared against and beat.
+ */
+import { TileHandlerParams } from "../ai-summarizer-types";
+
+interface DrawingObjectSnapshot {
+  type?: unknown;
+  x?: unknown;
+  y?: unknown;
+  width?: unknown;
+  height?: unknown;
+  rx?: unknown;
+  ry?: unknown;
+  dx?: unknown;
+  dy?: unknown;
+  text?: unknown;
+  deltaPoints?: unknown;
+  objects?: unknown;
+}
+
+const isFinite_ = (value: unknown): value is number => typeof value === "number" && Number.isFinite(value);
+
+/** Rounded to whole pixels: sub-pixel precision is drag noise, not something a reader needs. */
+const round = (value: number): string => String(Math.round(value));
+
+function describeSize(object: DrawingObjectSnapshot): string {
+  if (isFinite_(object.width) && isFinite_(object.height)) {
+    return `, ${round(object.width)}×${round(object.height)}`;
+  }
+  // An ellipse carries radii rather than a bounding box.
+  if (isFinite_(object.rx) && isFinite_(object.ry)) {
+    return `, radii ${round(object.rx)}×${round(object.ry)}`;
+  }
+  // A vector is a displacement from its own origin.
+  if (isFinite_(object.dx) && isFinite_(object.dy)) {
+    return `, ${round(object.dx)}×${round(object.dy)} from its start`;
+  }
+  if (Array.isArray(object.deltaPoints)) {
+    // +1: the points are deltas *after* the object's own origin, which is the first vertex.
+    return `, ${object.deltaPoints.length + 1} points`;
+  }
+  return "";
+}
+
+function describeObject(object: DrawingObjectSnapshot): string {
+  const type = typeof object.type === "string" && object.type.length > 0 ? object.type : "object";
+  const at = isFinite_(object.x) && isFinite_(object.y)
+    ? ` at (${round(object.x)}, ${round(object.y)})`
+    : "";
+  // Quoted so an empty string, or one with punctuation, reads as content rather than as prose.
+  const text = typeof object.text === "string" && object.text.length > 0
+    ? `: ${JSON.stringify(object.text)}`
+    : "";
+  const group = Array.isArray(object.objects)
+    ? ` containing ${object.objects.length} ${object.objects.length === 1 ? "object" : "objects"}`
+    : "";
+  return `- ${type}${at}${describeSize(object)}${group}${text}`;
+}
+
+/** "2 rectangles, 1 text", in first-appearance order so the same drawing always reads the same. */
+function countsByType(objects: DrawingObjectSnapshot[]): string {
+  const counts = new Map<string, number>();
+  for (const object of objects) {
+    const type = typeof object.type === "string" && object.type.length > 0 ? object.type : "object";
+    counts.set(type, (counts.get(type) ?? 0) + 1);
+  }
+  return [...counts].map(([type, count]) => `${count} ${type}${count === 1 ? "" : "s"}`).join(", ");
+}
+
+export function handleDrawingTileText({ tile }: TileHandlerParams): string | undefined {
+  const content = tile.model.content as { type?: string; objects?: unknown };
+  if (content.type !== "Drawing") return undefined;
+
+  const objects = (Array.isArray(content.objects) ? content.objects : []) as DrawingObjectSnapshot[];
+  if (objects.length === 0) return "This tile contains a drawing, which is empty.";
+
+  const objectWord = objects.length === 1 ? "object" : "objects";
+  return `This tile contains a drawing with ${objects.length} ${objectWord} ` +
+    `(${countsByType(objects)}). Each object's type, position and size are listed below; ` +
+    "positions are in the drawing's own coordinates.\n\n" +
+    objects.map(describeObject).join("\n");
+}


### PR DESCRIPTION
**Milestone 3** of [CLUE-371](https://concord-consortium.atlassian.net/browse/CLUE-371), against [docs/plans/CLUE-371-harness-implementation-3.md](docs/plans/CLUE-371-harness-implementation-3.md).

Milestone 1 built the harness, a synthetic corpus, text-only runs, the response cache and the spend ceiling. Milestone 2 added the screenshot, so image-only baselines could run against the same corpus. **This milestone adds text and picture together, plus the dimensions an experiment needs to turn around it.**

## What it adds

| | |
|---|---|
| **Mixed messages** | `buildMixedMessages` in `shared/`, and a `mixed` message shape end to end |
| **Image detail** | `low` / `high` / `auto`, a request-level dimension |
| **Image sets** | `full-document`, `per-tile`, `visual-tiles-only` |
| **Extras** | `extras-fixed`, `extras-production-current`, `no-extras` |
| **Skip-empty** | A run declines documents it has nothing to say about, and records why |
| **Two text variants** | `no-dataset-tables`, and a pure Drawing serializer |
| **Accurate-height Shutterbug** | Captures each document at its own measured height |
| **Render flags** | `--concurrency`, and `--timeout-ms` on the modes that keep a per-document budget |

`shared/` changes are additive and byte-identical for every existing call shape — `buildImageMessages` still accepts a bare URL, and `buildSummaryMessages` and `buildMixedMessages` now share one `summaryContentParts` so a mixed message cannot drift from a summary message with pictures added. `functions-v2` is unaffected.

## Verified against the real thing

All 26 fixtures rendered against a real dev server and real headless Chromium in both capture modes, then a real `mixed-vs-baselines` run — followed by a re-render and partial re-run after a fix found in review:

```
run     234 row(s): 138 sent (61 from cache, 77 API calls), 96 skipped.
        Reserved at peak $0.2198 of a $1.1000 ceiling; actually spent $0.1570.
run     18 row(s): 216 already complete, 3 from cache, 15 API call(s).   ← after the fix
        Reserved at peak $0.0562 of a $0.3000 ceiling; actually spent $0.0313.
report  252 row(s) read; 234 current, 18 superseded by a later re-run.
```

Findings recorded in the README, with the confounds named:

- **The image-token estimate holds.** 98.6% of billed prompt tokens in `image-puppeteer`, 98.9% per-tile (467,511 of 472,847), 98.4% visual-tiles-only. `detail-low` is the loosest at 92.4%, which is arithmetic rather than error — a low-detail image is a flat 2833 tokens, so fixed prompt text is a larger share of a smaller total.
- **The extras bug is priced.** Same 7 documents, same prompt: `no-extras` 3,725 prompt tokens, `extras-fixed` 3,895, `extras-production-current` 4,537. The three differ on exactly the two documents with `relatedSummaries`, and that 642-token gap is spike finding 6a (CLUE - 630) reproduced and measured — it re-sends the analyzed document's own summary in place of each related one.
- **Per-tile cost scales with tile count, not document size.** Median 14,399 prompt tokens, but 141,902 for the ten-tile `tall` fixture. Budget for the widest document, not the typical one.
- **First evidence for the mixed hypothesis, and it is thin.** Skip-empty means text and image runs no longer send the same documents, so the only fair comparison is the 7 they both send. There, mixed reproduced text-only's category on all 7 while image-only lost 3 to `unknown`. n=7 on one- and two-tile synthetic fixtures. **This establishes that the pipeline works and what it costs — not that any representation is better.** That needs milestone 5's rubric and real documents.

## Three fixtures were lying, and two of them silently

**`graph` had never rendered.** CLUE was showing its error page, and a 164 KB screenshot of that error page had been stored as a valid render since milestone 2. Bisected to the fixture: `AxisModel` requires `place`, and the axis union dispatches on `type` — the fixture had neither. It renders at 944×510 now, and the local backend gained a check for CLUE's own error screen (`.document-error` fails the render before the capture), a third fatal condition alongside page errors and failed script loads.

**`question` was snapshotted three times.** A per-tile capture used `.tool-tile`, which matches nested tiles too — so the one top-level Question tile produced three pictures, two of them content the outer picture already contained. Found in review; the selector is now `.tool-tile:not(.tool-tile .tool-tile)`, checked against a real Chromium.

Nothing could have caught it: the fake browser returns a fixed element list whatever selector it is handed, and `local-render.integration.ts` only ever rendered `puppeteer-full-height`. It now makes a per-tile pass as well — `question` must give one image, `mixed` two.

**`tall` was not tall.** Added to cover the frame-resize path, it measured 944×500, because paragraphs overflow *inside* a tile rather than growing the row. Ten rows with explicit heights; 944×1280 now.

**`error-test` is un-renderable on purpose**, which meant every render of the example corpus reported a failure that was the fixture doing its job. A corpus can now mark a document `expectedRenderFailure`, counted separately so the exit code keeps meaning something, evidence still written, and a warning if it unexpectedly succeeds.

## Review notes

- **`DEVIATIONS` was re-verified against the code**, not re-read. Three entries had drifted and two departures were unrecorded. Worth reading if you're checking spec conformance.
- **Result rows stay `schemaVersion: 2`** — every added field is additive, and a bump would invalidate milestone-2 files to describe rows they cannot contain. DEVIATION 26 records why.
- **`--timeout-ms` is refused by the Shutterbug modes** rather than accepted and dropped. A hosted mode bounds its request and its download separately, with retries around them, and has no whole-document deadline to give a budget to.
- **Three fixtures do not render deterministically.** `data-card`, `dataflow` and `graph` produce different pixels on every render — 15 of the 18 rows re-run above. It makes the cache useless for them and means any `--refresh` re-spends. Recorded in the README; the cause is worth its own look.
- **`experiments/mixed-vs-baselines.json`** runs the whole comparison from one file; the older `image-vs-text.json` stays as milestone 2's narrower one.


[CLUE-371]: https://concord-consortium.atlassian.net/browse/CLUE-371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ