### PR TITLE
feat: AI harness milestone 4 (CLUE-371)

### DIFF
--- a/scripts/ai-harness/README.md
+++ b/scripts/ai-harness/README.md
@@ -706,6 +706,14 @@ experiment file — so the report needs that file, and refuses unless its hash e
 corpus named in the rows has to be on this machine too, since the summaries and pictures come from
 it.
 
+The header lists every run in experiment-file order with its configuration and its prompt's name
+and hash. A run whose current rows carry **more than one** prompt hash is flagged rather than
+summarised: a prompt file's content is not part of the experiment hash but is part of the request
+key, so editing a prompt and re-running into the same results file re-runs every pair — and a re-run
+that stops early leaves some pairs on the new prompt and some on the old. The header then says how
+many versions there are and each card names its own, because those cards are not all comparable with
+each other.
+
 Each document's outputs are one card per run in experiment-file order: the recognized response
 fields (category, key indicators, discussion — all optional in the prompt schema, so whichever exist
 are shown and anything else is printed as JSON), or a refusal, or an error with its attempt count,

--- a/scripts/ai-harness/README.md
+++ b/scripts/ai-harness/README.md
@@ -748,6 +748,13 @@ Three properties are deliberate:
   screenshot with last week's output, even with a warning, invites a judgement about the wrong
   thing.
 
+  A row's `imageSha256s` records **every** picture its envelope holds, because that is the render's
+  provenance, and `imageSet` says which of them the run sent — so the report re-applies the set
+  through `imagesForSet`, the same function execution selects with, and the two cannot disagree
+  about what a set means. `visual-tiles-only` is the one set whose membership is not structural: it
+  is the tiles the classifier marked, so reconstructing it means classifying the same content the
+  run classified. A document edited since gets a notice rather than a confident wrong answer.
+
   The notice text comes from a fixed vocabulary rather than from the underlying error, because those
   errors carry absolute paths (which hold the corpus and document id), image filenames (which hold
   the document id) and freshness reasons (which name the mode, backend and version). The unredacted

--- a/scripts/ai-harness/README.md
+++ b/scripts/ai-harness/README.md
@@ -822,7 +822,11 @@ later read.
 Both sidecars are named from the **resolved** output path, `--out` included, so no two reports can
 collide on a key. The rules around them:
 
-- Every collision is checked **before anything is written** — a refused run leaves nothing behind.
+- Every collision is checked **before anything is written** — a refused run leaves nothing behind —
+  and the checks do not depend on the mode. With `--out` the mode is not in the filename, so the
+  sidecars beside a path are the only record of what that path is for: a plain report over a
+  blinded one's `--out` is refused rather than replacing a judge's page with an unredacted one and
+  leaving the key decoding a page that no longer exists.
 - An existing key is never overwritten. Without `--reuse-key`, its existence is an error: silently
   rotating a key orphans every rating already written against the old labels.
 - `--reuse-key` reads and validates the existing key and never rewrites it. Reuse is refused if the

--- a/scripts/ai-harness/README.md
+++ b/scripts/ai-harness/README.md
@@ -1102,12 +1102,15 @@ Milestone 4 (against
     produced with — required and hash-checked, because the run list, `detail`, `imageSet` and
     `extras` exist nowhere else — and the corpus tree, for the summaries and pictures. `report`
     stays "reports as data"; this is a document for humans.
-32. **A blinded report withholds skip reasons rather than printing them.** The spec has skipped
-    outcomes rendering with their `skipReasons` in every mode, and separately requires that no run
-    configuration appear in a blind report. Those conflict: a skip reason names the shape and
-    settings of the run that declined ("image-only run with imageSet `visual-tiles-only`: …"), which
-    is a configuration standing beside labelled cards. Blind mode keeps the strip and the count and
-    says the reasons are withheld; every other mode prints them.
+32. **A blinded *or shareable* report withholds skip reasons rather than printing them.** The spec
+    has skipped outcomes rendering with their `skipReasons` in every mode, and separately requires
+    that no run configuration appear in a blind report and no document identifier in a shareable
+    one. Both conflict, because a skip reason is not a fixed vocabulary: it names the shape and
+    settings of the run that declined ("image-only run with imageSet `visual-tiles-only`: …"), and
+    it carries whatever `imagesForSet` and `expectedRenderFailure` put in it — up to five tile ids
+    and a line of author-written prose. A tile id contains the document id outright in this corpus,
+    so a shareable report printed `wave-runner-tile` under the heading `doc-02`. Both modes keep the
+    strip and the count and say the reasons are withheld; the team-internal report prints them.
 33. **`--shareable` also drops tile ids and representation warnings.** The spec lists the fields to
     omit — document ids, unit, investigation, problem, `contextId`, source, file paths, render-target
     URLs, git commit — and tile ids are not among them. In this corpus a tile id contains the

--- a/scripts/ai-harness/README.md
+++ b/scripts/ai-harness/README.md
@@ -737,9 +737,11 @@ Three properties are deliberate:
   `data:` URLs, no external reference of any kind. A `Content-Security-Policy` meta tag
   (`default-src 'none'; img-src data:; style-src 'unsafe-inline'`) is there as defence in depth —
   with no script and no external loads it should be redundant, and it exists so that a bug in the
-  escaping still cannot reach the network. Embedded pictures make the file large (1.3 MB for the
+  escaping still cannot reach the network. Embedded pictures make the file large (1.4 MB for the
   synthetic corpus; a real capture is far bigger). Accepted for now: legibility is one of the things
-  under judgement, so nothing is downscaled.
+  under judgement, so nothing is downscaled. Reading a report also hashes every picture twice — once
+  in the freshness check, once to prove the bytes on the page are the bytes that were sent — which
+  is nothing at 26 documents and worth revisiting for a production corpus.
 - **An input is shown only if it is still the input that was sent.** A representation is displayed
   when its *whole* descriptor matches — variant id, variant version and source content hash for a
   summary; mode, backend, backend version, source content and every recorded image hash for a
@@ -837,7 +839,10 @@ collide on a key. The rules around them:
   invocation, **if any outcome it labels has been re-run since it was written**, if its pseudonyms
   are not the ones the report renders, or if its labels are not
   exactly one per outcome — same inputs, same labels and pseudonyms, or nothing. The report is
-  rendered from the key's own mapping, so a `--reuse-key` run regenerates byte-identical HTML.
+  rendered from the key's own mapping, so a `--reuse-key` run puts every card back under the label
+  the judge saw. The page is not byte-identical: its `Generated` timestamp is the time it was
+  regenerated, and the superseded count moves if the results file has grown since. The tests pin
+  byte-identity under an injected clock, which is the only condition it holds under.
 - Under `--reuse-key` an existing ratings template is preserved byte for byte; it may hold a judge's
   half-entered answers. The template is written only when there is none.
 
@@ -1120,7 +1125,18 @@ Milestone 4 (against
     document id outright (`wave-runner-tile`), so printing one beside `doc-26` would undo the
     pseudonym; the same goes for a row's `representationWarnings`, which name the tiles a capture
     missed. Both are shown in the team-internal report.
-34. **`--out` must name a `.html` file.** The spec does not constrain it. Both sidecars are named
+34. **`visual-tiles-only` inputs are reconstructed, not verified.** A row records `imageSha256s` —
+    every picture its envelope held, which is the render's provenance — and `imageSet`, but not the
+    hashes it actually sent. For `full-document` and `per-tile` the set is structural, so re-applying
+    it reproduces exactly what went; for `visual-tiles-only` the membership is the classifier's, and
+    the report classifies the document again to recover it. Flipping `requiresVisualRepresentation`
+    for a tile type in `src/capability.ts` would therefore change which pictures a *past* run is
+    shown as having sent, with no notice — the newly selected picture is still among the recorded
+    hashes, so nothing on the row can catch it. Closing it means recording what was sent (a
+    `sentImageSha256s` on the descriptor, optional for existing rows), which changes what a run
+    writes and is out of scope for a milestone that is a renderer. Worth doing before a judging
+    round rides on a `visual-tiles-only` comparison.
+35. **`--out` must name a `.html` file.** The spec does not constrain it. Both sidecars are named
     from the resolved output path, so an `--out` with another extension would produce a key whose
     name the next invocation could not predict — and predicting it is how a key is found and not
     overwritten.

--- a/scripts/ai-harness/README.md
+++ b/scripts/ai-harness/README.md
@@ -802,9 +802,16 @@ recovered from the HTML plus this repository — and with it, regeneration is ex
 `--shareable` and `--blind` each write **one** key file, `<output-html-basename>.key.json`, and
 blind+shareable writes a single combined one rather than two sidecars racing for a path. It records
 the schema version, corpus, experiment hash, which flags produced the report, the documents in
-presentation order, the exact judgeable (document, run) set, the pseudonyms, the seed and the
-label→run mapping. It is validated on read like every other on-disk format. A plain report writes no
-sidecars at all.
+presentation order, the judgeable outcomes, the pseudonyms, the seed and the label→run mapping. It
+is validated on read like every other on-disk format. A plain report writes no sidecars at all.
+
+Each judgeable outcome is recorded as (document, run) **plus a fingerprint** of the row the label was
+put on — its request, its representation and its answer. The pair alone does not identify an
+outcome: a re-run appends a replacement row for the same pair, so without the fingerprint a
+`--reuse-key` regeneration would accept the new answer, keep the old label on it, and preserve a
+ratings template whose scores were given to the answer it replaced. The fingerprint deliberately
+excludes `runMeta`, `usage` and `cost`, so a re-run served from the cache — which changes all three
+and changes nothing a judge read — is still reusable.
 
 Blind modes also write `<output-html-basename>.ratings-template.csv`: one row per (document, label)
 over the judgeable cards, columns `document,label,rating,notes`, values empty, using the pseudonym
@@ -820,7 +827,8 @@ collide on a key. The rules around them:
   rotating a key orphans every rating already written against the old labels.
 - `--reuse-key` reads and validates the existing key and never rewrites it. Reuse is refused if the
   key's corpus, experiment hash, mode flags, document set or judgeable run set differs from this
-  invocation, if its pseudonyms are not the ones the report renders, or if its labels are not
+  invocation, **if any outcome it labels has been re-run since it was written**, if its pseudonyms
+  are not the ones the report renders, or if its labels are not
   exactly one per outcome — same inputs, same labels and pseudonyms, or nothing. The report is
   rendered from the key's own mapping, so a `--reuse-key` run regenerates byte-identical HTML.
 - Under `--reuse-key` an existing ratings template is preserved byte for byte; it may hold a judge's

--- a/scripts/ai-harness/README.md
+++ b/scripts/ai-harness/README.md
@@ -765,9 +765,12 @@ Three properties are deliberate:
 
 Replaces document ids with per-report pseudonyms (`doc-01`… numbered in **presentation** order, so
 the key and the ratings template read down the page rather than across it) and omits harness
-metadata: unit,
-investigation, problem, `contextId`, source, file paths, tile ids, the results path and the harness
-commit. Run configurations and prompt name/hash stay — they are what a reader is judging.
+metadata: unit, investigation, problem, `contextId`, source, file paths, tile ids, skip reasons, the
+results path, the harness commit and **the corpus name** — that last one is free-form and chosen by
+whoever ran `import --corpus <name>`, so a production pull could easily be named after a class or a
+school. The heading falls back to the experiment name, and the key file still records the corpus, so
+nothing about decoding changes. Run configurations and prompt name/hash stay — they are what a
+reader is judging.
 
 **The flag removes harness metadata identifiers; it does not anonymize or redact document content.**
 The summaries, pictures and model outputs are shown as they are, and can themselves identify

--- a/scripts/ai-harness/README.md
+++ b/scripts/ai-harness/README.md
@@ -4,15 +4,16 @@ A checked-in tool that runs (representation × prompt × message-shape) experime
 CLUE documents and reports quality inputs plus token and cost numbers — so text-only vs. image-only
 vs. mixed-mode claims are backed by measurements instead of intuition.
 
-This is **milestone 3** of [CLUE-371](../../docs/plans/CLUE-371-harness-plan.md). Milestone 1 built
+This is **milestone 4** of [CLUE-371](../../docs/plans/CLUE-371-harness-plan.md). Milestone 1 built
 the shared message builders, the harness skeleton, a synthetic corpus, text-only runs, the response
 cache, the spend ceiling, and reports as data. Milestone 2 added the other production representation
-— the screenshot — so image-only baselines could run against the same corpus. Milestone 3 adds the
+— the screenshot — so image-only baselines could run against the same corpus. Milestone 3 added the
 message the whole question is about, text **and** picture together, plus the dimensions an
 experiment needs to turn around it: image detail, per-tile and visual-tiles-only image sets, the
-extras settings, two new text variants, and skip-empty execution. The HTML review report
-(milestone 4), rubric scoring (milestone 5) and the production corpus pull (milestone 6) are not
-here yet.
+extras settings, two new text variants, and skip-empty execution. Milestone 4 adds the `review`
+command: the side-by-side HTML report a human judge reads, with a `--shareable` mode for reports
+that leave the team and a `--blind` mode for the judging round milestone 5 will run. Rubric scoring
+(milestone 5) and the production corpus pull (milestone 6) are not here yet.
 
 All runs target `gpt-4o-mini`. That is deliberately the rolling alias, not a pinned snapshot:
 production calls the alias, and a harness that pinned a snapshot would stop measuring what production
@@ -77,6 +78,7 @@ OPENAI_API_KEY=sk-…
 | `plan` | no | no | Validates everything and prints the expanded run list and worst-case cost. |
 | `run` | **yes** | **yes** | The only command that calls OpenAI. `--max-cost` is required. |
 | `report` | no | no | Reads a results JSONL file and writes `<basename>.summary.json` beside it. |
+| `review` | no | no | Renders the side-by-side HTML review report from a results file, its experiment file and the corpus. |
 
 ```bash
 npx tsx harness.ts import    --from examples/synthetic-corpus --corpus synthetic-corpus \
@@ -90,6 +92,9 @@ npx tsx harness.ts plan      --corpus synthetic-corpus --experiment experiments/
 npx tsx harness.ts run       --corpus synthetic-corpus --experiment experiments/text-baselines.json \
                              --max-cost 0.50 [--output <file>] [--no-cache | --refresh-cache]
 npx tsx harness.ts report    --results data/results/synthetic-corpus__text-baselines.jsonl
+npx tsx harness.ts review    --results data/results/synthetic-corpus__text-baselines.jsonl \
+                             --experiment experiments/text-baselines.json \
+                             [--out <file>.html] [--shareable] [--blind] [--reuse-key]
 ```
 
 Flags are plain `--name value` pairs. An unknown flag is an error, not a warning.
@@ -117,6 +122,12 @@ stands.
   corpora arrive: delete them when the experiment concludes, keep document ids and Firestore paths
   out of anything that leaves the team, and remember that injected related-summaries data contains
   *other* students' work.
+- **`review --shareable` removes harness metadata identifiers; it does not anonymize or redact
+  document content.** Document ids become per-report pseudonyms and the unit, investigation,
+  problem, `contextId`, source, file paths and tile ids are omitted — but the summaries, pictures
+  and model outputs are shown as they are, and a student who typed their name into a text tile is
+  still named. Whether a particular report may leave the team is a human judgement made when it is
+  sent. See "Review report".
 - Milestones 1 and 2 touch no production data, no credentials, and no `firebase-admin`.
 
 ## Concepts
@@ -404,20 +415,40 @@ alone would never fire.
 
 ### What the synthetic corpus cannot show you yet
 
-Two fixture-level problems surfaced when the corpus was first rendered for real. Both are deferred —
-they are corpus changes, and editing a fixture changes its content hash, forcing a re-render and a
-re-run — but they bound what an image-mode result on this corpus means.
+Two fixture-level problems surfaced when the corpus was first rendered for real. The first is fixed;
+the second is deferred, and still bounds what an image-mode result on this corpus means.
 
-- **Text tiles authored with `format: "markdown"` render blank.** `src/models/tiles/text/text-content.ts`
-  returns `[]` for that format, behind an explicit `// TODO: figure out what to do about markdown`.
-  Most fixtures use it, so the text summarizer sees full content where image mode sees an empty
-  tile. `text` and `adversarial-text` render byte-identically as a result, which also means the
-  adversarial fixture's whole point — that student text containing `</script>` must not break the
-  render — cannot be observed through the image path. The generated HTML is still covered by unit
-  tests and a snapshot.
+- **Fixed in milestone 4: text tiles authored with `format: "markdown"` rendered blank.**
+  `src/models/tiles/text/text-content.ts` returns `[]` for that format, behind an explicit
+  `// TODO: figure out what to do about markdown`, so CLUE drew an empty tile while the summarizer —
+  which reads the `text` property directly — saw the full content. Four fixtures used it, and the
+  review report made the consequence impossible to miss: an image run was categorizing a blank
+  rectangle on `text`, `adversarial-text`, `mixed` and `question`, and the first two rendered
+  byte-identically.
+
+  `text`, `mixed` and `question` are now `format: "html"`, matching `tall` and the format real CLUE
+  content overwhelmingly uses (3,654 Text tiles across this repository, against 68 markdown).
+  `adversarial-text` carries **no** `format` at all, so it renders as plain text: authoring it as
+  HTML would let CLUE interpret the `<b>bold</b>` and `<img onerror=…>` its whole point is to carry
+  through as characters. It now renders every one of those characters visibly.
+
+  This is *not* a fix to the markdown blank spot itself, which is production's to make (or not); it
+  is the corpus no longer standing on it. A document authored as markdown still renders blank, so a
+  production corpus containing one would hit this again — and the numbers below show what it costs,
+  because they moved when the fixtures changed.
 - **An unregistered tile renders invisibly.** `empty` and `unknown` produce byte-identical PNGs, so
   image mode cannot tell an empty document from one containing an unregistered tile — even though
-  the render diagnostics correctly count `unknownTiles: 1` for the latter.
+  the render diagnostics correctly count `unknownTiles: 1` for the latter. Still deferred: it is a
+  corpus change, and editing a fixture forces a re-render and a re-run.
+
+**A dev server that will not compile silently poisons every render.** webpack-dev-server injects its
+error overlay *inside* the CLUE iframe, on top of the document, so the capture is a picture of a red
+error screen with the document behind it. Nothing catches this: the tiles really are in the DOM, so
+the tile-count diagnostics pass and `render` reports success. It happened during the milestone-4
+re-render — a type error on `master` (CLUE-616, `brainwaves-gripper.tsx`) put the overlay over all
+25 documents. Run the dev server with `--no-client-overlay`, and look at a picture or two before
+trusting a batch. A backend check for the overlay element would close it properly, and belongs with
+the other fatal-condition checks in `src/backends/puppeteer.ts`.
 
 ### Data leaving the machine
 
@@ -616,8 +647,9 @@ API-reported usage is authoritative for final numbers.
 ### Results and reports
 
 Result rows are a discriminated union on `status` (`success`, `refusal`, `error`, `skipped`), all
-sharing the same identifying fields. `skipped` ships now but is unused: skip-empty *execution*
-is written by skip-empty execution. `report` handles all four statuses exhaustively and writes
+sharing the same identifying fields. A `skipped` row is written by skip-empty execution, for every
+(run, document) pair a run declines to send — see "Which documents a run declines to send".
+`report` handles all four statuses exhaustively and writes
 `<results-basename>.summary.json` next to the results file — named after it, because a single
 `summary.json` per directory meant every experiment in `data/results/` shared one path and reporting
 on one silently overwrote another's. Groups are per run configuration × message shape × modality,
@@ -653,7 +685,131 @@ naming the file and the field. The versions are not all the same number:
 |---|---|
 | Result rows (`data/results/*.jsonl`) | **2** — see above |
 | Corpus manifest, text representation envelopes, image envelopes | 1 |
-| Prompt files, experiment files, report summaries, cache entries | 1 |
+| Prompt files, experiment files, report summaries, cache entries, review key files | 1 |
+
+### Review report
+
+`review` writes the document a human judge reads: **one section per document**, showing the input
+each run was given — the picture(s) and the summary — beside what every run said about it. `report`
+answers aggregate questions; this answers "for this document, which output is better?".
+
+```bash
+npx tsx harness.ts review --results data/results/mixed-run__mixed-vs-baselines.jsonl \
+                          --experiment experiments/mixed-vs-baselines.json \
+                          [--out <file>.html] [--shareable] [--blind] [--reuse-key]
+```
+
+`--experiment` is **required and hash-checked**. Result rows do not carry `detail`, `imageSet` or
+`extras`, a skipped row carries no representation descriptor at all, and run order lives in the
+experiment file — so the report needs that file, and refuses unless its hash equals every row's
+`experimentSha256`. A name match is not enough: an experiment file can be edited after a run. The
+corpus named in the rows has to be on this machine too, since the summaries and pictures come from
+it.
+
+Each document's outputs are one card per run in experiment-file order: the recognized response
+fields (category, key indicators, discussion — all optional in the prompt schema, so whichever exist
+are shown and anything else is printed as JSON), or a refusal, or an error with its attempt count,
+plus tokens, modeled cost and whether the answer came from the cache. A mixed row whose text half was
+dropped is flagged prominently, because that output saw half the input. **Skipped outcomes go in
+their own strip below the cards**, with their reasons: a skipped run produced no feedback to judge.
+
+Three properties are deliberate:
+
+- **Everything student-authored is escaped, everywhere.** Document text reaches the page through
+  summaries, through model outputs that quote it, through refusals and through error messages. One
+  escape function handles all of it: markup is built with a tagged template that escapes every
+  interpolated value unless it is already an escaped fragment, so forgetting is not something the
+  renderer can do by omission. Summaries are rendered as preformatted text, never as interpreted
+  markdown — markdown rendering of student text is markup injection with extra steps. The line and
+  paragraph separators (U+2028, U+2029) are escaped as numeric references as well: they are ordinary
+  characters in HTML and a browser decodes them back, so the page is unchanged, but a file holding
+  them raw is one editors report as having unusual line terminators. Student text does contain
+  them — the `adversarial-text` fixture has one of each.
+- **Self-contained and inert.** One HTML file: inline CSS, **no JavaScript**, images embedded as
+  `data:` URLs, no external reference of any kind. A `Content-Security-Policy` meta tag
+  (`default-src 'none'; img-src data:; style-src 'unsafe-inline'`) is there as defence in depth —
+  with no script and no external loads it should be redundant, and it exists so that a bug in the
+  escaping still cannot reach the network. Embedded pictures make the file large (1.3 MB for the
+  synthetic corpus; a real capture is far bigger). Accepted for now: legibility is one of the things
+  under judgement, so nothing is downscaled.
+- **An input is shown only if it is still the input that was sent.** A representation is displayed
+  when its *whole* descriptor matches — variant id, variant version and source content hash for a
+  summary; mode, backend, backend version, source content and every recorded image hash for a
+  render, with the bytes on disk re-hashed. Anything else renders a "no longer available / no longer
+  matches this run" notice, and the current file is **not** shown in its place. Pairing today's
+  screenshot with last week's output, even with a warning, invites a judgement about the wrong
+  thing.
+
+  The notice text comes from a fixed vocabulary rather than from the underlying error, because those
+  errors carry absolute paths (which hold the corpus and document id), image filenames (which hold
+  the document id) and freshness reasons (which name the mode, backend and version). The unredacted
+  detail is appended **only** in the team-internal report, where it is what makes the notice
+  actionable.
+
+#### `--shareable`
+
+Replaces document ids with per-report pseudonyms (`doc-01`… numbered in **presentation** order, so
+the key and the ratings template read down the page rather than across it) and omits harness
+metadata: unit,
+investigation, problem, `contextId`, source, file paths, tile ids, the results path and the harness
+commit. Run configurations and prompt name/hash stay — they are what a reader is judging.
+
+**The flag removes harness metadata identifiers; it does not anonymize or redact document content.**
+The summaries, pictures and model outputs are shown as they are, and can themselves identify
+someone — a student typing their name into a text tile, a photograph of a worksheet. Deciding
+whether a particular corpus may leave the team is a human judgement made when the file is sent, and
+the report says so on its own front page.
+
+#### `--blind`
+
+What milestone 5's judging round consumes. Per document, the judgeable cards (success, refusal,
+error) are shuffled and labelled `A`, `B`, `C`…, with everything identifying the producing run
+hidden: run id, representation labels, detail, image set, extras, variant, tokens, cost and cache
+status. Status stays visible — a refusal is an outcome worth rating. The header's run list becomes a
+run *count*, since a list of configurations beside labelled cards is a decoding aid, and skipped
+outcomes stay in their strip, unlabelled and with their reasons withheld (a reason names the shape
+and settings of the run that declined). The inputs block still shows every picture and summary the
+document's runs used, without the labels naming which mode or variant produced them: the judge needs
+the document; what is hidden is which output came from which configuration.
+
+**The blinding removes labels, not language.** An output can still betray its own mode by what it
+says — "the picture shows…" comes from a run that was given a picture. Worth knowing before reading
+a judging round as if it were airtight.
+
+**Ordering is seeded, and the seed is secret.** Each card's position comes from
+`HMAC(seed, docId + runId)`, with 32 fresh random bytes generated at report time and stored **only**
+in the key file. A seedless hash of the row data would be reconstructible by anyone who reads
+`blindLabelsFor`; `Math.random()` would not regenerate. Without the key file the mapping cannot be
+recovered from the HTML plus this repository — and with it, regeneration is exact.
+
+#### The key file, the ratings template, and their rules
+
+`--shareable` and `--blind` each write **one** key file, `<output-html-basename>.key.json`, and
+blind+shareable writes a single combined one rather than two sidecars racing for a path. It records
+the schema version, corpus, experiment hash, which flags produced the report, the documents in
+presentation order, the exact judgeable (document, run) set, the pseudonyms, the seed and the
+label→run mapping. It is validated on read like every other on-disk format. A plain report writes no
+sidecars at all.
+
+Blind modes also write `<output-html-basename>.ratings-template.csv`: one row per (document, label)
+over the judgeable cards, columns `document,label,rating,notes`, values empty, using the pseudonym
+when the report is shareable. Milestone 5 defines the rubric and the command that reads the filled
+file back; this milestone only guarantees the judge has somewhere to write answers a program can
+later read.
+
+Both sidecars are named from the **resolved** output path, `--out` included, so no two reports can
+collide on a key. The rules around them:
+
+- Every collision is checked **before anything is written** — a refused run leaves nothing behind.
+- An existing key is never overwritten. Without `--reuse-key`, its existence is an error: silently
+  rotating a key orphans every rating already written against the old labels.
+- `--reuse-key` reads and validates the existing key and never rewrites it. Reuse is refused if the
+  key's corpus, experiment hash, mode flags, document set or judgeable run set differs from this
+  invocation, if its pseudonyms are not the ones the report renders, or if its labels are not
+  exactly one per outcome — same inputs, same labels and pseudonyms, or nothing. The report is
+  rendered from the key's own mapping, so a `--reuse-key` run regenerates byte-identical HTML.
+- Under `--reuse-key` an existing ratings template is preserved byte for byte; it may hold a judge's
+  half-entered answers. The template is written only when there is none.
 
 ### Version lockstep
 
@@ -685,6 +841,7 @@ src/cache.ts               response cache
 src/cost.ts                pricing, estimation, reservation ledger
 src/execute.ts             run expansion, OpenAI calls, concurrency, retries, JSONL writer
 src/report.ts              summary tables from result JSONL
+src/review.ts              the side-by-side HTML review report, its escaping, key and blinding
 prompts/                   prompt files with provenance
 experiments/               experiment definitions
 examples/synthetic-corpus/ committed fixtures + expectations.json (no manifest — import makes it)
@@ -908,6 +1065,33 @@ Milestone 3 (against
     reports it as "nothing to capture" and writes no envelope. Nothing downstream needs the
     envelope, because skip-empty declines to send a contentless document in any case.
 
+Milestone 4 (against
+[docs/plans/CLUE-371-harness-implementation-4.md](../../docs/plans/CLUE-371-harness-implementation-4.md)):
+
+31. **`review` is its own command over a results file plus its experiment file.** The parent plan's
+    CLI sketch shows `report --corpus <name> --runs <run-ids> [--shareable]`. That predates the
+    results-file conventions milestone 1 settled on: a run's outcomes live in one JSONL file, and
+    `report` already reads one. `review` reads the same file, plus the experiment file it was
+    produced with — required and hash-checked, because the run list, `detail`, `imageSet` and
+    `extras` exist nowhere else — and the corpus tree, for the summaries and pictures. `report`
+    stays "reports as data"; this is a document for humans.
+32. **A blinded report withholds skip reasons rather than printing them.** The spec has skipped
+    outcomes rendering with their `skipReasons` in every mode, and separately requires that no run
+    configuration appear in a blind report. Those conflict: a skip reason names the shape and
+    settings of the run that declined ("image-only run with imageSet `visual-tiles-only`: …"), which
+    is a configuration standing beside labelled cards. Blind mode keeps the strip and the count and
+    says the reasons are withheld; every other mode prints them.
+33. **`--shareable` also drops tile ids and representation warnings.** The spec lists the fields to
+    omit — document ids, unit, investigation, problem, `contextId`, source, file paths, render-target
+    URLs, git commit — and tile ids are not among them. In this corpus a tile id contains the
+    document id outright (`wave-runner-tile`), so printing one beside `doc-26` would undo the
+    pseudonym; the same goes for a row's `representationWarnings`, which name the tiles a capture
+    missed. Both are shown in the team-internal report.
+34. **`--out` must name a `.html` file.** The spec does not constrain it. Both sidecars are named
+    from the resolved output path, so an `--out` with another extension would produce a key whose
+    name the next invocation could not predict — and predicting it is how a key is found and not
+    overwritten.
+
 ### Verified against a real API call, a real browser, a real service?
 
 All of it, by hand. The 26 fixtures were rendered against a real dev server and a real headless
@@ -924,11 +1108,14 @@ command:
 | skipped | 114 |
 | current, superseded | 260, 0 |
 
-Three things were repaired between the first run and this one, and each is worth knowing before
+Four things were repaired between the first run and this one, and each is worth knowing before
 reading the numbers. A per-tile capture was photographing tiles nested inside a Question, so
 `question` produced three overlapping pictures instead of one. The mixed prompt told the model it
-had been given a summary on documents where the summary was dropped. And `drawing-text` had no
-experiment run at all.
+had been given a summary on documents where the summary was dropped. `drawing-text` had no
+experiment run at all. And — found by reading the milestone-4 review report rather than by any
+test — four fixtures rendered as blank tiles, so every image run on them was categorizing an empty
+rectangle. **That last one moved the results**, and the comparison at the end of this section is the
+opposite of what it said before the fixtures were converted.
 
 Two of those cost money to correct and one did not. Re-rendering changed 18 rows, of which only
 `question` changed because of the fix — the other 15 are `data-card`, `dataflow` and `graph`, which
@@ -944,6 +1131,13 @@ rather than the experiment, so all 153 rows the experiment then had came straigh
 That figure is from before the run this section records was reduced to ten; the whole session's
 real spend was about $0.25.
 
+Converting the four blank-rendering fixtures then forced the whole thing again — new content hashes,
+so a re-render, a re-represent and a re-run — and it cost **$0.0538 for 33 API calls**, with the
+other 113 rows served from the cache. That ratio is the useful part: a re-render only re-spends
+where the *pixels* actually changed, and a document that renders deterministically produces
+byte-identical bytes, the same image hash, and therefore the same request key. Only the four
+converted fixtures and the three nondeterministic documents cost anything.
+
 **Any edit to an experiment file does this**, including renaming a run. If you hold results from an
 earlier definition and re-run into the same `--output`, every row rebuilds and `report` then refuses
 the file for mixing two definitions — it says so, and names the fix. Re-run into a fresh file, or
@@ -958,14 +1152,15 @@ move the old one aside. The cache means recovery costs time rather than money.
   smaller total.
 - **Every text dimension is priced, over the same 7 documents and the same prompt.** Named by run,
   because two dimensions are in play and the settings alone would not say which: `text-extras-none`
-  sends 3,725 prompt tokens; `text-no-dataset-tables` 3,823; `text-default` and `text-extras-all`
-  3,895; `text-drawing-text` 3,958. The recorded session also carried an eleventh run, since
+  sends 3,741 prompt tokens; `text-no-dataset-tables` 3,839; `text-default` and `text-extras-all`
+  3,911; `text-drawing-text` 3,974 (it sends an eighth document, `drawing`, for a further 377).
+  The recorded session also carried an eleventh run, since
   removed, whose `extras-production-current` setting reproduced CLUE-630's bug and sent 4,537 — a
   642-token premium for repeating the analyzed document's own summary in place of each related one.
   Kept here because it prices what redundant extras cost, which is the shape of the control
   CLUE-607 will want.
 - **`drawing-text` is the only run that ever answered `form`.** Across all 146 rows the categories
-  are 90 `unknown`, 41 `function`, 14 `user` and a single `form` — the `drawing` fixture, two shapes
+  are 81 `unknown`, 47 `function`, 17 `user` and a single `form` — the `drawing` fixture, two shapes
   and no text, which every other run either skips or calls `unknown`. The model gave "drawing with 2
   objects", "rectangle and ellipse", "specified positions and sizes" as its indicators. One document
   is not evidence that describing geometry beats photographing it, but it is the variant doing
@@ -985,16 +1180,36 @@ move the old one aside. The cache means recovery costs time rather than money.
   summary only when there is one moved **0 of 23** categories. The fidelity problem was real and its
   measured effect here was nil; both halves are worth stating, because a fix reported without its
   measurement is just a claim.
-- **Observation, not a conclusion.** Skip-empty means text and image runs no longer send the same
-  documents, so the only fair comparison is the 7 documents both send. There, mixed reproduced
-  text-only's category on all 7, while image-only lost 4 of them to `unknown` — the picture alone
-  was worse, and adding the picture to the text cost nothing in agreement. Across everything each
-  run did send, `unknown` came back 17/23 for image-only, 16/23 for mixed, 19/23 for per-tile, 1/7
-  for text and 1/8 for `drawing-text`. This is heavily confounded: these are one- and two-tile
-  synthetic documents, several render nearly blank (see "What the synthetic corpus cannot show you
-  yet"), and n=7 on the paired comparison. **This establishes that the pipeline works and what it
-  costs — not that any representation is better.** That comparison needs milestone 5's rubric and a
-  corpus of real documents.
+- **A measurement that reversed when a fixture was fixed.** Skip-empty means text and image runs no
+  longer send the same documents, so the only fair comparison is the 7 documents both send. Before
+  the blank-rendering fixtures were converted, mixed reproduced text-only's category on all 7 while
+  image-only lost 4 of them to `unknown`, and this section concluded "the picture alone was worse".
+  With the pictures actually showing the text, **image-only reproduces text-only's category on all
+  7** and mixed on 6 of 7. The earlier result was measuring four blank rectangles, not the image
+  representation.
+
+  Across everything each run did send, `unknown` now comes back 15/23 for image-only, 15/23 for
+  mixed, 16/23 for per-tile, 16/18 for visual-tiles-only, 1/7 for text and 1/8 for `drawing-text`.
+  This is still heavily confounded: these are one- and two-tile synthetic documents, `empty` and
+  `unknown` still render identically (see "What the synthetic corpus cannot show you yet"), and n=7
+  on the paired comparison — one disagreement is 14% of it. **This establishes that the pipeline
+  works and what it costs — not that any representation is better.** That comparison needs milestone
+  5's rubric and a corpus of real documents.
+
+  The lesson is worth more than the numbers: a quality claim from this harness is only as good as
+  the pictures behind it, and nothing in the aggregate table would ever have shown four of them were
+  blank. Looking at the review report did.
+
+**The review report was generated from that run and read in a browser**, in all four combinations.
+The 26 documents render as 146 cards and 114 skips, with 56 distinct pictures embedded; the plain
+report is 1.4 MB. The `adversarial-text` fixture displays as text in every mode — its `</script>`,
+its `<img onerror=…>` and its markdown link are all visible as characters — and the file contains no
+`<script`, no external URL, and no tag beyond the ones the report itself writes.
+
+Reading it turned up three things no test had: two leaks — a tile id carrying the document id into a
+shareable report, and a skip reason carrying an image-set name into a blinded one (DEVIATIONS 32 and
+33) — and the blank-rendering fixtures above, which had been distorting the image-mode results since
+milestone 2 while every aggregate number looked entirely reasonable.
 
 **The parity mode was verified by hand against the real service**, with the `drawing` fixture:
 

--- a/scripts/ai-harness/examples/synthetic-corpus/documents/adversarial-text.json
+++ b/scripts/ai-harness/examples/synthetic-corpus/documents/adversarial-text.json
@@ -18,8 +18,7 @@
       "id": "adversarial-tile",
       "content": {
         "type": "Text",
-        "format": "markdown",
-        "text": "adversarial-fixture-marker </script><img src=x onerror=alert(1)> \"quoted\" 'single' A & B <b>bold</b> line sep para sep backslash \\u003c and \\ alone"
+        "text": "adversarial-fixture-marker </script><img src=x onerror=alert(1)> \"quoted\" 'single' A & B <b>bold</b> line\u2028sep para\u2029sep backslash \\u003c and \\ alone"
       }
     }
   }

--- a/scripts/ai-harness/examples/synthetic-corpus/documents/mixed.json
+++ b/scripts/ai-harness/examples/synthetic-corpus/documents/mixed.json
@@ -28,8 +28,8 @@
       "id": "mixed-text-tile",
       "content": {
         "type": "Text",
-        "format": "markdown",
-        "text": "We drew the latch and then wrote up why it works. mixed-fixture-marker"
+        "format": "html",
+        "text": "<p>We drew the latch and then wrote up why it works. mixed-fixture-marker</p>"
       }
     },
     "mixed-drawing-tile": {

--- a/scripts/ai-harness/examples/synthetic-corpus/documents/question.json
+++ b/scripts/ai-harness/examples/synthetic-corpus/documents/question.json
@@ -47,16 +47,16 @@
       "id": "question-prompt",
       "content": {
         "type": "Text",
-        "format": "markdown",
-        "text": "What problem does your design solve?"
+        "format": "html",
+        "text": "<p>What problem does your design solve?</p>"
       }
     },
     "question-response": {
       "id": "question-response",
       "content": {
         "type": "Text",
-        "format": "markdown",
-        "text": "It keeps the lunchbox shut on the bus."
+        "format": "html",
+        "text": "<p>It keeps the lunchbox shut on the bus.</p>"
       }
     }
   }

--- a/scripts/ai-harness/examples/synthetic-corpus/documents/text.json
+++ b/scripts/ai-harness/examples/synthetic-corpus/documents/text.json
@@ -18,8 +18,8 @@
       "id": "text-tile",
       "content": {
         "type": "Text",
-        "format": "markdown",
-        "text": "Our lunchbox latch is for a first grader who cannot work a stiff clasp. text-fixture-marker"
+        "format": "html",
+        "text": "<p>Our lunchbox latch is for a first grader who cannot work a stiff clasp. text-fixture-marker</p>"
       }
     }
   }

--- a/scripts/ai-harness/harness.ts
+++ b/scripts/ai-harness/harness.ts
@@ -880,21 +880,30 @@ function commandReview(flags: Record<string, string | true>, deps: HarnessDeps):
     throw new Error("--reuse-key applies to --shareable and --blind reports, which are the ones " +
       "that write a key. A plain review report writes no sidecars.");
   }
-  // Checked together, before a single byte is written.
-  if (needsKey) {
-    if (fs.existsSync(sidecars.key) && !reuseKey) {
-      throw new Error(`${sidecars.key} already exists, and a key is never overwritten: its labels ` +
-        "and pseudonyms are what any ratings already collected refer to. Pass --reuse-key to " +
-        "regenerate this same report, or --out to write a different one.");
-    }
-    if (!fs.existsSync(sidecars.key) && reuseKey) {
-      throw new Error(`--reuse-key was given, but there is no key at ${sidecars.key} to reuse.`);
-    }
-    if (modes.blind && !reuseKey && fs.existsSync(sidecars.ratings)) {
-      throw new Error(`${sidecars.ratings} already exists without a key beside it. It may hold a ` +
-        "judge's ratings against labels this report is about to generate afresh; move it aside, or " +
-        "pass --out to write a different report.");
-    }
+  // Every path this run would touch is settled here, before a single byte is written — and the
+  // rules do not depend on the mode. A sidecar beside the output path belongs to some report, and
+  // with `--out` the mode is not in the filename, so those sidecars are the only record of what
+  // that path is. Checking them only in the modes that write them let a plain report overwrite a
+  // blinded one: an unredacted page in a file believed to be shareable, a key that decodes nothing,
+  // and a judge's page replaced mid-round.
+  if (fs.existsSync(sidecars.key) && !reuseKey) {
+    throw new Error(`${sidecars.key} already exists, so this path holds a shareable or blinded ` +
+      `report. A key is never overwritten: its labels and pseudonyms are what any ratings already ` +
+      "collected refer to" + (needsKey
+        ? ". Pass --reuse-key to regenerate that same report, or --out to write a different one."
+        : ", and a plain report would replace its HTML with an unredacted one and leave the key " +
+          "decoding a page that no longer exists. Pass --out to write a different report."));
+  }
+  if (!fs.existsSync(sidecars.key) && reuseKey) {
+    throw new Error(`--reuse-key was given, but there is no key at ${sidecars.key} to reuse.`);
+  }
+  // A template is preserved by exactly one kind of run: a blinded regeneration against its own key.
+  // Any other run at this path would leave a judge's ratings naming labels the page no longer has.
+  const preservesRatings = modes.blind && reuseKey;
+  if (fs.existsSync(sidecars.ratings) && !preservesRatings) {
+    throw new Error(`${sidecars.ratings} already exists, and this run would not preserve it: a ` +
+      "ratings template names the labels of the blinded report that wrote it, and may hold a " +
+      "judge's answers against them. Move it aside, or pass --out to write a different report.");
   }
 
   const existingKey = reuseKey

--- a/scripts/ai-harness/harness.ts
+++ b/scripts/ai-harness/harness.ts
@@ -10,11 +10,14 @@
  *   npx tsx harness.ts run       --corpus <name> --experiment <file> --max-cost <usd>
  *                                [--output <file>] [--no-cache | --refresh-cache]
  *   npx tsx harness.ts report    --results <file>.jsonl
+ *   npx tsx harness.ts review    --results <file>.jsonl --experiment <file>.json [--out <file>.html]
+ *                                [--shareable] [--blind] [--reuse-key]
  *
  * See README.md for setup and per-command prerequisites.
  */
 import fs from "node:fs";
 import path from "node:path";
+import { randomBytes } from "node:crypto";
 import dotenv from "dotenv";
 import {
   corpusPaths, defaultDataRoot, harnessRoot, importCorpus, isContainedBy, readCorpusDocument, readJsonFile,
@@ -40,10 +43,17 @@ import { expectedTileCount, kDefaultRenderTimeoutMs } from "./src/backends/puppe
 import {
   RenderUnitServer, kHarnessRenderUnitId, startRenderUnitServer
 } from "./src/backends/render-unit.js";
-import { formatSummaryTable, summarizeResults, summaryPathFor, writeSummary } from "./src/report.js";
+import {
+  assertSingleCorpusAndExperiment, formatSummaryTable, summarizeResults, summaryPathFor, writeSummary
+} from "./src/report.js";
+import {
+  ReviewModes, assertExperimentMatchesRows, buildReviewModel, ratingsTemplateCsv, renderReviewHtml,
+  reviewKeyFileFor, reviewOutputPathFor, reviewSidecarPaths
+} from "./src/review.js";
+import { writeFileAtomically } from "./src/files.js";
 import {
   CorpusSource, corpusSources, kSchemaVersion, sendsImages, sendsText, sha256Canonical,
-  validateExperimentFile
+  validateExperimentFile, validateReviewKeyFile
 } from "./src/schemas.js";
 
 /** Four pages at a time: enough to be quick, few enough not to starve a dev server. */
@@ -65,6 +75,11 @@ export interface HarnessDeps {
   renderConcurrency?: number;
   /** Injected by tests so `run` does not really download hosted images to check them. */
   checkHostedImage?: HostedImageCheck;
+  /**
+   * The random seed a blind `review` orders its cards by. Injected by tests, which need two reports
+   * that differ only in their seed; a real run generates 32 fresh bytes and keeps them in the key.
+   */
+  reviewSeed?: () => string;
 }
 
 const promptsDir = path.join(harnessRoot, "prompts");
@@ -78,7 +93,9 @@ export interface ParsedArgs {
   flags: Record<string, string | true>;
 }
 
-const kBooleanFlags = new Set(["prune", "no-cache", "refresh-cache", "refresh"]);
+const kBooleanFlags = new Set([
+  "prune", "no-cache", "refresh-cache", "refresh", "shareable", "blind", "reuse-key"
+]);
 
 /** Plain `--name value` pairs; a handful of flags are boolean. Unknown flags are errors. */
 export function parseArgs(argv: string[], knownFlags: Record<string, readonly string[]>): ParsedArgs {
@@ -124,7 +141,8 @@ const kKnownFlags = {
     "concurrency", "timeout-ms"],
   plan: ["corpus", "experiment"],
   run: ["corpus", "experiment", "max-cost", "output", "no-cache", "refresh-cache"],
-  report: ["results"]
+  report: ["results"],
+  review: ["results", "experiment", "out", "shareable", "blind", "reuse-key"]
 } as const;
 
 function required(flags: Record<string, string | true>, name: string): string {
@@ -784,10 +802,24 @@ function commandReport(flags: Record<string, string | true>, deps: HarnessDeps):
   const log = deps.log ?? console.log;
   // Reports are derived from student work, so both the file read and the summary written beside it
   // stay inside the data root.
-  const resultsFile = resolveDataPath(required(flags, "results"), "--results", dataRootFor(deps));
-  // readResultRows treats a missing file as "no rows", which is what `run` needs when it creates a
-  // fresh output file. For `report` that is a typo waiting to be misread as a result: an all-zeros
-  // table and an empty <basename>.summary.json written over whatever was there before.
+  const { resultsFile, rows } = readResultsFileFor(flags, dataRootFor(deps));
+  const summary = summarizeResults(rows, resultsFile, deps.now?.());
+  const summaryFile = resolveDataPath(summaryPathFor(resultsFile), "--results", dataRootFor(deps));
+  log(formatSummaryTable(summary));
+  log(`\nRead ${summary.rows} row(s) from ${resultsFile}; ` +
+    `${summary.currentRows} current, ${summary.superseded.rows} superseded by a later re-run.`);
+  log(`Wrote ${writeSummary(summary, summaryFile)}`);
+}
+
+/**
+ * The results file every `report`/`review` invocation reads, with the two ways of getting it wrong
+ * separated: a path that is not there at all, and a file that holds no rows.
+ *
+ * `readResultRows` treats a missing file as "no rows", which is what `run` needs on a fresh
+ * `--output`. Here that would turn a typo into an all-zeros report written over whatever was there.
+ */
+function readResultsFileFor(flags: Record<string, string | true>, dataRoot: string) {
+  const resultsFile = resolveDataPath(required(flags, "results"), "--results", dataRoot);
   if (!fs.existsSync(resultsFile)) {
     throw new Error(`No results file at ${resultsFile}. Run \`harness.ts run\` first, or check ` +
       "--results — the default output path is data/results/<corpus>__<experiment>.jsonl.");
@@ -796,12 +828,113 @@ function commandReport(flags: Record<string, string | true>, deps: HarnessDeps):
   if (rows.length === 0) {
     throw new Error(`${resultsFile} contains no result rows, so there is nothing to report.`);
   }
-  const summary = summarizeResults(rows, resultsFile, deps.now?.());
-  const summaryFile = resolveDataPath(summaryPathFor(resultsFile), "--results", dataRootFor(deps));
-  log(formatSummaryTable(summary));
-  log(`\nRead ${summary.rows} row(s) from ${resultsFile}; ` +
-    `${summary.currentRows} current, ${summary.superseded.rows} superseded by a later re-run.`);
-  log(`Wrote ${writeSummary(summary, summaryFile)}`);
+  return { resultsFile, rows };
+}
+
+/**
+ * The side-by-side HTML review report: what a human judge reads to compare runs on one document.
+ *
+ * Reads the results file, the experiment file and the corpus tree, and writes an HTML file plus —
+ * in the modes that need one — a key and a ratings template beside it. No network, no API key.
+ *
+ * Every collision is settled before anything is written, so a refused run leaves nothing behind. An
+ * existing key is never overwritten and never rewritten: rotating it would orphan every rating a
+ * judge has already written against the old labels.
+ */
+function commandReview(flags: Record<string, string | true>, deps: HarnessDeps): void {
+  const log = deps.log ?? console.log;
+  const dataRoot = dataRootFor(deps);
+  const { resultsFile, rows } = readResultsFileFor(flags, dataRoot);
+  assertSingleCorpusAndExperiment(rows, resultsFile);
+
+  // Required, and hash-checked. Result rows do not carry `detail`, `imageSet` or `extras`, a skipped
+  // row carries no representation descriptor at all, and run order lives in the experiment file —
+  // so the report needs that file, and needs to know it is the one these rows were produced with.
+  const { experiment, experimentSha256, file: experimentFile } =
+    loadExperiment(required(flags, "experiment"));
+  assertExperimentMatchesRows(rows, experimentSha256, experimentFile, resultsFile);
+
+  const corpus = rows[0].corpus;
+  const paths = corpusPaths(dataRoot, corpus);
+  if (!fs.existsSync(paths.manifest)) {
+    throw new Error(`These results were produced against corpus "${corpus}", which is not in ` +
+      `${dataRoot}. The review report shows the summaries and pictures each run sent, so it needs ` +
+      `the corpus tree: import it as "${corpus}" first.`);
+  }
+
+  const modes: ReviewModes = { shareable: flags.shareable === true, blind: flags.blind === true };
+  const outputFile = resolveDataPath(
+    typeof flags.out === "string" ? flags.out : reviewOutputPathFor(resultsFile, modes),
+    "--out", dataRoot);
+  if (!outputFile.endsWith(".html")) {
+    // The key and the ratings template are named from this path, so an `--out` with another
+    // extension would produce sidecars whose names nobody can predict — including the next
+    // invocation, which has to find the key it must not overwrite.
+    throw new Error(`--out must name a .html file, got ${outputFile}.`);
+  }
+  const sidecars = reviewSidecarPaths(outputFile);
+  const needsKey = modes.shareable || modes.blind;
+  const reuseKey = flags["reuse-key"] === true;
+
+  if (!needsKey && reuseKey) {
+    throw new Error("--reuse-key applies to --shareable and --blind reports, which are the ones " +
+      "that write a key. A plain review report writes no sidecars.");
+  }
+  // Checked together, before a single byte is written.
+  if (needsKey) {
+    if (fs.existsSync(sidecars.key) && !reuseKey) {
+      throw new Error(`${sidecars.key} already exists, and a key is never overwritten: its labels ` +
+        "and pseudonyms are what any ratings already collected refer to. Pass --reuse-key to " +
+        "regenerate this same report, or --out to write a different one.");
+    }
+    if (!fs.existsSync(sidecars.key) && reuseKey) {
+      throw new Error(`--reuse-key was given, but there is no key at ${sidecars.key} to reuse.`);
+    }
+    if (modes.blind && !reuseKey && fs.existsSync(sidecars.ratings)) {
+      throw new Error(`${sidecars.ratings} already exists without a key beside it. It may hold a ` +
+        "judge's ratings against labels this report is about to generate afresh; move it aside, or " +
+        "pass --out to write a different report.");
+    }
+  }
+
+  const existingKey = reuseKey
+    ? { key: validateReviewKeyFile(readJsonFile(sidecars.key), sidecars.key), file: sidecars.key }
+    : undefined;
+
+  const model = buildReviewModel({
+    rows,
+    resultsFile,
+    experiment,
+    experimentSha256,
+    paths,
+    now: deps.now?.() ?? new Date(),
+    modes,
+    // 32 bytes from the OS, kept only in the key file: an ordering derived from anything in the
+    // results is reconstructible by whoever reads `blindLabelsFor`.
+    seed: (deps.reviewSeed ?? (() => randomBytes(32).toString("hex")))(),
+    existingKey
+  });
+
+  // The key goes down first. A key with no report beside it costs a re-run — `--reuse-key`
+  // regenerates the report exactly — while a report with no key is a document nobody can decode.
+  if (needsKey && !reuseKey) {
+    writeJsonFile(sidecars.key, reviewKeyFileFor(model));
+    log(`Wrote ${sidecars.key} — the only copy of ` +
+      `${[modes.shareable && "the pseudonyms", modes.blind && "the label mapping"]
+        .filter(Boolean).join(" and ")}. Keep it; without it the report cannot be decoded.`);
+  }
+  writeFileAtomically(outputFile, renderReviewHtml(model));
+  log(`Wrote ${outputFile} — ${model.documents.length} document(s), ${model.judgeable.length} ` +
+    `judgeable outcome(s), ${model.counts.skipped} skipped.`);
+  if (modes.blind) {
+    if (fs.existsSync(sidecars.ratings)) {
+      // Never regenerated: it may already hold a judge's half-entered ratings.
+      log(`Left ${sidecars.ratings} as it is.`);
+    } else {
+      writeFileAtomically(sidecars.ratings, ratingsTemplateCsv(model));
+      log(`Wrote ${sidecars.ratings} — one empty row per labelled outcome.`);
+    }
+  }
 }
 
 function requireApiKey(): string {
@@ -826,6 +959,7 @@ export async function main(argv: string[], deps: HarnessDeps = {}): Promise<void
     case "plan": return commandPlan(flags, deps);
     case "run": return commandRun(flags, deps);
     case "report": return commandReport(flags, deps);
+    case "review": return commandReview(flags, deps);
     default: throw new Error(`Unknown command "${command}"`);
   }
 }

--- a/scripts/ai-harness/src/review.ts
+++ b/scripts/ai-harness/src/review.ts
@@ -24,16 +24,21 @@
 import fs from "node:fs";
 import path from "node:path";
 import { createHmac } from "node:crypto";
-import { CorpusPaths, readManifest, readRepresentation, representationPath } from "./corpus.js";
 import {
-  imageRepresentationIsUsable, imageRepresentationPath, readImageEnvelope, resolveImageFile,
-  sha256Bytes
+  CorpusPaths, readCorpusDocument, readManifest, readRepresentation, representationPath
+} from "./corpus.js";
+import {
+  imageRepresentationIsUsable, imageRepresentationPath, imagesForSet, readImageEnvelope,
+  resolveImageFile, sha256Bytes
 } from "./represent-image.js";
+import { classifyDocument } from "./capability.js";
+import { visualTileIdsOf } from "./execute.js";
 import { partitionSuperseded } from "./report.js";
 import {
   EnvelopeImage, ExperimentFile, ExperimentRun, ExtrasMode, ImageDetail, ImageRepresentation,
   ImageSet, ManifestDocument, MessageShape, Modality, ResultRow, ReviewKeyFile, ReviewKeyPair,
-  TextRepresentation, canonicalJson, kSchemaVersion, modalities, sendsImages, sendsText
+  TextRepresentation, canonicalJson, kSchemaVersion, modalities, sendsImages, sendsText,
+  sha256Canonical
 } from "./schemas.js";
 
 // ---------------------------------------------------------------------------
@@ -368,7 +373,8 @@ export type UnavailableReason =
   | "variant-changed"
   | "document-changed"
   | "render-changed"
-  | "bytes-changed";
+  | "bytes-changed"
+  | "selection-unknown";
 
 /** What went wrong, plus detail that only the team-internal report is allowed to print. */
 export interface UnavailableInput {
@@ -425,8 +431,18 @@ interface SentImage {
  * hashing to it. The second check is stated directly rather than inferred from the first: "these are
  * the bytes that were sent" is the claim the report makes, so it is the claim that gets tested.
  */
+/**
+ * A document's content, but only when it still hashes to what the run was given.
+ *
+ * `visual-tiles-only` is the one image set whose membership is not structural: it is the tiles the
+ * *classifier* marked as needing a picture, so reconstructing what a run sent means classifying the
+ * same content it classified. Anything else is a guess dressed as provenance.
+ */
+export type ContentMatching = (sourceContentSha256: string) => unknown | null;
+
 function readSentImages(
-  paths: CorpusPaths, docId: string, descriptor: ImageRepresentation
+  paths: CorpusPaths, docId: string, descriptor: ImageRepresentation,
+  contentMatching: ContentMatching
 ): { images: SentImage[] } | UnavailableInput {
   const file = imageRepresentationPath(paths, descriptor.modeId, docId);
   if (!fs.existsSync(file)) return { unavailable: "missing" };
@@ -446,18 +462,37 @@ function readSentImages(
   if (!usable.fresh) {
     return { unavailable: "render-changed", detail: usable.reasons[0] };
   }
-  const byHash = new Map(envelope.images.map((image) => [image.sha256, image]));
+  // `imageSha256s` is every picture the envelope holds — the render's provenance — and `imageSet`
+  // says which of them the run actually sent. Showing all of them displayed tile captures a
+  // `visual-tiles-only` run never received, labelled as though it had. The selection goes through
+  // the same function execution selects with, so the two cannot disagree about what a set means.
+  const imageSet = descriptor.imageSet ?? "full-document";
+  let selected;
+  try {
+    if (imageSet === "visual-tiles-only") {
+      const content = contentMatching(descriptor.sourceContentSha256);
+      if (content === null) return { unavailable: "selection-unknown" };
+      selected = imagesForSet(envelope, file, imageSet, visualTileIdsOf(classifyDocument(content)));
+    } else {
+      selected = imagesForSet(envelope, file, imageSet);
+    }
+  } catch (error) {
+    return { unavailable: "selection-unknown", detail: (error as Error).message };
+  }
+
+  const recorded = new Set(descriptor.imageSha256s);
   const images: SentImage[] = [];
-  for (const sha256 of descriptor.imageSha256s) {
-    const image = byHash.get(sha256);
-    if (!image) return { unavailable: "bytes-changed" };
+  for (const image of selected.images) {
+    // Belt and braces: a selected picture the row's provenance does not list would mean the
+    // envelope has changed under us in a way the freshness check did not catch.
+    if (!recorded.has(image.sha256)) return { unavailable: "bytes-changed" };
     let bytes: Buffer;
     try {
       bytes = fs.readFileSync(resolveImageFile(file, image));
     } catch {
       return { unavailable: "unreadable", detail: `${image.file} could not be read` };
     }
-    if (sha256Bytes(bytes) !== sha256) {
+    if (sha256Bytes(bytes) !== image.sha256) {
       return { unavailable: "bytes-changed", detail: `${image.file} holds different bytes` };
     }
     images.push({ image, bytes });
@@ -609,7 +644,9 @@ const kUnavailableSentences: Record<UnavailableReason, string> = {
   "document-changed": "the document has changed since this run, so what is on disk now describes " +
     "the newer content",
   "render-changed": "the render on disk no longer matches the one this run sent",
-  "bytes-changed": "the picture on disk no longer holds the bytes this run sent"
+  "bytes-changed": "the picture on disk no longer holds the bytes this run sent",
+  "selection-unknown": "which of the document's pictures this run sent cannot be established " +
+    "from what is on disk now"
 };
 
 /**
@@ -620,7 +657,8 @@ const kUnavailableSentences: Record<UnavailableReason, string> = {
  * appearance walking the rows in experiment-run order, which is stable.
  */
 function inputsFor(
-  paths: CorpusPaths, docId: string, rows: readonly ResultRow[], modes: ReviewModes
+  paths: CorpusPaths, docId: string, rows: readonly ResultRow[], modes: ReviewModes,
+  contentMatching: ContentMatching
 ): Pick<ReviewDocument, "images" | "texts" | "inputNotices"> {
   const { blind } = modes;
   const images: ReviewImageInput[] = [];
@@ -683,11 +721,15 @@ function inputsFor(
   // done to reach the same answer.
   const readImages = new Map<string, ReturnType<typeof readSentImages>>();
   const addImages = (descriptor: ImageRepresentation) => {
+    // `imageSet` belongs in this key: two runs over one render record the *same* whole-envelope
+    // hashes and differ only by the set they sent, so a key without it served a per-tile run's
+    // selection to a visual-tiles-only one.
     const key = `${descriptor.modeId} ${descriptor.backendId} ${descriptor.backendVersion} ` +
-      `${descriptor.sourceContentSha256} ${descriptor.imageSha256s.join(",")}`;
+      `${descriptor.sourceContentSha256} ${descriptor.imageSet ?? "full-document"} ` +
+      `${descriptor.imageSha256s.join(",")}`;
     let read = readImages.get(key);
     if (!read) {
-      read = readSentImages(paths, docId, descriptor);
+      read = readSentImages(paths, docId, descriptor, contentMatching);
       readImages.set(key, read);
     }
     if ("unavailable" in read) {
@@ -857,7 +899,7 @@ export function buildReviewModel(options: BuildReviewOptions): ReviewModel {
       overridden: first.modality !== first.computedModality,
       metadata: modes.shareable || !entry ? null : metadataFor(entry),
       missingFromManifest: !entry,
-      ...inputsFor(paths, docId, rowsForDocument, modes),
+      ...inputsFor(paths, docId, rowsForDocument, modes, contentMatchingFor(paths, entry)),
       cards,
       skipped: rowsForDocument
         .filter((row): row is ResultRow & { status: "skipped" } => row.status === "skipped")
@@ -886,6 +928,29 @@ export function buildReviewModel(options: BuildReviewOptions): ReviewModel {
     pseudonyms: modes.shareable ? pseudonyms : null,
     seed: modes.blind ? seed : null,
     labels: modes.blind ? labels : null
+  };
+}
+
+/**
+ * Reads a document's content back, but hands it over only when it still hashes to what the run was
+ * given — and reads it at most once per document however many rows ask.
+ *
+ * A document edited since the run classifies differently, so using it to work out which tiles a
+ * `visual-tiles-only` run sent would produce a confident, wrong answer. The report says it cannot
+ * tell instead.
+ */
+function contentMatchingFor(paths: CorpusPaths, entry: ManifestDocument | null): ContentMatching {
+  let loaded: { content: unknown } | null | undefined;
+  return (sourceContentSha256: string) => {
+    if (loaded === undefined) {
+      try {
+        loaded = entry ? { content: readCorpusDocument(paths, entry) } : null;
+      } catch {
+        loaded = null;
+      }
+    }
+    if (!loaded) return null;
+    return sha256Canonical(loaded.content) === sourceContentSha256 ? loaded.content : null;
   };
 }
 

--- a/scripts/ai-harness/src/review.ts
+++ b/scripts/ai-harness/src/review.ts
@@ -1257,6 +1257,9 @@ const kStyles = `
     border: 1px solid #e2e2e2; border-radius: 4px; padding: 0.6rem 0.75rem; margin: 0;
     font: 12px/1.45 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; max-height: 32rem;
     overflow-y: auto; }
+  pre:focus-visible { outline: 2px solid #1b1b1b; outline-offset: 2px; }
+  h2.caption { font-size: 0.85rem; margin: 1.25rem 0 0.5rem; padding: 0; border-bottom: none;
+    text-transform: uppercase; letter-spacing: 0.06em; color: #555; }
   .cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(19rem, 1fr)); gap: 0.75rem; }
   .card { border: 1px solid #c8c8c8; border-radius: 5px; padding: 0.6rem 0.75rem; background: #fcfcfc; }
   .card-header { display: flex; flex-wrap: wrap; align-items: baseline; gap: 0.5rem;
@@ -1354,7 +1357,7 @@ function headerBlock(model: ReviewModel): Html {
       </dl>
     </div>
     ${model.runs
-      ? html`<h4>Runs, in experiment-file order</h4>${runTable(model.runs)}`
+      ? html`<h2 class="caption">Runs, in experiment-file order</h2>${runTable(model.runs)}`
       : html`<p class="meta">${model.runCount} run(s). Which configuration produced which output is
           withheld: this is a blinded report, and the mapping is in its key file.</p>`}
     ${model.modes.shareable
@@ -1383,7 +1386,9 @@ function inputsBlock(document: ReviewDocument): Html {
           <p class="input-label">Summary ${index + 1} of ${document.texts.length}${text.labels.length > 0
             ? html` — variant ${text.labels.join("; ")}`
             : ""}</p>
-          <pre>${text.markdown}</pre>
+          <pre tabindex="0" role="region"
+            aria-label="Summary ${index + 1} sent for document ${document.displayName}"
+          >${text.markdown}</pre>
         </div>`)}
       ${document.images.length === 0 && document.texts.length === 0
         ? html`<p class="meta">No input is available to show for this document.</p>`
@@ -1404,13 +1409,14 @@ function configurationLine(configuration: ReviewRunConfiguration): string {
 
 function outcomeBlock(outcome: ReviewOutcome): Html {
   if (outcome.kind === "refusal") {
-    return html`<div class="field"><div class="field-name">refusal</div><pre>${outcome.refusal}</pre></div>`;
+    return html`<div class="field"><div class="field-name">refusal</div>
+      <pre tabindex="0" role="region" aria-label="Refusal text">${outcome.refusal}</pre></div>`;
   }
   if (outcome.kind === "error") {
     return html`
       <div class="field">
         <div class="field-name">error</div>
-        <pre>${outcome.type}: ${outcome.message}
+        <pre tabindex="0" role="region" aria-label="Error detail">${outcome.type}: ${outcome.message}
 attempts: ${outcome.attempts}</pre>
       </div>`;
   }
@@ -1431,7 +1437,8 @@ attempts: ${outcome.attempts}</pre>
       : ""}
     ${outcome.remainingJson
       ? html`<div class="field"><div class="field-name">other response fields</div>
-          <pre>${outcome.remainingJson}</pre></div>`
+          <pre tabindex="0" role="region" aria-label="Other response fields, as JSON"
+          >${outcome.remainingJson}</pre></div>`
       : ""}
     ${outcome.category === null && !outcome.keyIndicators && outcome.discussion === null &&
       !outcome.remainingJson

--- a/scripts/ai-harness/src/review.ts
+++ b/scripts/ai-harness/src/review.ts
@@ -1,0 +1,1334 @@
+/**
+ * The side-by-side HTML review report: one section per document, showing the input the model was
+ * given and every run's output beside it, for a human to compare.
+ *
+ * `report.ts` answers aggregate questions — tokens, cost, category counts per group. It cannot
+ * answer the one a judge is asked: *for this document, which output is better?* That takes seeing
+ * the document the way the model saw it, next to what each run said about it.
+ *
+ * Three rules run through the whole file:
+ *
+ * 1. **Student-authored content is untrusted input, everywhere it appears** — in summaries, in model
+ *    outputs quoting the document, in refusal strings, in error messages. Every value that reaches
+ *    the page goes through the `html` tagged template below, which escapes anything that is not an
+ *    already-escaped fragment. Nothing derived from a document is ever inlined as markup; the only
+ *    non-text content is PNG bytes as `data:` URLs.
+ * 2. **Show the input that was sent, or a notice — never a stand-in.** A representation is displayed
+ *    as a run's input only when its full descriptor still matches. Anything less renders a notice
+ *    and shows nothing: a report that pairs today's screenshot with last week's output invites a
+ *    judgement about the wrong thing.
+ * 3. **The blind mapping lives only in the key file.** Card order is derived from a random seed
+ *    generated at report time and stored only there, so the mapping cannot be reconstructed from the
+ *    HTML plus this source.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { createHmac } from "node:crypto";
+import { CorpusPaths, readManifest, readRepresentation, representationPath } from "./corpus.js";
+import {
+  imageRepresentationIsUsable, imageRepresentationPath, readImageEnvelope, resolveImageFile,
+  sha256Bytes
+} from "./represent-image.js";
+import { partitionSuperseded } from "./report.js";
+import {
+  EnvelopeImage, ExperimentFile, ExperimentRun, ExtrasMode, ImageDetail, ImageRepresentation,
+  ImageSet, ManifestDocument, MessageShape, Modality, ResultRow, ReviewKeyFile, ReviewKeyPair,
+  TextRepresentation, canonicalJson, kSchemaVersion, modalities, sendsImages, sendsText
+} from "./schemas.js";
+
+// ---------------------------------------------------------------------------
+// Escaping
+// ---------------------------------------------------------------------------
+
+/**
+ * The one escape function. Every string that reaches the page goes through it, with no exceptions
+ * for "safe-looking" fields — a document id is student-adjacent data too, and the day one of these
+ * fields stops being safe is the day nobody remembers which ones were exempt.
+ */
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;")
+    // U+2028 and U+2029 are ordinary text in HTML — a browser decodes these references back to the
+    // same characters and renders the page identically — but a file containing them raw makes
+    // editors warn about unusual line terminators, and student text really does contain them (the
+    // `adversarial-text` fixture has one of each). Written as regex escapes rather than literal
+    // characters: an invisible line separator in this source would be impossible to review. These
+    // two replacements introduce `&`, so they run after the `&` above rather than before it.
+    .replace(/\u2028/g, "&#8232;")
+    .replace(/\u2029/g, "&#8233;");
+}
+
+/** Markup that is already escaped, and so may be interpolated as-is. Only `html` produces one. */
+class HtmlFragment {
+  constructor(readonly markup: string) {}
+}
+
+export type Html = HtmlFragment;
+
+function interpolate(value: unknown): string {
+  if (value instanceof HtmlFragment) return value.markup;
+  if (Array.isArray(value)) return value.map(interpolate).join("");
+  // `false`, `null` and `undefined` render as nothing, so `condition && html\`…\`` reads naturally.
+  if (value === null || value === undefined || value === false) return "";
+  return escapeHtml(String(value));
+}
+
+/**
+ * Builds markup with every interpolated value escaped unless it is itself an `HtmlFragment`.
+ *
+ * This is the reason the escaping rule can be checked by reading rather than by remembering:
+ * composing markup *requires* the tag, and anything else that lands in a hole is escaped. Forgetting
+ * to escape is not a thing this file can do by omission — it would take deliberately building a
+ * fragment out of raw text, which happens exactly once, for the stylesheet constant.
+ */
+export function html(strings: TemplateStringsArray, ...values: unknown[]): Html {
+  let markup = strings[0];
+  values.forEach((value, index) => {
+    markup += interpolate(value) + strings[index + 1];
+  });
+  return new HtmlFragment(markup);
+}
+
+// ---------------------------------------------------------------------------
+// Output paths
+// ---------------------------------------------------------------------------
+
+export interface ReviewModes {
+  shareable: boolean;
+  blind: boolean;
+}
+
+/**
+ * The report sits beside its results file and is named after it, the way `summary.json` is — with a
+ * distinct name per mode, so a shareable or blinded report can never overwrite the team-internal
+ * one, or each other.
+ */
+export function reviewOutputPathFor(resultsFile: string, modes: ReviewModes): string {
+  const directory = path.dirname(resultsFile);
+  const base = path.basename(resultsFile, path.extname(resultsFile));
+  const suffix = `${modes.blind ? "-blind" : ""}${modes.shareable ? "-shareable" : ""}`;
+  return path.join(directory, `${base}.review${suffix}.html`);
+}
+
+export interface ReviewSidecarPaths {
+  /** The mapping from what a reader sees to what produced it. Written only in shareable/blind modes. */
+  key: string;
+  /** Where a judge writes their answers. Written only in blind modes. */
+  ratings: string;
+}
+
+/**
+ * Both sidecars are named from the **resolved** output HTML path, never from the results basename.
+ *
+ * Naming them after the results file would give a blind report and a blind+shareable one the same
+ * key path, and two `--out` targets over one results file the same one again — so generating the
+ * second report would either be refused for a collision it did not cause, or quietly rotate the
+ * first report's labels.
+ */
+export function reviewSidecarPaths(htmlFile: string): ReviewSidecarPaths {
+  const stem = htmlFile.replace(/\.html$/, "");
+  return { key: `${stem}.key.json`, ratings: `${stem}.ratings-template.csv` };
+}
+
+// ---------------------------------------------------------------------------
+// The model
+// ---------------------------------------------------------------------------
+
+/** A run's configuration, as the experiment file defines it. `null` fields mean "the default". */
+export interface ReviewRunConfiguration {
+  runId: string;
+  message: MessageShape;
+  textVariant: string | null;
+  imageMode: string | null;
+  detail: ImageDetail | null;
+  imageSet: ImageSet | null;
+  extras: ExtrasMode | null;
+  promptName: string;
+  /** From the run's own rows; `null` when the experiment defines a run this file has no rows for. */
+  promptSha256: string | null;
+}
+
+/** One picture a document's runs actually sent, with the bytes that were sent. */
+export interface ReviewImageInput {
+  sha256: string;
+  dataUrl: string;
+  widthPx: number;
+  heightPx: number;
+  bytes: number;
+  /**
+   * Which tile a per-tile capture is a picture of. `null` in shareable mode: a tile id is a document
+   * identifier, and in this corpus it literally contains the document id (`wave-runner-tile`), so
+   * printing it beside a pseudonym would undo the pseudonym.
+   */
+  tileId: string | null;
+  /** Which mode and image set sent it. Empty in blind mode, where it would name a configuration. */
+  labels: string[];
+}
+
+/** One summary a document's runs actually sent. */
+export interface ReviewTextInput {
+  variantId: string;
+  variantVersion: number;
+  markdown: string;
+  /** Empty in blind mode. */
+  labels: string[];
+}
+
+export type ReviewOutcome =
+  | {
+    kind: "success";
+    category: string | null;
+    keyIndicators: string[] | null;
+    discussion: string | null;
+    /**
+     * Whatever else the parsed response carried, as canonical JSON. Every field of the prompt's
+     * response schema is optional, so a response that answered differently is shown rather than
+     * dropped by a renderer that assumed a shape.
+     */
+    remainingJson: string | null;
+  }
+  | { kind: "refusal"; refusal: string }
+  | { kind: "error"; type: string; message: string; attempts: number };
+
+/** One run's outcome for one document: what a judge reads. */
+export interface ReviewCard {
+  docId: string;
+  /** `null` in blind mode — this is the thing the labels hide. */
+  runId: string | null;
+  /** `A`, `B`, `C`… in blind mode; `null` otherwise. */
+  label: string | null;
+  status: "success" | "refusal" | "error";
+  /** `null` in blind mode: a configuration beside a labelled card is a decoding aid. */
+  configuration: ReviewRunConfiguration | null;
+  outcome: ReviewOutcome;
+  /** `null` in blind mode. */
+  usage: { promptTokens: number; completionTokens: number; source: "api" | "cache" } | null;
+  /** `null` in blind mode. */
+  modeledUsd: number | null;
+  /** This row sent a mixed message with its text half dropped: it saw half the input. */
+  textPartOmitted: boolean;
+  /** Empty in blind and shareable modes; see `cardFor`. */
+  representationWarnings: string[];
+}
+
+/** A (run, document) pair that was never sent. There is nothing here to judge. */
+export interface ReviewSkipped {
+  /** `null` in blind mode. */
+  runId: string | null;
+  /**
+   * Empty in blind mode. A skip reason names the shape and settings of the run that declined —
+   * "image-only run with imageSet …" — which is a configuration standing beside labelled cards, so
+   * a blinded report keeps the count and drops the reasons. See DEVIATIONS in the README.
+   */
+  skipReasons: string[];
+}
+
+export interface ReviewDocumentMetadata {
+  unit: string | null;
+  investigation: string | null;
+  problem: string | null;
+  contextId: string | null;
+  source: string;
+  file: string;
+}
+
+export interface ReviewDocument {
+  docId: string;
+  /** What the report calls this document: its id, or its pseudonym in shareable mode. */
+  displayName: string;
+  modality: Modality;
+  computedModality: Modality;
+  /** True when a human's `modalityOverride` put this document in its group, not the classifier. */
+  overridden: boolean;
+  /** `null` in shareable mode, and for a document the manifest no longer lists. */
+  metadata: ReviewDocumentMetadata | null;
+  /** True when the results name a document the corpus manifest does not. */
+  missingFromManifest: boolean;
+  images: ReviewImageInput[];
+  texts: ReviewTextInput[];
+  /** Why an input a run sent is not shown: it no longer exists, or no longer matches this run. */
+  inputNotices: string[];
+  /** Judgeable outcomes: experiment-file order, or shuffled label order in blind mode. */
+  cards: ReviewCard[];
+  skipped: ReviewSkipped[];
+}
+
+export interface ReviewModel {
+  generatedAt: string;
+  corpus: string;
+  experimentName: string;
+  experimentSha256: string;
+  /** `null` in shareable mode, where file paths are stripped. */
+  resultsFile: string | null;
+  /** `null` in shareable mode. */
+  gitCommit: string | null;
+  modes: ReviewModes;
+  /** `null` in blind mode, where the header carries the run *count* instead. */
+  runs: ReviewRunConfiguration[] | null;
+  runCount: number;
+  counts: { success: number; refusal: number; error: number; skipped: number };
+  supersededRows: number;
+  groups: { modality: Modality; documents: ReviewDocument[] }[];
+  /** Presentation order — what the pseudonyms number, and what the key records. */
+  documents: ReviewDocument[];
+  judgeable: ReviewKeyPair[];
+  pseudonyms: Record<string, string> | null;
+  seed: string | null;
+  labels: Record<string, Record<string, string>> | null;
+}
+
+// ---------------------------------------------------------------------------
+// Blind ordering
+// ---------------------------------------------------------------------------
+
+/** `A`…`Z`, then `AA`, `AB`… — enough labels for any run list, in an order a reader can follow. */
+export function labelForIndex(index: number): string {
+  let label = "";
+  let remaining = index;
+  for (;;) {
+    label = String.fromCharCode(65 + (remaining % 26)) + label;
+    remaining = Math.floor(remaining / 26) - 1;
+    if (remaining < 0) return label;
+  }
+}
+
+/**
+ * The shuffled label order for one document's judgeable runs.
+ *
+ * Keyed on a secret: a seeded HMAC rather than a hash of the row data, because anything derived from
+ * the results file alone is reconstructible by whoever reads this function. Without the key file,
+ * the HTML plus this source says nothing about which card came from which run; with it, regeneration
+ * is exact.
+ */
+export function blindLabelsFor(seed: string, docId: string, runIds: string[]): Map<string, string> {
+  const sortKey = (runId: string) =>
+    createHmac("sha256", Buffer.from(seed, "hex")).update(`${docId} ${runId}`).digest("hex");
+  const keyed = runIds.map((runId) => ({ runId, key: sortKey(runId) }));
+  // The run id breaks a tie, so the order is total even in the impossible case of a digest
+  // collision — a report whose card order depended on input order would not regenerate.
+  keyed.sort((a, b) => (a.key === b.key ? a.runId.localeCompare(b.runId) : a.key < b.key ? -1 : 1));
+  return new Map(keyed.map((entry, index) => [entry.runId, labelForIndex(index)]));
+}
+
+// ---------------------------------------------------------------------------
+// Reading the inputs back
+// ---------------------------------------------------------------------------
+
+/**
+ * Why an input cannot be shown, as a fixed vocabulary rather than a sentence.
+ *
+ * The sentences these become are written at the rendering boundary, where the mode is known. That
+ * matters: the underlying errors carry absolute paths (which contain the corpus and document id),
+ * image filenames (which contain the document id) and freshness reasons (which name the mode,
+ * backend and version). Interpolating any of them would put a document identifier in a shareable
+ * report or a run configuration in a blinded one — the two things those modes exist to prevent.
+ */
+export type UnavailableReason =
+  | "missing"
+  | "unreadable"
+  | "wrong-document"
+  | "variant-changed"
+  | "document-changed"
+  | "render-changed"
+  | "bytes-changed";
+
+/** What went wrong, plus detail that only the team-internal report is allowed to print. */
+export interface UnavailableInput {
+  unavailable: UnavailableReason;
+  /** Never shown in a shareable or blind report; it may name a path, a file or a configuration. */
+  detail?: string;
+}
+
+/**
+ * The summary a text-carrying row sent, or why it cannot be shown.
+ *
+ * Every part of the descriptor has to match: the variant that produced it, the version of that
+ * variant, and the content it was produced from. A representation regenerated since the run is a
+ * different summary, and pairing it with that run's output — even with a warning — invites a
+ * judgement about text the model never saw.
+ */
+function readSentText(
+  paths: CorpusPaths, docId: string, descriptor: TextRepresentation
+): { markdown: string } | UnavailableInput {
+  const file = representationPath(paths, descriptor.variantId, docId);
+  if (!fs.existsSync(file)) return { unavailable: "missing" };
+  let envelope;
+  try {
+    envelope = readRepresentation(file);
+  } catch (error) {
+    return { unavailable: "unreadable", detail: (error as Error).message };
+  }
+  if (envelope.docId !== docId) return { unavailable: "wrong-document" };
+  if (envelope.variantId !== descriptor.variantId) return { unavailable: "wrong-document" };
+  if (envelope.variantVersion !== descriptor.variantVersion) {
+    return {
+      unavailable: "variant-changed",
+      detail: `version ${envelope.variantVersion} on disk, ${descriptor.variantVersion} was sent`
+    };
+  }
+  if (envelope.sourceContentSha256 !== descriptor.sourceContentSha256) {
+    return { unavailable: "document-changed" };
+  }
+  return { markdown: envelope.markdown };
+}
+
+interface SentImage {
+  image: EnvelopeImage;
+  bytes: Buffer;
+}
+
+/**
+ * The pictures an image-carrying row sent, or why they cannot be shown.
+ *
+ * Two checks, both required. The envelope has to still be usable for this row —
+ * `imageRepresentationIsUsable` covers mode, backend, backend version, source content and every
+ * file-level property, which is the same bar `run` applies before sending one. And every hash the
+ * row recorded has to be one of the pictures that envelope now holds, with the bytes on disk still
+ * hashing to it. The second check is stated directly rather than inferred from the first: "these are
+ * the bytes that were sent" is the claim the report makes, so it is the claim that gets tested.
+ */
+function readSentImages(
+  paths: CorpusPaths, docId: string, descriptor: ImageRepresentation
+): { images: SentImage[] } | UnavailableInput {
+  const file = imageRepresentationPath(paths, descriptor.modeId, docId);
+  if (!fs.existsSync(file)) return { unavailable: "missing" };
+  let envelope;
+  try {
+    envelope = readImageEnvelope(file);
+  } catch (error) {
+    return { unavailable: "unreadable", detail: (error as Error).message };
+  }
+  const usable = imageRepresentationIsUsable(envelope, {
+    docId,
+    modeId: descriptor.modeId,
+    backendId: descriptor.backendId,
+    backendVersion: descriptor.backendVersion,
+    contentSha256: descriptor.sourceContentSha256
+  }, file);
+  if (!usable.fresh) {
+    return { unavailable: "render-changed", detail: usable.reasons[0] };
+  }
+  const byHash = new Map(envelope.images.map((image) => [image.sha256, image]));
+  const images: SentImage[] = [];
+  for (const sha256 of descriptor.imageSha256s) {
+    const image = byHash.get(sha256);
+    if (!image) return { unavailable: "bytes-changed" };
+    let bytes: Buffer;
+    try {
+      bytes = fs.readFileSync(resolveImageFile(file, image));
+    } catch {
+      return { unavailable: "unreadable", detail: `${image.file} could not be read` };
+    }
+    if (sha256Bytes(bytes) !== sha256) {
+      return { unavailable: "bytes-changed", detail: `${image.file} holds different bytes` };
+    }
+    images.push({ image, bytes });
+  }
+  return { images };
+}
+
+// ---------------------------------------------------------------------------
+// Building the model
+// ---------------------------------------------------------------------------
+
+export interface BuildReviewOptions {
+  /** Every row in the results file; superseded ones are partitioned out here. */
+  rows: ResultRow[];
+  resultsFile: string;
+  experiment: ExperimentFile;
+  experimentSha256: string;
+  paths: CorpusPaths;
+  now: Date;
+  modes: ReviewModes;
+  /** A fresh random seed. Ignored when `existingKey` supplies one. */
+  seed: string;
+  /** The key a `--reuse-key` run is regenerating against, already validated as a file. */
+  existingKey?: { key: ReviewKeyFile; file: string };
+}
+
+/**
+ * Result rows deliberately do not carry the whole run configuration — `detail`, `imageSet` and
+ * `extras` live only in the experiment file, a skipped row carries no representation descriptor at
+ * all, and the header needs experiment-file run order. So the experiment file is a required input,
+ * and this is what stops it being a *different* experiment file: a name match proves nothing,
+ * because the file can be edited after a run.
+ */
+export function assertExperimentMatchesRows(
+  rows: ResultRow[], experimentSha256: string, experimentFile: string, resultsFile: string
+): void {
+  const mismatched = rows.find((row) => row.experimentSha256 !== experimentSha256);
+  if (!mismatched) return;
+  throw new Error(`${experimentFile} hashes to ${experimentSha256}, but ${resultsFile} was run ` +
+    `against ${mismatched.experimentSha256} (experiment "${mismatched.experiment}"). The file has ` +
+    "been edited since the run, so its run list no longer describes these rows. Check out the " +
+    "definition the rows were produced with, or re-run the current one into a fresh --output.");
+}
+
+/** The last row per (document, run) — the outcome that still stands. */
+function currentRowsByDocument(rows: ResultRow[]): Map<string, Map<string, ResultRow>> {
+  const byDocument = new Map<string, Map<string, ResultRow>>();
+  for (const row of rows) {
+    let forDocument = byDocument.get(row.docId);
+    if (!forDocument) {
+      forDocument = new Map();
+      byDocument.set(row.docId, forDocument);
+    }
+    forDocument.set(row.runId, row);
+  }
+  return byDocument;
+}
+
+function configurationFor(run: ExperimentRun, promptSha256: string | null): ReviewRunConfiguration {
+  return {
+    runId: run.id,
+    message: run.message,
+    textVariant: sendsText(run.message) ? run.textVariant ?? null : null,
+    imageMode: sendsImages(run.message) ? run.imageMode ?? null : null,
+    detail: run.detail ?? null,
+    imageSet: run.imageSet ?? null,
+    extras: sendsText(run.message) ? run.extras ?? "all" : null,
+    promptName: run.prompt,
+    promptSha256
+  };
+}
+
+/**
+ * The recognized fields of a parsed response, with everything else kept rather than dropped.
+ *
+ * A field leaves the JSON fallback only when it was actually rendered in its recognized form. A
+ * `category` that came back as a number, or a `discussion` that came back as an object, is not
+ * something the typed renderer can show — so it stays in the fallback, where it is at least
+ * visible. Dropping it by *name* lost the model's answer outright: a response of
+ * `{ category: 42 }` rendered as "the response parsed to an empty object", which is a card that
+ * says something untrue about what came back.
+ */
+function outcomeForSuccess(parsed: unknown): ReviewOutcome {
+  const record = (parsed !== null && typeof parsed === "object" && !Array.isArray(parsed))
+    ? parsed as Record<string, unknown>
+    : null;
+  // Not an object at all: there is nothing to pick fields out of, so the whole value is shown.
+  if (!record) {
+    return {
+      kind: "success", category: null, keyIndicators: null, discussion: null,
+      remainingJson: canonicalJson(parsed)
+    };
+  }
+  const category = typeof record.category === "string" ? record.category : null;
+  const keyIndicators = Array.isArray(record.keyIndicators)
+    ? record.keyIndicators.map((value) => typeof value === "string" ? value : canonicalJson(value))
+    : null;
+  const discussion = typeof record.discussion === "string" ? record.discussion : null;
+  const rendered = new Set([
+    ...(category === null ? [] : ["category"]),
+    ...(keyIndicators === null ? [] : ["keyIndicators"]),
+    ...(discussion === null ? [] : ["discussion"])
+  ]);
+  const remaining = Object.fromEntries(
+    Object.entries(record).filter(([field]) => !rendered.has(field)));
+  return {
+    kind: "success",
+    category,
+    keyIndicators,
+    discussion,
+    remainingJson: Object.keys(remaining).length > 0 ? canonicalJson(remaining) : null
+  };
+}
+
+function outcomeFor(row: ResultRow): ReviewOutcome {
+  switch (row.status) {
+    case "success": return outcomeForSuccess(row.response.parsed);
+    case "refusal": return { kind: "refusal", refusal: row.refusal };
+    case "error": return {
+      kind: "error", type: row.error.type, message: row.error.message, attempts: row.error.attempts
+    };
+    default: throw new Error(`A ${row.status} row has no outcome to review`);
+  }
+}
+
+/** Which mode and set sent a picture — the label an unblinded report puts under it. */
+function imageLabelFor(descriptor: ImageRepresentation): string {
+  return `${descriptor.modeId}, ${descriptor.imageSet ?? "full-document"}`;
+}
+
+function addLabel(labels: string[], label: string): void {
+  if (!labels.includes(label)) labels.push(label);
+}
+
+/**
+ * What each reason says on the page. Every sentence is safe in every mode: no path, no filename, no
+ * variant, mode, backend or version.
+ */
+const kUnavailableSentences: Record<UnavailableReason, string> = {
+  missing: "the file it was generated into is no longer on disk",
+  unreadable: "the stored file could not be read",
+  "wrong-document": "the stored file describes something other than this run's input",
+  "variant-changed": "the representation has been regenerated by a newer version of its variant",
+  "document-changed": "the document has changed since this run, so what is on disk now describes " +
+    "the newer content",
+  "render-changed": "the render on disk no longer matches the one this run sent",
+  "bytes-changed": "the picture on disk no longer holds the bytes this run sent"
+};
+
+/**
+ * The inputs a document's runs sent, deduplicated.
+ *
+ * Runs share inputs — three text runs over the `default` variant sent one summary between them — so
+ * the report shows each distinct input once, labelled with everything that sent it. Order is first
+ * appearance walking the rows in experiment-run order, which is stable.
+ */
+function inputsFor(
+  paths: CorpusPaths, docId: string, rows: readonly ResultRow[], modes: ReviewModes
+): Pick<ReviewDocument, "images" | "texts" | "inputNotices"> {
+  const { blind } = modes;
+  const images: ReviewImageInput[] = [];
+  const texts: ReviewTextInput[] = [];
+  const notices: string[] = [];
+  const imagesByHash = new Map<string, ReviewImageInput>();
+  const textsByDescriptor = new Map<string, ReviewTextInput>();
+  const noticed = new Set<string>();
+
+  /**
+   * One notice per distinct representation, however many runs sent it.
+   *
+   * Both halves are mode-aware. `what` names the variant or the render mode, so a blinded report
+   * drops it. The reason is written here from a fixed vocabulary rather than passed through from
+   * the reader, because the underlying errors carry absolute paths, image filenames and freshness
+   * reasons — a document identifier for a shareable report, a run configuration for a blinded one.
+   * `detail` is the unredacted version and only the team-internal report prints it.
+   */
+  const notice = (what: string, reason: UnavailableInput) => {
+    const because = kUnavailableSentences[reason.unavailable];
+    const message = blind
+      ? `An input this document's runs sent is not shown: ${because}.`
+      : `${what} is not shown: ${because}` +
+        (reason.detail && !modes.shareable ? ` (${reason.detail})` : "") +
+        ". The current file is deliberately not shown in its place — it is not what this run was " +
+        "given.";
+    if (!noticed.has(message)) {
+      noticed.add(message);
+      notices.push(message);
+    }
+  };
+
+  const addText = (descriptor: TextRepresentation) => {
+    const key = `${descriptor.variantId} ${descriptor.variantVersion} ${descriptor.sourceContentSha256}`;
+    const existing = textsByDescriptor.get(key);
+    if (existing) {
+      if (!blind) addLabel(existing.labels, descriptor.variantId);
+      return;
+    }
+    const read = readSentText(paths, docId, descriptor);
+    if ("unavailable" in read) {
+      notice(`The summary sent by variant "${descriptor.variantId}"`, read);
+      // Recorded as seen, so a second run over the same descriptor does not repeat the read.
+      textsByDescriptor.set(key, { variantId: descriptor.variantId,
+        variantVersion: descriptor.variantVersion, markdown: "", labels: [] });
+      return;
+    }
+    const entry: ReviewTextInput = {
+      variantId: descriptor.variantId,
+      variantVersion: descriptor.variantVersion,
+      markdown: read.markdown,
+      labels: blind ? [] : [descriptor.variantId]
+    };
+    textsByDescriptor.set(key, entry);
+    texts.push(entry);
+  };
+
+  // Several runs usually send the same pictures — an image run, a mixed run and a detail variant all
+  // over one render — and reading and hashing a few hundred kilobytes once per row would be work
+  // done to reach the same answer.
+  const readImages = new Map<string, ReturnType<typeof readSentImages>>();
+  const addImages = (descriptor: ImageRepresentation) => {
+    const key = `${descriptor.modeId} ${descriptor.backendId} ${descriptor.backendVersion} ` +
+      `${descriptor.sourceContentSha256} ${descriptor.imageSha256s.join(",")}`;
+    let read = readImages.get(key);
+    if (!read) {
+      read = readSentImages(paths, docId, descriptor);
+      readImages.set(key, read);
+    }
+    if ("unavailable" in read) {
+      notice(`The picture(s) sent by ${imageLabelFor(descriptor)}`, read);
+      return;
+    }
+    for (const { image, bytes } of read.images) {
+      const existing = imagesByHash.get(image.sha256);
+      if (existing) {
+        if (!blind) addLabel(existing.labels, imageLabelFor(descriptor));
+        continue;
+      }
+      const entry: ReviewImageInput = {
+        sha256: image.sha256,
+        dataUrl: `data:${image.mimeType};base64,${bytes.toString("base64")}`,
+        widthPx: image.widthPx,
+        heightPx: image.heightPx,
+        bytes: image.bytes,
+        tileId: modes.shareable ? null : image.tileId,
+        labels: blind ? [] : [imageLabelFor(descriptor)]
+      };
+      imagesByHash.set(image.sha256, entry);
+      images.push(entry);
+    }
+  };
+
+  for (const row of rows) {
+    if (row.status === "skipped") continue;
+    const representation = row.representation;
+    if (representation.kind === "text") {
+      addText(representation);
+    } else if (representation.kind === "image") {
+      addImages(representation);
+    } else {
+      // A mixed row whose text half was dropped sent no summary, and saying it sent one would be
+      // exactly the misdirection this report exists to avoid.
+      if (!row.textPartOmitted) addText(representation.text);
+      addImages(representation.image);
+    }
+  }
+  return { images, texts, inputNotices: notices };
+}
+
+/**
+ * Assembles the whole document: the rows, the experiment's run list and the corpus tree in, one
+ * renderable model out.
+ *
+ * Nothing is written here. A `--reuse-key` run's refusals — a key from another corpus, another
+ * experiment, another mode or another set of outcomes — are raised from this function, which is why
+ * a refused run can be guaranteed to have written nothing.
+ */
+export function buildReviewModel(options: BuildReviewOptions): ReviewModel {
+  const { rows, experiment, paths, modes, existingKey } = options;
+  const { current, superseded } = partitionSuperseded(rows);
+  const manifest = readManifest(paths);
+  const byDocument = currentRowsByDocument(current);
+  const manifestById = new Map(manifest.documents.map((entry) => [entry.id, entry]));
+
+  // Manifest order, then anything the results name that the manifest no longer does — dropping
+  // those would hide outcomes a run really produced.
+  const inManifestOrder = [
+    ...manifest.documents.map((entry) => entry.id).filter((docId) => byDocument.has(docId)),
+    ...[...byDocument.keys()].filter((docId) => !manifestById.has(docId)).sort()
+  ];
+  // **Presentation order**: the page groups documents by modality, so manifest order is not the
+  // order anyone reads in. Everything numbered or listed downstream — the pseudonyms, the key's
+  // document list, the ratings template — is built from this one sequence, so a judge working down
+  // the page works down the spreadsheet at the same time. Within a group, manifest order stands.
+  const modalityOf = (docId: string) => byDocument.get(docId)!.values().next().value!.modality;
+  const docIds = modalities.flatMap(
+    (modality) => inManifestOrder.filter((docId) => modalityOf(docId) === modality));
+  const known = new Set(experiment.runs.map((run) => run.id));
+  /** Every document's rows in experiment-file order — the order the header lists runs in. */
+  const rowsByDocument = new Map(docIds.map((docId) => {
+    const forDocument = byDocument.get(docId)!;
+    const ordered = experiment.runs
+      .map((run) => forDocument.get(run.id))
+      .filter((row): row is ResultRow => row !== undefined);
+    // A row for a run the experiment does not define can only come from a hand-edited file. It is
+    // still an outcome, so it is shown after the defined ones rather than dropped.
+    const extra = [...forDocument.values()]
+      .filter((row) => !known.has(row.runId))
+      .sort((a, b) => a.runId.localeCompare(b.runId));
+    return [docId, [...ordered, ...extra]] as const;
+  }));
+
+  const counts = { success: 0, refusal: 0, error: 0, skipped: 0 };
+  const judgeable: ReviewKeyPair[] = [];
+  for (const docId of docIds) {
+    for (const row of rowsByDocument.get(docId)!) {
+      counts[row.status] += 1;
+      if (row.status !== "skipped") judgeable.push({ docId, runId: row.runId });
+    }
+  }
+
+  const pseudonyms: Record<string, string> = {};
+  docIds.forEach((docId, index) => {
+    pseudonyms[docId] = `doc-${String(index + 1).padStart(2, "0")}`;
+  });
+
+  // Checked before a single file is read, let alone written: a `--reuse-key` run over a different
+  // corpus, experiment, mode or set of outcomes is refused here.
+  if (existingKey) {
+    assertKeyIsReusable(existingKey.key, {
+      corpus: manifest.name,
+      experimentSha256: options.experimentSha256,
+      modes,
+      documents: docIds,
+      judgeable,
+      pseudonyms: modes.shareable ? pseudonyms : null
+    }, existingKey.file);
+  }
+
+  const promptShaByRun = new Map<string, string>();
+  for (const row of current) promptShaByRun.set(row.runId, row.prompt.sha256);
+  const configurations = experiment.runs.map(
+    (run) => configurationFor(run, promptShaByRun.get(run.id) ?? null));
+  const configurationById = new Map(configurations.map((entry) => [entry.runId, entry]));
+
+  const seed = existingKey?.key.seed ?? options.seed;
+  const labels: Record<string, Record<string, string>> = {};
+
+  const documents: ReviewDocument[] = docIds.map((docId) => {
+    const rowsForDocument = rowsByDocument.get(docId)!;
+    const sent = rowsForDocument.filter((row) => row.status !== "skipped");
+    const cards = sent.map(
+      (row) => cardFor(row, configurationById.get(row.runId) ?? null, modes));
+
+    if (modes.blind) {
+      // A reused key's own mapping is applied rather than re-derived. Re-deriving from its seed
+      // would give the same answer — that is what the seed is for — but reading back the mapping the
+      // judge was actually shown removes the question, and a hand-edited key cannot then produce a
+      // report whose labels disagree with the file that decodes it.
+      const labelByRun = existingKey?.key.labels
+        ? new Map(Object.entries(existingKey.key.labels[docId] ?? {})
+          .map(([label, runId]) => [runId, label]))
+        : blindLabelsFor(seed, docId, sent.map((row) => row.runId));
+      cards.forEach((card, index) => {
+        card.label = labelByRun.get(sent[index].runId)!;
+      });
+      // Presented in label order. Leaving them in experiment order with shuffled letters attached
+      // would hand the mapping straight back to anyone who knows the run list.
+      cards.sort((a, b) => a.label!.localeCompare(b.label!));
+      // A document with nothing to judge gets no entry at all, rather than an empty one: the key
+      // maps labels, and there are no labels here.
+      if (labelByRun.size > 0) {
+        labels[docId] = Object.fromEntries(
+          [...labelByRun.entries()].map(([runId, label]) => [label, runId]));
+      }
+    }
+
+    const entry = manifestById.get(docId) ?? null;
+    const first = rowsForDocument[0];
+    return {
+      docId,
+      displayName: modes.shareable ? pseudonyms[docId] : docId,
+      modality: first.modality,
+      computedModality: first.computedModality,
+      overridden: first.modality !== first.computedModality,
+      metadata: modes.shareable || !entry ? null : metadataFor(entry),
+      missingFromManifest: !entry,
+      ...inputsFor(paths, docId, rowsForDocument, modes),
+      cards,
+      skipped: rowsForDocument
+        .filter((row): row is ResultRow & { status: "skipped" } => row.status === "skipped")
+        .map((row) => ({
+          runId: modes.blind ? null : row.runId,
+          skipReasons: modes.blind ? [] : row.skipReasons
+        }))
+    };
+  });
+
+  return {
+    generatedAt: options.now.toISOString(),
+    corpus: manifest.name,
+    experimentName: experiment.name,
+    experimentSha256: options.experimentSha256,
+    resultsFile: modes.shareable ? null : options.resultsFile,
+    gitCommit: modes.shareable ? null : current[current.length - 1]?.runMeta.gitCommit ?? null,
+    modes,
+    runs: modes.blind ? null : configurations,
+    runCount: experiment.runs.length,
+    counts,
+    supersededRows: superseded.length,
+    groups: groupByModality(documents),
+    documents,
+    judgeable,
+    pseudonyms: modes.shareable ? pseudonyms : null,
+    seed: modes.blind ? seed : null,
+    labels: modes.blind ? labels : null
+  };
+}
+
+function metadataFor(entry: ManifestDocument): ReviewDocumentMetadata {
+  return {
+    unit: entry.unit,
+    investigation: entry.investigation,
+    problem: entry.problem,
+    contextId: entry.contextId,
+    source: entry.source,
+    file: entry.file
+  };
+}
+
+function cardFor(
+  row: ResultRow, configuration: ReviewRunConfiguration | null, modes: ReviewModes
+): ReviewCard {
+  if (row.status === "skipped") throw new Error("A skipped row is not a judgeable card");
+  const { blind } = modes;
+  return {
+    docId: row.docId,
+    runId: blind ? null : row.runId,
+    label: null,
+    status: row.status,
+    configuration: blind ? null : configuration,
+    outcome: outcomeFor(row),
+    usage: blind || !row.usage ? null : { ...row.usage },
+    modeledUsd: blind || !row.cost ? null : row.cost.modeledUsd,
+    textPartOmitted: row.textPartOmitted === true,
+    // Only the team-internal report carries these. They name the run's shape and the tile ids it
+    // could not photograph, which are a configuration in a blinded report and a document identifier
+    // in a shareable one.
+    representationWarnings: blind || modes.shareable ? [] : row.representationWarnings ?? []
+  };
+}
+
+/**
+ * Documents grouped the way `report` groups rows: by the modality each row was filed under.
+ *
+ * `documents` is already in presentation order, so this only partitions it — the groups appear in
+ * the order the documents do, and flattening the groups gives back exactly the input sequence.
+ */
+function groupByModality(documents: ReviewDocument[]): ReviewModel["groups"] {
+  return modalities
+    .map((modality) => ({
+      modality,
+      documents: documents.filter((document) => document.modality === modality)
+    }))
+    .filter((group) => group.documents.length > 0);
+}
+
+// ---------------------------------------------------------------------------
+// The key file
+// ---------------------------------------------------------------------------
+
+export function reviewKeyFileFor(model: ReviewModel): ReviewKeyFile {
+  return {
+    schemaVersion: kSchemaVersion,
+    generatedAt: model.generatedAt,
+    corpus: model.corpus,
+    experiment: model.experimentName,
+    experimentSha256: model.experimentSha256,
+    modes: { ...model.modes },
+    documents: model.documents.map((document) => document.docId),
+    judgeable: model.judgeable,
+    pseudonyms: model.pseudonyms,
+    seed: model.seed,
+    labels: model.labels
+  };
+}
+
+function pairsOf(pairs: ReviewKeyPair[]): string[] {
+  return pairs.map((pair) => `${pair.docId} ${pair.runId}`).sort();
+}
+
+/** What a key has to agree with before it may be reused. */
+export interface ReviewKeyFacts {
+  corpus: string;
+  experimentSha256: string;
+  modes: ReviewModes;
+  /** Presentation order, which is what the pseudonyms number. */
+  documents: string[];
+  judgeable: ReviewKeyPair[];
+  /** The mapping this invocation would produce; `null` when the report is not shareable. */
+  pseudonyms: Record<string, string> | null;
+}
+
+export function reviewKeyFactsOf(model: ReviewModel): ReviewKeyFacts {
+  return {
+    corpus: model.corpus,
+    experimentSha256: model.experimentSha256,
+    modes: model.modes,
+    documents: model.documents.map((document) => document.docId),
+    judgeable: model.judgeable,
+    pseudonyms: model.pseudonyms
+  };
+}
+
+/**
+ * Whether an existing key may be reused for this invocation: same corpus, same experiment
+ * definition, same modes, same documents in the same order, same judgeable outcomes.
+ *
+ * Anything less and the labels would mean something different from what the judge was shown: a
+ * document added, a run re-run into a new outcome, a mode flag changed, the pseudonyms renumbered.
+ * Same inputs, same labels and pseudonyms, or nothing.
+ */
+export function assertKeyIsReusable(
+  key: ReviewKeyFile, facts: ReviewKeyFacts, keyFile: string
+): void {
+  const refuse = (what: string, wasOver: string, isOver: string): never => {
+    throw new Error(`${keyFile} cannot be reused: it was generated over ${what} ${wasOver}, and this ` +
+      `report covers ${isOver}. Reusing it would put labels a judge has already seen on different ` +
+      "outcomes. Generate a fresh report with a different --out.");
+  };
+  if (key.corpus !== facts.corpus) refuse("corpus", key.corpus, facts.corpus);
+  if (key.experimentSha256 !== facts.experimentSha256) {
+    refuse("experiment definition", key.experimentSha256, facts.experimentSha256);
+  }
+  if (key.modes.shareable !== facts.modes.shareable || key.modes.blind !== facts.modes.blind) {
+    refuse("modes", `shareable=${key.modes.shareable}, blind=${key.modes.blind}`,
+      `shareable=${facts.modes.shareable}, blind=${facts.modes.blind}`);
+  }
+  if (key.documents.join(" ") !== facts.documents.join(" ")) {
+    refuse("documents", `${key.documents.length} of them`,
+      `${facts.documents.length}, with different ids or in a different order`);
+  }
+  const stored = pairsOf(key.judgeable);
+  const now = pairsOf(facts.judgeable);
+  if (stored.join(" ") !== now.join(" ")) {
+    refuse("judgeable outcomes", `${stored.length} of them`, `${now.length}`);
+  }
+  // The pseudonyms are numbered from the presentation order, which the document check above has
+  // already pinned — but the key's own mapping is what a reader holding it will decode with, and
+  // nothing else compares the two. A key naming `doc-99` for a report that says `doc-01` decodes
+  // nothing, however well formed it is.
+  if (facts.pseudonyms) {
+    const expected = canonicalJson(facts.pseudonyms);
+    if (canonicalJson(key.pseudonyms ?? {}) !== expected) {
+      throw new Error(`${keyFile} cannot be reused: its pseudonyms are not the ones this report ` +
+        "renders, so it would not decode them.");
+    }
+  }
+  if (!key.labels) return;
+  // The stored labels are what a reused report is rendered from, so a key that does not label
+  // exactly this set — one label per outcome, one outcome per label — is refused rather than
+  // half-applied. Counting labels as well as runs is what catches a second label aliased onto a run
+  // that is already mapped: the set of runs would look complete while the extra label decided,
+  // silently, which one the report actually showed.
+  for (const docId of facts.documents) {
+    const forDocument = key.labels[docId] ?? {};
+    const labelled = new Set(Object.values(forDocument));
+    const expected = facts.judgeable.filter((pair) => pair.docId === docId);
+    if (Object.keys(forDocument).length !== expected.length ||
+        labelled.size !== expected.length ||
+        !expected.every((pair) => labelled.has(pair.runId))) {
+      throw new Error(`${keyFile} cannot be reused: its labels for document "${docId}" do not ` +
+        "cover exactly the outcomes this report renders, one label each.");
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The ratings template
+// ---------------------------------------------------------------------------
+
+function csvField(value: string): string {
+  return `"${value.replace(/"/g, '""')}"`;
+}
+
+/**
+ * One row per judgeable card, and nothing else.
+ *
+ * Milestone 5 defines the rubric and the command that reads this back; all this milestone
+ * guarantees is that a judge has somewhere to write answers that a program can later read. Inventing
+ * rubric columns here would fix a rubric nobody has agreed on yet.
+ */
+export function ratingsTemplateCsv(model: ReviewModel): string {
+  const lines = ["document,label,rating,notes"];
+  for (const document of model.documents) {
+    for (const card of document.cards) {
+      lines.push([document.displayName, card.label ?? "", "", ""].map(csvField).join(","));
+    }
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+const kStyles = `
+  :root { color-scheme: light; }
+  body { margin: 0; padding: 0 1.5rem 4rem; color: #1b1b1b; background: #fff;
+    font: 15px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; }
+  h1 { font-size: 1.5rem; margin: 1.5rem 0 0.5rem; }
+  h2 { font-size: 1.2rem; margin: 2.5rem 0 0.5rem; padding-bottom: 0.25rem;
+    border-bottom: 2px solid #1b1b1b; }
+  h3 { font-size: 1.05rem; margin: 0 0 0.25rem; }
+  h4 { font-size: 0.85rem; margin: 1rem 0 0.5rem; text-transform: uppercase;
+    letter-spacing: 0.06em; color: #555; }
+  .meta { color: #555; font-size: 0.85rem; }
+  .meta dl { display: grid; grid-template-columns: max-content 1fr; gap: 0.15rem 0.75rem; margin: 0.5rem 0; }
+  .meta dt { font-weight: 600; }
+  .meta dd { margin: 0; }
+  table { border-collapse: collapse; font-size: 0.85rem; margin: 0.5rem 0; }
+  th, td { border: 1px solid #d4d4d4; padding: 0.2rem 0.5rem; text-align: left; vertical-align: top; }
+  th { background: #f2f2f2; }
+  .document { border: 1px solid #c8c8c8; border-radius: 6px; padding: 1rem 1.25rem;
+    margin: 1.25rem 0; break-inside: avoid; }
+  .document-header { display: flex; flex-wrap: wrap; align-items: baseline; gap: 0.75rem; }
+  .inputs { margin: 0.75rem 0; }
+  .input-block { margin: 0 0 1rem; }
+  .input-label { font-size: 0.8rem; color: #555; margin: 0 0 0.25rem; }
+  img { max-width: 100%; height: auto; border: 1px solid #d4d4d4; background: #fbfbfb; }
+  pre { white-space: pre-wrap; overflow-wrap: anywhere; background: #f7f7f7;
+    border: 1px solid #e2e2e2; border-radius: 4px; padding: 0.6rem 0.75rem; margin: 0;
+    font: 12px/1.45 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; max-height: 32rem;
+    overflow-y: auto; }
+  .cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(19rem, 1fr)); gap: 0.75rem; }
+  .card { border: 1px solid #c8c8c8; border-radius: 5px; padding: 0.6rem 0.75rem; background: #fcfcfc; }
+  .card-header { display: flex; flex-wrap: wrap; align-items: baseline; gap: 0.5rem;
+    border-bottom: 1px solid #e2e2e2; padding-bottom: 0.35rem; margin-bottom: 0.5rem; }
+  .card-title { font-weight: 700; }
+  .card-config { color: #555; font-size: 0.8rem; }
+  .field { margin: 0.4rem 0; }
+  .field-name { font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.06em; color: #666; }
+  .badge { display: inline-block; border-radius: 999px; padding: 0.05rem 0.5rem; font-size: 0.75rem;
+    font-weight: 700; border: 1px solid; }
+  .badge-success { color: #1c5d2c; border-color: #1c5d2c; background: #eaf6ec; }
+  .badge-refusal { color: #8a5b00; border-color: #8a5b00; background: #fdf3e0; }
+  .badge-error { color: #8a1c1c; border-color: #8a1c1c; background: #fbecec; }
+  .badge-skipped { color: #444; border-color: #999; background: #f0f0f0; }
+  .badge-flag { color: #8a1c1c; border-color: #8a1c1c; background: #fbecec; }
+  .notice { border-left: 4px solid #8a5b00; background: #fdf3e0; padding: 0.4rem 0.6rem;
+    margin: 0.4rem 0; font-size: 0.85rem; }
+  .skipped-strip { margin-top: 1rem; border-top: 1px dashed #b0b0b0; padding-top: 0.6rem;
+    color: #444; font-size: 0.85rem; }
+  .skipped-strip ul { margin: 0.25rem 0; padding-left: 1.25rem; }
+  ul.indicators { margin: 0.2rem 0; padding-left: 1.25rem; }
+`;
+
+function shortSha(sha256: string): string {
+  return sha256.slice(0, 12);
+}
+
+/** Picture sizes span three orders of magnitude here, and "0 KB" describes none of them. */
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} bytes`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function statusBadge(status: "success" | "refusal" | "error" | "skipped"): Html {
+  return html`<span class="badge badge-${status}">${status}</span>`;
+}
+
+function runTable(runs: ReviewRunConfiguration[]): Html {
+  const cell = (value: string | null) => html`<td>${value ?? "—"}</td>`;
+  return html`
+    <table>
+      <thead><tr><th>run</th><th>message</th><th>text variant</th><th>image mode</th><th>detail</th>
+        <th>image set</th><th>extras</th><th>prompt</th></tr></thead>
+      <tbody>
+        ${runs.map((run) => html`<tr>
+          <td>${run.runId}</td>
+          <td>${run.message}</td>
+          ${cell(run.textVariant)}
+          ${cell(run.imageMode)}
+          ${cell(run.detail)}
+          ${cell(run.imageSet)}
+          ${cell(run.extras)}
+          <td>${run.promptName}${run.promptSha256
+            ? html` <span class="meta">(${shortSha(run.promptSha256)})</span>`
+            : ""}</td>
+        </tr>`)}
+      </tbody>
+    </table>`;
+}
+
+function headerBlock(model: ReviewModel): Html {
+  const { counts } = model;
+  return html`
+    <h1>Review: ${model.corpus}</h1>
+    <div class="meta">
+      <dl>
+        <dt>Experiment</dt>
+        <dd>${model.experimentName} (${shortSha(model.experimentSha256)})</dd>
+        <dt>Documents</dt>
+        <dd>${model.documents.length}</dd>
+        <dt>Outcomes</dt>
+        <dd>${counts.success} success, ${counts.refusal} refusal, ${counts.error} error,
+          ${counts.skipped} skipped${model.supersededRows > 0
+            ? html`; ${model.supersededRows} superseded row(s) replaced by a later re-run and not
+              shown`
+            : ""}</dd>
+        <dt>Generated</dt>
+        <dd>${model.generatedAt}</dd>
+        ${model.resultsFile ? html`<dt>Results</dt><dd>${model.resultsFile}</dd>` : ""}
+        ${model.gitCommit ? html`<dt>Harness commit</dt><dd>${model.gitCommit}</dd>` : ""}
+      </dl>
+    </div>
+    ${model.runs
+      ? html`<h4>Runs, in experiment-file order</h4>${runTable(model.runs)}`
+      : html`<p class="meta">${model.runCount} run(s). Which configuration produced which output is
+          withheld: this is a blinded report, and the mapping is in its key file.</p>`}
+    ${model.modes.shareable
+      ? html`<p class="notice">Shareable: document ids are replaced by per-report pseudonyms and
+          harness metadata is omitted. <strong>Document content is not redacted</strong> — the
+          summaries, pictures and model outputs below can themselves contain identifying
+          information.</p>`
+      : ""}`;
+}
+
+function inputsBlock(document: ReviewDocument): Html {
+  return html`
+    <div class="inputs">
+      <h4>What the model was given</h4>
+      ${document.inputNotices.map((message) => html`<p class="notice">${message}</p>`)}
+      ${document.images.map((image, index) => html`
+        <div class="input-block">
+          <p class="input-label">Image ${index + 1} of ${document.images.length}${image.tileId
+            ? html`, tile ${image.tileId}`
+            : ""}${image.labels.length > 0 ? html` — ${image.labels.join("; ")}` : ""}
+            (${image.widthPx}×${image.heightPx}, ${formatBytes(image.bytes)})</p>
+          <img src="${image.dataUrl}" alt="Rendered document ${document.displayName}, image ${index + 1}">
+        </div>`)}
+      ${document.texts.map((text, index) => html`
+        <div class="input-block">
+          <p class="input-label">Summary ${index + 1} of ${document.texts.length}${text.labels.length > 0
+            ? html` — variant ${text.labels.join("; ")}`
+            : ""}</p>
+          <pre>${text.markdown}</pre>
+        </div>`)}
+      ${document.images.length === 0 && document.texts.length === 0
+        ? html`<p class="meta">No input is available to show for this document.</p>`
+        : ""}
+    </div>`;
+}
+
+function configurationLine(configuration: ReviewRunConfiguration): string {
+  const parts: string[] = [configuration.message];
+  if (configuration.textVariant) parts.push(configuration.textVariant);
+  if (configuration.imageMode) parts.push(configuration.imageMode);
+  if (configuration.detail) parts.push(`detail ${configuration.detail}`);
+  if (configuration.imageSet) parts.push(configuration.imageSet);
+  if (configuration.extras) parts.push(`extras ${configuration.extras}`);
+  parts.push(configuration.promptName);
+  return parts.join(" · ");
+}
+
+function outcomeBlock(outcome: ReviewOutcome): Html {
+  if (outcome.kind === "refusal") {
+    return html`<div class="field"><div class="field-name">refusal</div><pre>${outcome.refusal}</pre></div>`;
+  }
+  if (outcome.kind === "error") {
+    return html`
+      <div class="field">
+        <div class="field-name">error</div>
+        <pre>${outcome.type}: ${outcome.message}
+attempts: ${outcome.attempts}</pre>
+      </div>`;
+  }
+  return html`
+    ${outcome.category !== null
+      ? html`<div class="field"><div class="field-name">category</div><div>${outcome.category}</div></div>`
+      : ""}
+    ${outcome.keyIndicators
+      ? html`<div class="field"><div class="field-name">key indicators</div>
+          ${outcome.keyIndicators.length > 0
+            // An empty list is a real answer — the model returned the field and put nothing in it —
+            // so it is said rather than drawn as an empty bullet list.
+            ? html`<ul class="indicators">${outcome.keyIndicators.map((item) => html`<li>${item}</li>`)}</ul>`
+            : html`<div class="meta">none listed</div>`}</div>`
+      : ""}
+    ${outcome.discussion !== null
+      ? html`<div class="field"><div class="field-name">discussion</div><div>${outcome.discussion}</div></div>`
+      : ""}
+    ${outcome.remainingJson
+      ? html`<div class="field"><div class="field-name">other response fields</div>
+          <pre>${outcome.remainingJson}</pre></div>`
+      : ""}
+    ${outcome.category === null && !outcome.keyIndicators && outcome.discussion === null &&
+      !outcome.remainingJson
+      ? html`<p class="meta">The response parsed to an empty object.</p>`
+      : ""}`;
+}
+
+function cardBlock(card: ReviewCard): Html {
+  return html`
+    <div class="card">
+      <div class="card-header">
+        <span class="card-title">${card.label ?? card.runId}</span>
+        ${statusBadge(card.status)}
+        ${card.textPartOmitted
+          ? html`<span class="badge badge-flag">no summary sent</span>`
+          : ""}
+      </div>
+      ${card.configuration
+        ? html`<p class="card-config">${configurationLine(card.configuration)}</p>`
+        : ""}
+      ${card.textPartOmitted
+        ? html`<p class="notice">This document carried no student-authored text, so the summary and
+            related summaries were dropped: this output saw the picture(s) only.</p>`
+        : ""}
+      ${outcomeBlock(card.outcome)}
+      ${card.representationWarnings.map((warning) => html`<p class="notice">${warning}</p>`)}
+      ${card.usage
+        ? html`<p class="card-config">${[
+          `${card.usage.promptTokens} in / ${card.usage.completionTokens} out tokens`,
+          card.modeledUsd === null ? null : `$${card.modeledUsd.toFixed(4)} modeled`,
+          card.usage.source === "cache" ? "from cache" : "fresh call"
+        ].filter(Boolean).join(" · ")}</p>`
+        : ""}
+    </div>`;
+}
+
+function documentBlock(document: ReviewDocument): Html {
+  return html`
+    <article class="document">
+      <div class="document-header">
+        <h3>${document.displayName}</h3>
+        ${document.overridden
+          ? html`<span class="badge badge-flag">modality overridden (classifier said
+              ${document.computedModality})</span>`
+          : ""}
+        ${document.missingFromManifest
+          ? html`<span class="badge badge-flag">no longer in the corpus manifest</span>`
+          : ""}
+      </div>
+      ${document.metadata
+        ? html`<p class="meta">${[
+          document.metadata.unit && `unit ${document.metadata.unit}`,
+          document.metadata.investigation && `investigation ${document.metadata.investigation}`,
+          document.metadata.problem && `problem ${document.metadata.problem}`,
+          document.metadata.contextId && `class ${document.metadata.contextId}`,
+          `source ${document.metadata.source}`,
+          document.metadata.file
+        ].filter(Boolean).join(" · ")}</p>`
+        : ""}
+      ${inputsBlock(document)}
+      <h4>What each run said</h4>
+      ${document.cards.length > 0
+        ? html`<div class="cards">${document.cards.map(cardBlock)}</div>`
+        : html`<p class="meta">No run produced an outcome for this document.</p>`}
+      ${document.skipped.length > 0
+        ? html`
+          <div class="skipped-strip">
+            <div><strong>${document.skipped.length} run(s) declined to send this document</strong>
+              ${statusBadge("skipped")} — nothing was produced, so there is nothing to judge here.</div>
+            ${document.skipped.some((entry) => entry.skipReasons.length > 0)
+              ? html`<ul>
+                ${document.skipped.map((entry) => html`<li>${entry.runId
+                  ? html`<strong>${entry.runId}</strong>: `
+                  : ""}${entry.skipReasons.join("; ")}</li>`)}
+              </ul>`
+              // A skip reason names the shape and settings of the run that declined, which is a
+              // configuration standing next to labelled cards.
+              : html`<div>Why each one declined is withheld: the reasons name run configurations.</div>`}
+          </div>`
+        : ""}
+    </article>`;
+}
+
+/**
+ * One self-contained, inert file: inline CSS, **no JavaScript**, images as `data:` URLs, no external
+ * reference of any kind.
+ *
+ * The CSP meta tag should be redundant — there is no script to run and nothing to fetch. It is there
+ * so that a bug in the escaping above still cannot reach the network.
+ */
+export function renderReviewHtml(model: ReviewModel): string {
+  const title = `Review: ${model.corpus} / ${model.experimentName}` +
+    `${model.modes.blind ? " (blind)" : ""}${model.modes.shareable ? " (shareable)" : ""}`;
+  const page = html`<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src data:; style-src 'unsafe-inline'">
+<title>${title}</title>
+<!-- The one place a fragment is built from a plain string. \`kStyles\` is a constant in this file
+     with nothing interpolated into it; escaping it would break the CSS rather than protect it. -->
+<style>${new HtmlFragment(kStyles)}</style>
+</head>
+<body>
+${headerBlock(model)}
+${model.groups.map((group) => html`
+<h2>${group.modality} (${group.documents.length} document(s))</h2>
+${group.documents.map(documentBlock)}`)}
+</body>
+</html>
+`;
+  return page.markup;
+}

--- a/scripts/ai-harness/src/review.ts
+++ b/scripts/ai-harness/src/review.ts
@@ -303,7 +303,11 @@ export interface ReviewModel {
 // Blind ordering
 // ---------------------------------------------------------------------------
 
-/** `A`…`Z`, then `AA`, `AB`… — enough labels for any run list, in an order a reader can follow. */
+/**
+ * `A`…`Z`, then `AA`, `AB`… — enough labels for any run list, in an order a reader can follow.
+ *
+ * Sort them with `compareLabels`, never with `localeCompare` alone: see below.
+ */
 export function labelForIndex(index: number): string {
   let label = "";
   let remaining = index;
@@ -312,6 +316,18 @@ export function labelForIndex(index: number): string {
     remaining = Math.floor(remaining / 26) - 1;
     if (remaining < 0) return label;
   }
+}
+
+/**
+ * Orders labels the way `labelForIndex` issues them.
+ *
+ * Plain lexicographic ordering is wrong past `Z`: it puts `AA` immediately after `A`, so a document
+ * with more than 26 outcomes would render `A, AA, AB, …, B`. Length first, because the labels are
+ * bijective base-26 and their length rises with the index, so length-then-lexicographic *is* index
+ * order. It lives here rather than at the sort, so the sequence and its ordering cannot drift apart.
+ */
+export function compareLabels(a: string, b: string): number {
+  return a.length - b.length || a.localeCompare(b);
 }
 
 /**
@@ -822,7 +838,7 @@ export function buildReviewModel(options: BuildReviewOptions): ReviewModel {
       });
       // Presented in label order. Leaving them in experiment order with shuffled letters attached
       // would hand the mapping straight back to anyone who knows the run list.
-      cards.sort((a, b) => a.label!.localeCompare(b.label!));
+      cards.sort((a, b) => compareLabels(a.label!, b.label!));
       // A document with nothing to judge gets no entry at all, rather than an empty one: the key
       // maps labels, and there are no labels here.
       if (labelByRun.size > 0) {

--- a/scripts/ai-harness/src/review.ts
+++ b/scripts/ai-harness/src/review.ts
@@ -243,9 +243,14 @@ export interface ReviewSkipped {
   /** `null` in blind mode. */
   runId: string | null;
   /**
-   * Empty in blind mode. A skip reason names the shape and settings of the run that declined —
-   * "image-only run with imageSet …" — which is a configuration standing beside labelled cards, so
-   * a blinded report keeps the count and drops the reasons. See DEVIATIONS in the README.
+   * Empty in blind **and** shareable modes; only the team-internal report carries them.
+   *
+   * A skip reason is not a fixed vocabulary. It names the shape and settings of the run that
+   * declined ("image-only run with imageSet …"), which is a configuration standing beside labelled
+   * cards; and it carries whatever `imagesForSet` and `expectedRenderFailure` put in it, which is up
+   * to five tile ids and a line of author-written prose. A tile id contains the document id outright
+   * in this corpus, so a shareable report printed `wave-runner-tile` under the heading `doc-02`.
+   * Same leak as DEVIATIONS 33, one path further along. See DEVIATIONS in the README.
    */
   skipReasons: string[];
 }
@@ -929,7 +934,7 @@ export function buildReviewModel(options: BuildReviewOptions): ReviewModel {
         .filter((row): row is ResultRow & { status: "skipped" } => row.status === "skipped")
         .map((row) => ({
           runId: modes.blind ? null : row.runId,
-          skipReasons: modes.blind ? [] : row.skipReasons
+          skipReasons: modes.blind || modes.shareable ? [] : row.skipReasons
         }))
     };
   });
@@ -1469,9 +1474,10 @@ function documentBlock(document: ReviewDocument): Html {
                   ? html`<strong>${entry.runId}</strong>: `
                   : ""}${entry.skipReasons.join("; ")}</li>`)}
               </ul>`
-              // A skip reason names the shape and settings of the run that declined, which is a
-              // configuration standing next to labelled cards.
-              : html`<div>Why each one declined is withheld: the reasons name run configurations.</div>`}
+              // A skip reason carries a run's configuration and, through `imagesForSet` and
+              // `expectedRenderFailure`, tile ids and author-written prose.
+              : html`<div>Why each one declined is withheld: the reasons name run configurations and
+                  can quote identifiers from the document.</div>`}
           </div>`
         : ""}
     </article>`;

--- a/scripts/ai-harness/src/review.ts
+++ b/scripts/ai-harness/src/review.ts
@@ -287,7 +287,18 @@ export interface ReviewDocument {
 
 export interface ReviewModel {
   generatedAt: string;
+  /** The corpus these rows were run against. Recorded in the key; see `displayCorpus` for the page. */
   corpus: string;
+  /**
+   * The corpus name as the page may print it, or `null` in shareable mode.
+   *
+   * A corpus name is free-form and chosen by whoever ran `import --corpus <name>`, so a production
+   * pull could easily be named after a class or a school — and it was rendering in the heading and
+   * the browser tab of every shareable report. The key file still records the true name, so nothing
+   * about decoding changes; the page falls back to the experiment name, which is authored to
+   * describe the experiment.
+   */
+  displayCorpus: string | null;
   experimentName: string;
   experimentSha256: string;
   /** `null` in shareable mode, where file paths are stripped. */
@@ -427,24 +438,36 @@ interface SentImage {
 }
 
 /**
- * The pictures an image-carrying row sent, or why they cannot be shown.
- *
- * Two checks, both required. The envelope has to still be usable for this row —
- * `imageRepresentationIsUsable` covers mode, backend, backend version, source content and every
- * file-level property, which is the same bar `run` applies before sending one. And every hash the
- * row recorded has to be one of the pictures that envelope now holds, with the bytes on disk still
- * hashing to it. The second check is stated directly rather than inferred from the first: "these are
- * the bytes that were sent" is the claim the report makes, so it is the claim that gets tested.
- */
-/**
  * A document's content, but only when it still hashes to what the run was given.
  *
  * `visual-tiles-only` is the one image set whose membership is not structural: it is the tiles the
  * *classifier* marked as needing a picture, so reconstructing what a run sent means classifying the
  * same content it classified. Anything else is a guess dressed as provenance.
+ *
+ * Wrapped in an object rather than returned bare: `unknown | null` collapses to `unknown`, so the
+ * signature would say nothing about the sentinel every caller checks.
  */
-export type ContentMatching = (sourceContentSha256: string) => unknown | null;
+export type ContentMatching = (sourceContentSha256: string) => { content: unknown } | null;
 
+/**
+ * The pictures an image-carrying row sent, or why they cannot be shown.
+ *
+ * The envelope has to still be usable for this row — `imageRepresentationIsUsable` covers mode,
+ * backend, backend version, source content and every file-level property, which is the same bar
+ * `run` applies before sending one. Then the run's image set decides which of the envelope's
+ * pictures it sent, and each of those is re-read and re-hashed here: "these are the bytes that were
+ * sent" is the claim the report makes, so it is the claim that gets tested.
+ *
+ * **How far that claim reaches, exactly.** A row records `imageSha256s` — every picture the envelope
+ * held — and `imageSet`, not the hashes it actually sent. For `full-document` and `per-tile` the set
+ * is structural, so re-applying it reproduces the same pictures and the claim is tight. For
+ * `visual-tiles-only` the membership is the classifier's, and it is *reconstructed* here rather than
+ * verified: flipping `requiresVisualRepresentation` for a tile type in `capability.ts` would select
+ * differently for the same unchanged content and envelope, and the newly selected picture is still
+ * among `imageSha256s`, so the check below cannot notice. Closing that means recording what was
+ * sent — a `sentImageSha256s` on the descriptor — which changes what a run writes and so belongs to
+ * a later milestone. See DEVIATIONS in the README.
+ */
 function readSentImages(
   paths: CorpusPaths, docId: string, descriptor: ImageRepresentation,
   contentMatching: ContentMatching
@@ -475,9 +498,10 @@ function readSentImages(
   let selected;
   try {
     if (imageSet === "visual-tiles-only") {
-      const content = contentMatching(descriptor.sourceContentSha256);
-      if (content === null) return { unavailable: "selection-unknown" };
-      selected = imagesForSet(envelope, file, imageSet, visualTileIdsOf(classifyDocument(content)));
+      const matching = contentMatching(descriptor.sourceContentSha256);
+      if (!matching) return { unavailable: "selection-unknown" };
+      selected = imagesForSet(
+        envelope, file, imageSet, visualTileIdsOf(classifyDocument(matching.content)));
     } else {
       selected = imagesForSet(envelope, file, imageSet);
     }
@@ -488,8 +512,9 @@ function readSentImages(
   const recorded = new Set(descriptor.imageSha256s);
   const images: SentImage[] = [];
   for (const image of selected.images) {
-    // Belt and braces: a selected picture the row's provenance does not list would mean the
-    // envelope has changed under us in a way the freshness check did not catch.
+    // Every selected picture must be one the row recorded. This proves the picture existed when the
+    // run happened — not that this run selected it, which for `visual-tiles-only` nothing on the row
+    // can prove (see above).
     if (!recorded.has(image.sha256)) return { unavailable: "bytes-changed" };
     let bytes: Buffer;
     try {
@@ -821,16 +846,9 @@ export function buildReviewModel(options: BuildReviewOptions): ReviewModel {
     ...manifest.documents.map((entry) => entry.id).filter((docId) => byDocument.has(docId)),
     ...[...byDocument.keys()].filter((docId) => !manifestById.has(docId)).sort()
   ];
-  // **Presentation order**: the page groups documents by modality, so manifest order is not the
-  // order anyone reads in. Everything numbered or listed downstream — the pseudonyms, the key's
-  // document list, the ratings template — is built from this one sequence, so a judge working down
-  // the page works down the spreadsheet at the same time. Within a group, manifest order stands.
-  const modalityOf = (docId: string) => byDocument.get(docId)!.values().next().value!.modality;
-  const docIds = modalities.flatMap(
-    (modality) => inManifestOrder.filter((docId) => modalityOf(docId) === modality));
   const known = new Set(experiment.runs.map((run) => run.id));
   /** Every document's rows in experiment-file order — the order the header lists runs in. */
-  const rowsByDocument = new Map(docIds.map((docId) => {
+  const rowsByDocument = new Map(inManifestOrder.map((docId) => {
     const forDocument = byDocument.get(docId)!;
     const ordered = experiment.runs
       .map((run) => forDocument.get(run.id))
@@ -842,6 +860,25 @@ export function buildReviewModel(options: BuildReviewOptions): ReviewModel {
       .sort((a, b) => a.runId.localeCompare(b.runId));
     return [docId, [...ordered, ...extra]] as const;
   }));
+
+  /**
+   * The modality a document is filed under: its first row in **experiment-file** order.
+   *
+   * One row decides, and every reader of it uses the same one. Ordering once read the first row in
+   * results-file order while the document itself read the first in experiment-file order — the same
+   * row only until a resume or a re-run appended out of that order, and two rows can disagree about
+   * modality (a hand-set `modalityOverride` between two appends). The page would then be grouped by
+   * one answer and ordered by the other, which is exactly the "work down the page, work down the
+   * spreadsheet" property below.
+   */
+  const modalityOf = (docId: string) => rowsByDocument.get(docId)![0].modality;
+
+  // **Presentation order**: the page groups documents by modality, so manifest order is not the
+  // order anyone reads in. Everything numbered or listed downstream — the pseudonyms, the key's
+  // document list, the ratings template — is built from this one sequence, so a judge working down
+  // the page works down the spreadsheet at the same time. Within a group, manifest order stands.
+  const docIds = modalities.flatMap(
+    (modality) => inManifestOrder.filter((docId) => modalityOf(docId) === modality));
 
   const counts = { success: 0, refusal: 0, error: 0, skipped: 0 };
   const judgeable: ReviewKeyPair[] = [];
@@ -923,7 +960,7 @@ export function buildReviewModel(options: BuildReviewOptions): ReviewModel {
     return {
       docId,
       displayName: modes.shareable ? pseudonyms[docId] : docId,
-      modality: first.modality,
+      modality: modalityOf(docId),
       computedModality: first.computedModality,
       overridden: first.modality !== first.computedModality,
       metadata: modes.shareable || !entry ? null : metadataFor(entry),
@@ -942,6 +979,7 @@ export function buildReviewModel(options: BuildReviewOptions): ReviewModel {
   return {
     generatedAt: options.now.toISOString(),
     corpus: manifest.name,
+    displayCorpus: modes.shareable ? null : manifest.name,
     experimentName: experiment.name,
     experimentSha256: options.experimentSha256,
     resultsFile: modes.shareable ? null : options.resultsFile,
@@ -979,7 +1017,7 @@ function contentMatchingFor(paths: CorpusPaths, entry: ManifestDocument | null):
       }
     }
     if (!loaded) return null;
-    return sha256Canonical(loaded.content) === sourceContentSha256 ? loaded.content : null;
+    return sha256Canonical(loaded.content) === sourceContentSha256 ? loaded : null;
   };
 }
 
@@ -1296,7 +1334,7 @@ function runTable(runs: ReviewRunConfiguration[]): Html {
 function headerBlock(model: ReviewModel): Html {
   const { counts } = model;
   return html`
-    <h1>Review: ${model.corpus}</h1>
+    <h1>Review: ${model.displayCorpus ?? model.experimentName}</h1>
     <div class="meta">
       <dl>
         <dt>Experiment</dt>
@@ -1491,7 +1529,8 @@ function documentBlock(document: ReviewDocument): Html {
  * so that a bug in the escaping above still cannot reach the network.
  */
 export function renderReviewHtml(model: ReviewModel): string {
-  const title = `Review: ${model.corpus} / ${model.experimentName}` +
+  const title = `Review: ${model.displayCorpus ? `${model.displayCorpus} / ` : ""}` +
+    `${model.experimentName}` +
     `${model.modes.blind ? " (blind)" : ""}${model.modes.shareable ? " (shareable)" : ""}`;
   const page = html`<!DOCTYPE html>
 <html lang="en">

--- a/scripts/ai-harness/src/review.ts
+++ b/scripts/ai-harness/src/review.ts
@@ -537,6 +537,28 @@ export function assertExperimentMatchesRows(
     "definition the rows were produced with, or re-run the current one into a fresh --output.");
 }
 
+/**
+ * What a label was put on: the request that was sent, what it was built from, and what came back.
+ *
+ * A (document, run) pair does not identify an outcome — a re-run appends a replacement row for the
+ * same pair. `runMeta`, `usage` and `cost` are left out on purpose: a re-run served from the cache
+ * changes all three while the card a judge read stays identical.
+ */
+function judgeableFingerprint(row: ResultRow): string {
+  if (row.status === "skipped") throw new Error("A skipped row is not judgeable");
+  return sha256Canonical({
+    requestKey: row.requestKey,
+    representation: row.representation,
+    status: row.status,
+    textPartOmitted: row.textPartOmitted === true,
+    // The answer itself, by status. `response.raw` is excluded: it carries a per-call id that
+    // differs between two calls that returned the same thing.
+    parsed: row.status === "success" ? row.response.parsed : undefined,
+    refusal: row.status === "refusal" ? row.refusal : undefined,
+    error: row.status === "error" ? row.error : undefined
+  });
+}
+
 /** The last row per (document, run) — the outcome that still stands. */
 function currentRowsByDocument(rows: ResultRow[]): Map<string, Map<string, ResultRow>> {
   const byDocument = new Map<string, Map<string, ResultRow>>();
@@ -821,7 +843,9 @@ export function buildReviewModel(options: BuildReviewOptions): ReviewModel {
   for (const docId of docIds) {
     for (const row of rowsByDocument.get(docId)!) {
       counts[row.status] += 1;
-      if (row.status !== "skipped") judgeable.push({ docId, runId: row.runId });
+      if (row.status !== "skipped") {
+        judgeable.push({ docId, runId: row.runId, fingerprint: judgeableFingerprint(row) });
+      }
     }
   }
 
@@ -1027,6 +1051,15 @@ function pairsOf(pairs: ReviewKeyPair[]): string[] {
   return pairs.map((pair) => `${pair.docId} ${pair.runId}`).sort();
 }
 
+/** The outcomes whose row has changed since the key was written, by (document, run). */
+function movedOutcomes(key: ReviewKeyFile, facts: ReviewKeyFacts): string[] {
+  const stored = new Map(key.judgeable.map((pair) => [`${pair.docId} ${pair.runId}`, pair.fingerprint]));
+  return facts.judgeable
+    .filter((pair) => stored.get(`${pair.docId} ${pair.runId}`) !== pair.fingerprint)
+    .map((pair) => `${pair.docId}/${pair.runId}`)
+    .sort();
+}
+
 /** What a key has to agree with before it may be reused. */
 export interface ReviewKeyFacts {
   corpus: string;
@@ -1082,6 +1115,17 @@ export function assertKeyIsReusable(
   const now = pairsOf(facts.judgeable);
   if (stored.join(" ") !== now.join(" ")) {
     refuse("judgeable outcomes", `${stored.length} of them`, `${now.length}`);
+  }
+  // Same pairs, different outcomes: a re-run has replaced a row since the key was written. The
+  // labels would survive onto answers nobody rated, and the ratings template — which `--reuse-key`
+  // preserves byte for byte — would go on describing the outcomes it replaced.
+  const moved = movedOutcomes(key, facts);
+  if (moved.length > 0) {
+    throw new Error(`${keyFile} cannot be reused: ${moved.length} outcome(s) have been re-run ` +
+      `since it was written (${moved.slice(0, 3).join(", ")}${moved.length > 3 ? ", …" : ""}). ` +
+      "Its labels would sit on answers nobody has read, and any ratings collected against them " +
+      "would describe the outcomes those answers replaced. Generate a fresh report with a " +
+      "different --out.");
   }
   // The pseudonyms are numbered from the presentation order, which the document check above has
   // already pinned — but the key's own mapping is what a reader holding it will decode with, and

--- a/scripts/ai-harness/src/review.ts
+++ b/scripts/ai-harness/src/review.ts
@@ -148,8 +148,21 @@ export interface ReviewRunConfiguration {
   imageSet: ImageSet | null;
   extras: ExtrasMode | null;
   promptName: string;
-  /** From the run's own rows; `null` when the experiment defines a run this file has no rows for. */
+  /**
+   * The prompt this run's rows actually used. `null` when the experiment defines a run this file
+   * has no rows for, and — the case worth knowing about — when its rows disagree.
+   */
   promptSha256: string | null;
+  /**
+   * How many distinct prompt hashes this run's current rows carry.
+   *
+   * Normally 1. It can be more: a prompt file's content is not part of the experiment hash, but it
+   * *is* part of the request key, so editing a prompt and re-running into the same results file
+   * re-runs every pair — and a re-run that stops early (the spend ceiling, an error, an interrupt)
+   * leaves some pairs on the new prompt and some on the old, all of them current. The header then
+   * cannot honestly name one prompt for the run, and each card carries its own instead.
+   */
+  promptVersions: number;
 }
 
 /** One picture a document's runs actually sent, with the bytes that were sent. */
@@ -209,6 +222,11 @@ export interface ReviewCard {
   usage: { promptTokens: number; completionTokens: number; source: "api" | "cache" } | null;
   /** `null` in blind mode. */
   modeledUsd: number | null;
+  /**
+   * The prompt this row actually used. `null` in blind mode, where it would identify the run.
+   * Rendered only when its run's rows disagree — see `ReviewRunConfiguration.promptVersions`.
+   */
+  promptSha256: string | null;
   /** This row sent a mixed message with its text half dropped: it saw half the input. */
   textPartOmitted: boolean;
   /** Empty in blind and shareable modes; see `cardFor`. */
@@ -482,7 +500,9 @@ function currentRowsByDocument(rows: ResultRow[]): Map<string, Map<string, Resul
   return byDocument;
 }
 
-function configurationFor(run: ExperimentRun, promptSha256: string | null): ReviewRunConfiguration {
+function configurationFor(
+  run: ExperimentRun, promptShas: Set<string>
+): ReviewRunConfiguration {
   return {
     runId: run.id,
     message: run.message,
@@ -492,7 +512,10 @@ function configurationFor(run: ExperimentRun, promptSha256: string | null): Revi
     imageSet: run.imageSet ?? null,
     extras: sendsText(run.message) ? run.extras ?? "all" : null,
     promptName: run.prompt,
-    promptSha256
+    // One hash only when the rows agree on one. Reporting the last row's hash for a run whose rows
+    // disagree told a reader that every card came from that prompt, which was false for some.
+    promptSha256: promptShas.size === 1 ? [...promptShas][0] : null,
+    promptVersions: promptShas.size
   };
 }
 
@@ -762,10 +785,18 @@ export function buildReviewModel(options: BuildReviewOptions): ReviewModel {
     }, existingKey.file);
   }
 
-  const promptShaByRun = new Map<string, string>();
-  for (const row of current) promptShaByRun.set(row.runId, row.prompt.sha256);
+  // Every prompt hash each run's current rows carry, not just the last one — and only from the rows
+  // that actually sent a request. A skipped row records the prompt its run *would* have used, but it
+  // produced no card, so letting it disagree would flag a run whose every card came from one prompt.
+  const promptShasByRun = new Map<string, Set<string>>();
+  for (const row of current) {
+    if (row.status === "skipped") continue;
+    const shas = promptShasByRun.get(row.runId) ?? new Set<string>();
+    shas.add(row.prompt.sha256);
+    promptShasByRun.set(row.runId, shas);
+  }
   const configurations = experiment.runs.map(
-    (run) => configurationFor(run, promptShaByRun.get(run.id) ?? null));
+    (run) => configurationFor(run, promptShasByRun.get(run.id) ?? new Set()));
   const configurationById = new Map(configurations.map((entry) => [entry.runId, entry]));
 
   const seed = existingKey?.key.seed ?? options.seed;
@@ -867,6 +898,7 @@ function cardFor(
     outcome: outcomeFor(row),
     usage: blind || !row.usage ? null : { ...row.usage },
     modeledUsd: blind || !row.cost ? null : row.cost.modeledUsd,
+    promptSha256: blind ? null : row.prompt.sha256,
     textPartOmitted: row.textPartOmitted === true,
     // Only the team-internal report carries these. They name the run's shape and the tile ids it
     // could not photograph, which are a configuration in a blinded report and a document identifier
@@ -1095,6 +1127,21 @@ function statusBadge(status: "success" | "refusal" | "error" | "skipped"): Html 
   return html`<span class="badge badge-${status}">${status}</span>`;
 }
 
+/**
+ * What the header says about a run's prompt: its hash, or that its rows do not agree on one.
+ *
+ * The mixed case is not a failure — it is a results file that holds a prompt edit part-way through —
+ * but the report must not paper over it, because the run's cards are then not all comparable with
+ * each other. Each card names its own prompt when this fires.
+ */
+function promptVersionNote(run: ReviewRunConfiguration): Html {
+  if (run.promptSha256) return html` <span class="meta">(${shortSha(run.promptSha256)})</span>`;
+  if (run.promptVersions > 1) {
+    return html` <span class="badge badge-flag">${run.promptVersions} versions — see each card</span>`;
+  }
+  return html``;
+}
+
 function runTable(runs: ReviewRunConfiguration[]): Html {
   const cell = (value: string | null) => html`<td>${value ?? "—"}</td>`;
   return html`
@@ -1110,9 +1157,7 @@ function runTable(runs: ReviewRunConfiguration[]): Html {
           ${cell(run.detail)}
           ${cell(run.imageSet)}
           ${cell(run.extras)}
-          <td>${run.promptName}${run.promptSha256
-            ? html` <span class="meta">(${shortSha(run.promptSha256)})</span>`
-            : ""}</td>
+          <td>${run.promptName}${promptVersionNote(run)}</td>
         </tr>`)}
       </tbody>
     </table>`;
@@ -1237,7 +1282,12 @@ function cardBlock(card: ReviewCard): Html {
           : ""}
       </div>
       ${card.configuration
-        ? html`<p class="card-config">${configurationLine(card.configuration)}</p>`
+        ? html`<p class="card-config">${configurationLine(card.configuration)}${
+          // Only where the run's rows disagree: on every other card this would be the same hash the
+          // header already carries, repeated once per card for nothing.
+          card.configuration.promptVersions > 1 && card.promptSha256
+            ? html` · <strong>prompt ${shortSha(card.promptSha256)}</strong>`
+            : ""}</p>`
         : ""}
       ${card.textPartOmitted
         ? html`<p class="notice">This document carried no student-authored text, so the summary and

--- a/scripts/ai-harness/src/review.ts
+++ b/scripts/ai-harness/src/review.ts
@@ -466,7 +466,7 @@ export type ContentMatching = (sourceContentSha256: string) => { content: unknow
  * differently for the same unchanged content and envelope, and the newly selected picture is still
  * among `imageSha256s`, so the check below cannot notice. Closing that means recording what was
  * sent — a `sentImageSha256s` on the descriptor — which changes what a run writes and so belongs to
- * a later milestone. See DEVIATIONS in the README.
+ * a later milestone. See DEVIATIONS 34 in the README.
  */
 function readSentImages(
   paths: CorpusPaths, docId: string, descriptor: ImageRepresentation,

--- a/scripts/ai-harness/src/review.ts
+++ b/scripts/ai-harness/src/review.ts
@@ -1204,8 +1204,18 @@ export function assertKeyIsReusable(
 // The ratings template
 // ---------------------------------------------------------------------------
 
-function csvField(value: string): string {
-  return `"${value.replace(/"/g, '""')}"`;
+/**
+ * One CSV field, quoted for the parser and defused for the spreadsheet.
+ *
+ * Excel and LibreOffice evaluate a field beginning `=`, `+`, `-` or `@` as a formula even inside
+ * quotes, and this file exists to be opened in a spreadsheet by a judge. Nothing writes such a value
+ * today — document ids and labels cannot start with those characters — but the `document` column
+ * carries whatever a corpus calls its documents, and a pseudonym is only used in shareable mode. A
+ * leading apostrophe is the standard defusing and spreadsheets do not show it.
+ */
+export function csvField(value: string): string {
+  const defused = /^[=+\-@\t\r]/.test(value) ? `'${value}` : value;
+  return `"${defused.replace(/"/g, '""')}"`;
 }
 
 /**

--- a/scripts/ai-harness/src/schemas.ts
+++ b/scripts/ai-harness/src/schemas.ts
@@ -1251,6 +1251,137 @@ export function validateResultRow(value: unknown, file: string): ResultRow {
 }
 
 // ---------------------------------------------------------------------------
+// Review key file
+// ---------------------------------------------------------------------------
+
+/** One judgeable outcome: a document and the run that produced it. */
+export interface ReviewKeyPair {
+  docId: string;
+  runId: string;
+}
+
+/**
+ * The single sidecar a `review --shareable` or `review --blind` report writes.
+ *
+ * It is the only place the mapping from what a reader sees to what actually produced it exists: the
+ * pseudonym for each document id, and — for a blind report — the random seed the card order was
+ * derived from plus the label→run mapping that seed produced. The HTML deliberately contains
+ * neither, so losing this file loses the decoding, and rewriting it orphans every rating already
+ * written against the old labels. Hence: one key per report, never overwritten, and validated on
+ * read like every other on-disk format.
+ */
+export interface ReviewKeyFile {
+  schemaVersion: number;
+  generatedAt: string;
+  corpus: string;
+  experiment: string;
+  experimentSha256: string;
+  /** Which flags produced the report this key belongs to. */
+  modes: { shareable: boolean; blind: boolean };
+  /** Every document the report renders, in presentation order — what the pseudonyms number. */
+  documents: string[];
+  /** The exact set of judgeable outcomes the report was generated over. */
+  judgeable: ReviewKeyPair[];
+  /** Document id → pseudonym. `null` unless the report is shareable. */
+  pseudonyms: Record<string, string> | null;
+  /** The hex seed the card order derives from. `null` unless the report is blind. */
+  seed: string | null;
+  /** Document id → presentation label → run id. `null` unless the report is blind. */
+  labels: Record<string, Record<string, string>> | null;
+}
+
+/** Read back and checked field by field: a key that does not decode its report is worse than none. */
+export function validateReviewKeyFile(value: unknown, file: string): ReviewKeyFile {
+  const record = asObject(value, file, "key");
+  checkSchemaVersion(record, file);
+  const modes = asObject(record.modes, file, "modes");
+  const shareable = asBoolean(modes.shareable, file, "modes.shareable");
+  const blind = asBoolean(modes.blind, file, "modes.blind");
+  // A key that records neither mode belongs to a report that writes no key at all, so reading one
+  // means the file was written by something that disagrees about what a key is for.
+  if (!shareable && !blind) {
+    fail(file, "modes", "records neither shareable nor blind, and a plain report writes no key");
+  }
+  const documents = asArray(record.documents, file, "documents")
+    .map((docId, index) => asString(docId, file, `documents[${index}]`));
+  const judgeable = asArray(record.judgeable, file, "judgeable").map((entry, index) => {
+    const pair = asObject(entry, file, `judgeable[${index}]`);
+    return {
+      docId: asString(pair.docId, file, `judgeable[${index}].docId`),
+      runId: asString(pair.runId, file, `judgeable[${index}].runId`)
+    };
+  });
+
+  // Each mapping is required by exactly the mode that uses it, and refused otherwise: a blind key
+  // with no labels decodes nothing, and a plain key carrying a seed describes a report that was
+  // never blinded.
+  const mapping = (mode: boolean, name: "pseudonyms" | "seed" | "labels", read: () => unknown) => {
+    const present = record[name] !== undefined && record[name] !== null;
+    if (mode !== present) {
+      fail(file, name, `must be ${mode ? "set" : "null"} on a key whose modes are ` +
+        `shareable=${shareable}, blind=${blind}`);
+    }
+    return present ? read() : null;
+  };
+
+  const pseudonyms = mapping(shareable, "pseudonyms", () => {
+    const entries = asObject(record.pseudonyms, file, "pseudonyms");
+    const byDocument = Object.fromEntries(Object.entries(entries)
+      .map(([docId, name]) => [docId, asString(name, file, `pseudonyms.${docId}`)]));
+    // Two documents sharing a pseudonym would make the report ambiguous about which one a rating
+    // refers to, which is the one thing this mapping exists to settle.
+    const names = Object.values(byDocument);
+    if (new Set(names).size !== names.length) {
+      const repeated = names.find((name, index) => names.indexOf(name) !== index);
+      fail(file, "pseudonyms", `gives more than one document the pseudonym "${repeated}"`);
+    }
+    return byDocument;
+  }) as Record<string, string> | null;
+
+  const seed = mapping(blind, "seed", () => {
+    const text = asString(record.seed, file, "seed");
+    // Whole bytes, so `Buffer.from(seed, "hex")` cannot quietly drop a trailing half-byte and key
+    // the ordering with something other than what the file says.
+    if (!/^([0-9a-f]{2}){16,}$/.test(text)) {
+      fail(file, "seed", `must be at least 16 whole bytes of lower-case hex, got "${text}"`);
+    }
+    return text;
+  }) as string | null;
+
+  const labels = mapping(blind, "labels", () => {
+    const perDocument = asObject(record.labels, file, "labels");
+    return Object.fromEntries(Object.entries(perDocument).map(([docId, forDocument]) => {
+      const entries = asObject(forDocument, file, `labels.${docId}`);
+      const byLabel = Object.fromEntries(Object.entries(entries)
+        .map(([label, runId]) => [label, asString(runId, file, `labels.${docId}.${label}`)]));
+      // One label per run, and one run per label. Two labels naming one run would read as a
+      // complete mapping and decode to whichever the reader happened to apply last — so the report
+      // and the key that is supposed to decode it could disagree while both looked well formed.
+      const runIds = Object.values(byLabel);
+      if (new Set(runIds).size !== runIds.length) {
+        const repeated = runIds.find((runId, index) => runIds.indexOf(runId) !== index);
+        fail(file, `labels.${docId}`, `gives run "${repeated}" more than one label`);
+      }
+      return [docId, byLabel];
+    }));
+  }) as Record<string, Record<string, string>> | null;
+
+  return {
+    schemaVersion: kSchemaVersion,
+    generatedAt: asString(record.generatedAt, file, "generatedAt"),
+    corpus: asString(record.corpus, file, "corpus"),
+    experiment: asString(record.experiment, file, "experiment"),
+    experimentSha256: asString(record.experimentSha256, file, "experimentSha256"),
+    modes: { shareable, blind },
+    documents,
+    judgeable,
+    pseudonyms,
+    seed,
+    labels
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Fixture expectations (the committed synthetic corpus)
 // ---------------------------------------------------------------------------
 

--- a/scripts/ai-harness/src/schemas.ts
+++ b/scripts/ai-harness/src/schemas.ts
@@ -1254,10 +1254,22 @@ export function validateResultRow(value: unknown, file: string): ResultRow {
 // Review key file
 // ---------------------------------------------------------------------------
 
-/** One judgeable outcome: a document and the run that produced it. */
+/** One judgeable outcome: a document, the run that produced it, and which outcome that was. */
 export interface ReviewKeyPair {
   docId: string;
   runId: string;
+  /**
+   * A hash of the row this label was put on: its request, its representation and its answer.
+   *
+   * The pair alone does not identify an outcome. A re-run appends a replacement row for the same
+   * (document, run), so without this a `--reuse-key` regeneration accepted the new answer, kept the
+   * old label on it, and preserved a ratings template whose scores were given to the old one. The
+   * ratings then described an outcome nobody had read.
+   *
+   * Deliberately excludes `runMeta`, `usage` and `cost`: a re-run that returns the same answer from
+   * the cache changes all three and changes nothing a judge rated.
+   */
+  fingerprint: string;
 }
 
 /**
@@ -1306,9 +1318,18 @@ export function validateReviewKeyFile(value: unknown, file: string): ReviewKeyFi
     .map((docId, index) => asString(docId, file, `documents[${index}]`));
   const judgeable = asArray(record.judgeable, file, "judgeable").map((entry, index) => {
     const pair = asObject(entry, file, `judgeable[${index}]`);
+    // Named rather than reported as a missing string: a key without fingerprints was written before
+    // they existed, and it cannot tell whether the outcomes it labelled have since been re-run —
+    // which is the one thing reuse needs it for.
+    if (pair.fingerprint === undefined) {
+      fail(file, `judgeable[${index}].fingerprint`, "is missing. This key was written before " +
+        "outcome fingerprints, so it cannot say whether the outcomes it labels have been re-run " +
+        "since. Generate a fresh report (a different --out), and a fresh judging round with it.");
+    }
     return {
       docId: asString(pair.docId, file, `judgeable[${index}].docId`),
-      runId: asString(pair.runId, file, `judgeable[${index}].runId`)
+      runId: asString(pair.runId, file, `judgeable[${index}].runId`),
+      fingerprint: asSha256(pair.fingerprint, file, `judgeable[${index}].fingerprint`)
     };
   });
 

--- a/scripts/ai-harness/test/review-command.test.ts
+++ b/scripts/ai-harness/test/review-command.test.ts
@@ -1,0 +1,270 @@
+import fs from "node:fs";
+import path from "node:path";
+import { main } from "../harness.js";
+import { validateReviewKeyFile } from "../src/schemas.js";
+import { listFilesUnder } from "./helpers.js";
+import { ReviewFixture, buildReviewFixture, kSentinels } from "./review-fixture.js";
+
+const kSeed = "c".repeat(64);
+const kNow = new Date("2026-08-20T00:00:00.000Z");
+
+function depsFor(fixture: ReviewFixture, seed = kSeed) {
+  const output: string[] = [];
+  return {
+    output,
+    deps: {
+      dataRoot: fixture.dataRoot,
+      log: (message: string) => output.push(message),
+      // Determinism claims only hold with the clock fixed: the generation date is real output.
+      now: () => kNow,
+      reviewSeed: () => seed
+    }
+  };
+}
+
+function review(fixture: ReviewFixture, flags: string[], seed = kSeed) {
+  const { output, deps } = depsFor(fixture, seed);
+  return main(["review", "--results", fixture.resultsFile, "--experiment", fixture.experimentFile,
+    ...flags], deps).then(() => output);
+}
+
+/** Where a mode's three files land, given the results file the fixture wrote. */
+function pathsFor(fixture: ReviewFixture, suffix: string) {
+  const stem = fixture.resultsFile.replace(/\.jsonl$/, `.review${suffix}`);
+  return { html: `${stem}.html`, key: `${stem}.key.json`, ratings: `${stem}.ratings-template.csv` };
+}
+
+describe("review writes one report per mode, with the sidecars that mode needs", () => {
+  const fixture = buildReviewFixture("review-command-modes");
+
+  it("writes a plain report and no sidecars at all", async () => {
+    await review(fixture, []);
+    const paths = pathsFor(fixture, "");
+    expect(fs.existsSync(paths.html)).toBe(true);
+    expect(fs.existsSync(paths.key)).toBe(false);
+    expect(fs.existsSync(paths.ratings)).toBe(false);
+  });
+
+  it("writes a shareable report with a key, and no ratings template", async () => {
+    await review(fixture, ["--shareable"]);
+    const paths = pathsFor(fixture, "-shareable");
+    expect(fs.existsSync(paths.html)).toBe(true);
+    const key = validateReviewKeyFile(JSON.parse(fs.readFileSync(paths.key, "utf8")), paths.key);
+    expect(key.modes).toEqual({ shareable: true, blind: false });
+    expect(key.pseudonyms).toEqual({ alpha: "doc-01", beta: "doc-02", gamma: "doc-03" });
+    // Nothing to rate: the cards are not labelled.
+    expect(fs.existsSync(paths.ratings)).toBe(false);
+  });
+
+  it("writes a blind report with a key and a ratings template", async () => {
+    await review(fixture, ["--blind"]);
+    const paths = pathsFor(fixture, "-blind");
+    const key = validateReviewKeyFile(JSON.parse(fs.readFileSync(paths.key, "utf8")), paths.key);
+    expect(key.seed).toBe(kSeed);
+    expect(Object.keys(key.labels!)).toEqual(["alpha", "beta"]);
+    expect(fs.readFileSync(paths.ratings, "utf8").trim().split("\n"))
+      .toHaveLength(key.judgeable.length + 1);
+  });
+
+  it("writes exactly one combined key for blind + shareable", async () => {
+    await review(fixture, ["--blind", "--shareable"]);
+    const paths = pathsFor(fixture, "-blind-shareable");
+    const key = validateReviewKeyFile(JSON.parse(fs.readFileSync(paths.key, "utf8")), paths.key);
+    expect(key.modes).toEqual({ shareable: true, blind: true });
+    expect(key.pseudonyms).not.toBeNull();
+    expect(key.labels).not.toBeNull();
+    // One key file for this report, not a shareable one and a blind one racing for the same path.
+    const keys = listFilesUnder(path.dirname(paths.html)).filter((file) => file.endsWith(".key.json"));
+    expect(keys).toHaveLength(3);
+    expect(new Set(keys).size).toBe(3);
+  });
+
+  it("leaves the four reports and their sidecars all distinct", () => {
+    const files = listFilesUnder(path.dirname(fixture.resultsFile))
+      .map((file) => path.basename(file)).sort();
+    expect(files).toEqual([
+      "review-corpus__review-fixture.jsonl",
+      "review-corpus__review-fixture.review-blind-shareable.html",
+      "review-corpus__review-fixture.review-blind-shareable.key.json",
+      "review-corpus__review-fixture.review-blind-shareable.ratings-template.csv",
+      "review-corpus__review-fixture.review-blind.html",
+      "review-corpus__review-fixture.review-blind.key.json",
+      "review-corpus__review-fixture.review-blind.ratings-template.csv",
+      "review-corpus__review-fixture.review-shareable.html",
+      "review-corpus__review-fixture.review-shareable.key.json",
+      "review-corpus__review-fixture.review.html"
+    ]);
+  });
+
+  it("keeps everything it wrote inside the data root", () => {
+    for (const file of listFilesUnder(fixture.dataRoot)) {
+      expect(file.startsWith(fixture.dataRoot)).toBe(true);
+    }
+  });
+});
+
+describe("an existing key is never overwritten, and never rewritten", () => {
+  it("refuses a second blind report over the same key, and writes nothing", async () => {
+    const fixture = buildReviewFixture("review-command-key-exists");
+    await review(fixture, ["--blind"]);
+    const paths = pathsFor(fixture, "-blind");
+    const before = fs.readFileSync(paths.key, "utf8");
+    const htmlBefore = fs.readFileSync(paths.html, "utf8");
+
+    await expect(review(fixture, ["--blind"], "d".repeat(64)))
+      .rejects.toThrow(/already exists, and a key is never overwritten/);
+    // A refused run leaves every file exactly as it found it — including the HTML, which is checked
+    // before it is written rather than after.
+    expect(fs.readFileSync(paths.key, "utf8")).toBe(before);
+    expect(fs.readFileSync(paths.html, "utf8")).toBe(htmlBefore);
+  });
+
+  it("refuses --reuse-key when there is no key to reuse", async () => {
+    const fixture = buildReviewFixture("review-command-no-key");
+    await expect(review(fixture, ["--blind", "--reuse-key"]))
+      .rejects.toThrow(/there is no key at .* to reuse/);
+    expect(fs.existsSync(pathsFor(fixture, "-blind").html)).toBe(false);
+  });
+
+  it("refuses --reuse-key on a plain report, which writes no key", async () => {
+    const fixture = buildReviewFixture("review-command-reuse-plain");
+    await expect(review(fixture, ["--reuse-key"])).rejects.toThrow(/A plain review report writes no sidecars/);
+  });
+
+  it("refuses a ratings template left behind without its key", async () => {
+    const fixture = buildReviewFixture("review-command-orphan-template");
+    const paths = pathsFor(fixture, "-blind");
+    fs.mkdirSync(path.dirname(paths.ratings), { recursive: true });
+    fs.writeFileSync(paths.ratings, "document,label,rating,notes\n");
+    await expect(review(fixture, ["--blind"])).rejects.toThrow(/already exists without a key beside it/);
+    expect(fs.existsSync(paths.html)).toBe(false);
+  });
+});
+
+describe("--reuse-key regenerates the same report", () => {
+  const fixture = buildReviewFixture("review-command-reuse");
+  const paths = pathsFor(fixture, "-blind-shareable");
+
+  it("reproduces byte-identical HTML under a fixed clock, from the key's own seed", async () => {
+    await review(fixture, ["--blind", "--shareable"]);
+    const html = fs.readFileSync(paths.html, "utf8");
+    const key = fs.readFileSync(paths.key, "utf8");
+
+    // A different seed on the command line changes nothing: the key's seed is what the report is
+    // regenerated from, and the key itself is not rewritten.
+    await review(fixture, ["--blind", "--shareable", "--reuse-key"], "e".repeat(64));
+    expect(fs.readFileSync(paths.html, "utf8")).toBe(html);
+    expect(fs.readFileSync(paths.key, "utf8")).toBe(key);
+  });
+
+  it("preserves a judge's part-filled ratings template byte for byte", async () => {
+    const filled = 'document,label,rating,notes\n"doc-01","A","4","good"\n';
+    fs.writeFileSync(paths.ratings, filled);
+    await review(fixture, ["--blind", "--shareable", "--reuse-key"]);
+    expect(fs.readFileSync(paths.ratings, "utf8")).toBe(filled);
+  });
+
+  it("refuses a key from another corpus, experiment, mode or set of outcomes", async () => {
+    const stored = JSON.parse(fs.readFileSync(paths.key, "utf8"));
+    const edits: [string, unknown, RegExp][] = [
+      ["corpus", "another-corpus", /generated over corpus/],
+      ["experimentSha256", "f".repeat(64), /generated over experiment definition/],
+      
+      ["documents", ["alpha", "beta"], /generated over documents/],
+      ["judgeable", stored.judgeable.slice(1), /generated over judgeable outcomes/]
+    ];
+    for (const [field, value, message] of edits) {
+      fs.writeFileSync(paths.key, JSON.stringify({ ...stored, [field]: value }));
+      await expect(review(fixture, ["--blind", "--shareable", "--reuse-key"])).rejects.toThrow(message);
+    }
+    // A key for a blind-only report cannot be reused for a blind+shareable one: the pseudonyms it
+    // does not carry are part of what a reader would be shown.
+    fs.writeFileSync(paths.key, JSON.stringify({
+      ...stored, modes: { shareable: false, blind: true }, pseudonyms: null
+    }));
+    await expect(review(fixture, ["--blind", "--shareable", "--reuse-key"]))
+      .rejects.toThrow(/generated over modes/);
+    // And one whose labels no longer cover the outcomes the report renders.
+    fs.writeFileSync(paths.key, JSON.stringify({
+      ...stored, labels: { ...stored.labels, alpha: { A: kSentinels.textRun } }
+    }));
+    await expect(review(fixture, ["--blind", "--shareable", "--reuse-key"]))
+      .rejects.toThrow(/labels for document "alpha" do not cover exactly the outcomes/);
+    fs.writeFileSync(paths.key, JSON.stringify(stored));
+  });
+});
+
+describe("review refuses inputs it cannot report on honestly", () => {
+  it("refuses an experiment file that has been edited since the run", async () => {
+    const fixture = buildReviewFixture("review-command-edited-experiment");
+    const experiment = JSON.parse(fs.readFileSync(fixture.experimentFile, "utf8"));
+    experiment.runs[0].textVariant = "minimal";
+    fs.writeFileSync(fixture.experimentFile, JSON.stringify(experiment));
+    await expect(review(fixture, [])).rejects.toThrow(/has been edited since the run/);
+    expect(fs.existsSync(pathsFor(fixture, "").html)).toBe(false);
+  });
+
+  it("refuses a corpus that is not on this machine", async () => {
+    const fixture = buildReviewFixture("review-command-missing-corpus");
+    fs.rmSync(fixture.paths.manifest);
+    await expect(review(fixture, [])).rejects.toThrow(/which is not in .*import it as "review-corpus"/);
+  });
+
+  it("refuses a results file that is not there, or holds no rows", async () => {
+    const fixture = buildReviewFixture("review-command-missing-results");
+    const { deps } = depsFor(fixture);
+    const missing = path.join(fixture.dataRoot, "results", "typo.jsonl");
+    await expect(main(["review", "--results", missing, "--experiment", fixture.experimentFile], deps))
+      .rejects.toThrow(/No results file at/);
+    const empty = path.join(fixture.dataRoot, "results", "empty.jsonl");
+    fs.writeFileSync(empty, "");
+    await expect(main(["review", "--results", empty, "--experiment", fixture.experimentFile], deps))
+      .rejects.toThrow(/contains no result rows/);
+  });
+
+  it("requires the experiment file rather than guessing at it", async () => {
+    const fixture = buildReviewFixture("review-command-no-experiment");
+    const { deps } = depsFor(fixture);
+    await expect(main(["review", "--results", fixture.resultsFile], deps))
+      .rejects.toThrow(/--experiment is required/);
+  });
+
+  it("refuses an --out that would write outside the data root", async () => {
+    const fixture = buildReviewFixture("review-command-containment");
+    await expect(review(fixture, ["--out", "../escaped.html"]))
+      .rejects.toThrow(/--out must name a file inside the harness data directory/);
+  });
+
+  it("refuses an --out that is not a .html file, since the sidecars are named from it", async () => {
+    const fixture = buildReviewFixture("review-command-out-extension");
+    await expect(review(fixture, ["--out", path.join(fixture.dataRoot, "report.txt")]))
+      .rejects.toThrow(/--out must name a \.html file/);
+  });
+});
+
+describe("--out names the sidecars too", () => {
+  it("puts a second blind report's key beside that report, not beside the first", async () => {
+    const fixture = buildReviewFixture("review-command-out-sidecars");
+    await review(fixture, ["--blind"]);
+    const other = path.join(fixture.dataRoot, "results", "second.html");
+    await review(fixture, ["--blind", "--out", other], "f".repeat(64));
+    expect(fs.existsSync(path.join(fixture.dataRoot, "results", "second.key.json"))).toBe(true);
+    expect(fs.existsSync(path.join(fixture.dataRoot, "results", "second.ratings-template.csv")))
+      .toBe(true);
+    // The first report's key is untouched, and the two reports have different orders.
+    const first = pathsFor(fixture, "-blind");
+    expect(JSON.parse(fs.readFileSync(first.key, "utf8")).seed).toBe(kSeed);
+    expect(JSON.parse(fs.readFileSync(path.join(fixture.dataRoot, "results", "second.key.json"), "utf8"))
+      .seed).toBe("f".repeat(64));
+  });
+});
+
+describe("the flags are flags, not values", () => {
+  it("does not swallow the flag that follows a value-less one", async () => {
+    // `--shareable --blind` has to parse as two booleans; if `--shareable` took a value, the report
+    // would silently not be blinded.
+    const fixture = buildReviewFixture("review-command-flag-parsing");
+    const output = await review(fixture, ["--shareable", "--blind"]);
+    expect(output.join("\n")).toContain("review-blind-shareable.html");
+  });
+});

--- a/scripts/ai-harness/test/review-command.test.ts
+++ b/scripts/ai-harness/test/review-command.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { main } from "../harness.js";
+import { reviewSidecarPaths } from "../src/review.js";
 import { validateReviewKeyFile } from "../src/schemas.js";
 import { listFilesUnder } from "./helpers.js";
 import { ReviewFixture, buildReviewFixture, kSentinels } from "./review-fixture.js";
@@ -112,7 +113,7 @@ describe("an existing key is never overwritten, and never rewritten", () => {
     const htmlBefore = fs.readFileSync(paths.html, "utf8");
 
     await expect(review(fixture, ["--blind"], "d".repeat(64)))
-      .rejects.toThrow(/already exists, and a key is never overwritten/);
+      .rejects.toThrow(/A key is never overwritten/);
     // A refused run leaves every file exactly as it found it — including the HTML, which is checked
     // before it is written rather than after.
     expect(fs.readFileSync(paths.key, "utf8")).toBe(before);
@@ -136,8 +137,69 @@ describe("an existing key is never overwritten, and never rewritten", () => {
     const paths = pathsFor(fixture, "-blind");
     fs.mkdirSync(path.dirname(paths.ratings), { recursive: true });
     fs.writeFileSync(paths.ratings, "document,label,rating,notes\n");
-    await expect(review(fixture, ["--blind"])).rejects.toThrow(/already exists without a key beside it/);
+    await expect(review(fixture, ["--blind"]))
+      .rejects.toThrow(/this run would not preserve it/);
     expect(fs.existsSync(paths.html)).toBe(false);
+  });
+});
+
+describe("a plain report cannot overwrite a shareable or blinded one", () => {
+  /** A judging report written to an explicit `--out`, where the mode is not in the filename. */
+  const judging = async (name: string) => {
+    const fixture = buildReviewFixture(name);
+    const out = fixture.resultsFile.replace(/\.jsonl$/, ".judging.html");
+    const { deps } = depsFor(fixture);
+    await main(["review", "--results", fixture.resultsFile, "--experiment", fixture.experimentFile,
+      "--out", out, "--blind", "--shareable"], deps);
+    return { fixture, out, files: reviewSidecarPaths(out), deps };
+  };
+
+  it("refuses, rather than replacing a blinded page with an unredacted one", async () => {
+    // Dropping the flags from a command in shell history is all it takes. The sidecars beside the
+    // path are the only record of what that path is for.
+    const { fixture, out, files, deps } = await judging("review-command-clobber");
+    const blinded = fs.readFileSync(out, "utf8");
+    fs.writeFileSync(files.ratings, 'document,label,rating,notes\n"doc-01","A","5","x"\n');
+
+    await expect(main(["review", "--results", fixture.resultsFile,
+      "--experiment", fixture.experimentFile, "--out", out], deps))
+      .rejects.toThrow(/a plain report would replace its HTML with an unredacted one/);
+
+    // The judge's page, their ratings and the key that decodes them are all as they were.
+    expect(fs.readFileSync(out, "utf8")).toBe(blinded);
+    expect(fs.readFileSync(files.ratings, "utf8")).toContain('"5","x"');
+    expect(fs.existsSync(files.key)).toBe(true);
+  });
+
+  it("refuses over a ratings template even when the key has gone", async () => {
+    const { fixture, out, files, deps } = await judging("review-command-clobber-template");
+    fs.rmSync(files.key);
+    await expect(main(["review", "--results", fixture.resultsFile,
+      "--experiment", fixture.experimentFile, "--out", out], deps))
+      .rejects.toThrow(/this run would not preserve it/);
+  });
+
+  it("refuses a shareable report over a template it would strand, too", async () => {
+    // Not only plain mode: a shareable report has no labels, so a template beside it names labels
+    // its page does not have.
+    const { fixture, out, files, deps } = await judging("review-command-clobber-shareable");
+    fs.rmSync(files.key);
+    await expect(main(["review", "--results", fixture.resultsFile,
+      "--experiment", fixture.experimentFile, "--out", out, "--shareable"], deps))
+      .rejects.toThrow(/this run would not preserve it/);
+  });
+
+  it("still writes a plain report to a path with no sidecars", async () => {
+    const fixture = buildReviewFixture("review-command-plain-out");
+    const out = fixture.resultsFile.replace(/\.jsonl$/, ".plain.html");
+    const { deps } = depsFor(fixture);
+    await main(["review", "--results", fixture.resultsFile, "--experiment", fixture.experimentFile,
+      "--out", out], deps);
+    expect(fs.existsSync(out)).toBe(true);
+    // And re-running a plain report over its own output is fine: there is nothing to strand.
+    await main(["review", "--results", fixture.resultsFile, "--experiment", fixture.experimentFile,
+      "--out", out], deps);
+    expect(fs.existsSync(reviewSidecarPaths(out).key)).toBe(false);
   });
 });
 

--- a/scripts/ai-harness/test/review-command.test.ts
+++ b/scripts/ai-harness/test/review-command.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { main } from "../harness.js";
+import { harnessRoot } from "../src/corpus.js";
 import { reviewSidecarPaths } from "../src/review.js";
 import { validateReviewKeyFile } from "../src/schemas.js";
 import { listFilesUnder } from "./helpers.js";
@@ -97,10 +98,15 @@ describe("review writes one report per mode, with the sidecars that mode needs",
     ]);
   });
 
-  it("keeps everything it wrote inside the data root", () => {
-    for (const file of listFilesUnder(fixture.dataRoot)) {
-      expect(file.startsWith(fixture.dataRoot)).toBe(true);
-    }
+  it("writes nothing outside the data root", () => {
+    // Walking the data root and asserting every path is under it proves nothing: that is all
+    // `listFilesUnder` can return. The claim is about everything *else*, so this takes a picture of
+    // the harness tree outside `data/` and checks a report changes none of it.
+    const outsideData = () => listFilesUnder(harnessRoot)
+      .filter((file) => !file.startsWith(path.join(harnessRoot, "data")));
+    const before = outsideData();
+    return review(fixture, ["--blind", "--shareable", "--reuse-key"])
+      .then(() => expect(outsideData()).toEqual(before));
   });
 });
 

--- a/scripts/ai-harness/test/review-command.test.ts
+++ b/scripts/ai-harness/test/review-command.test.ts
@@ -164,6 +164,58 @@ describe("--reuse-key regenerates the same report", () => {
     expect(fs.readFileSync(paths.ratings, "utf8")).toBe(filled);
   });
 
+  it("refuses a key whose outcomes have been re-run since it was written", async () => {
+    // The reachable case, and the one the never-overwrite-a-key rule did not cover: no file is
+    // hand-edited, a re-run simply appends a replacement row for the same (document, run). The
+    // labels used to survive onto the new answers while the preserved ratings template went on
+    // describing the ones they replaced.
+    const rerun = buildReviewFixture("review-command-rerun");
+    await review(rerun, ["--blind"]);
+    const files = pathsFor(rerun, "-blind");
+    const html = fs.readFileSync(files.html, "utf8");
+    fs.writeFileSync(files.ratings, 'document,label,rating,notes\n"alpha","A","5","best"\n');
+
+    const rows = fs.readFileSync(rerun.resultsFile, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+    const replaced = rows.find((row) => row.docId === "alpha" && row.status === "success")!;
+    fs.appendFileSync(rerun.resultsFile, `${JSON.stringify({
+      ...replaced, requestKey: "alpha-text-rerun",
+      response: { parsed: { category: "user", discussion: "a different answer" }, raw: {} }
+    })}\n`);
+
+    await expect(review(rerun, ["--blind", "--reuse-key"]))
+      .rejects.toThrow(/1 outcome\(s\) have been re-run since it was written/);
+    // And nothing was written: the report the judge read, and their ratings, are as they were.
+    expect(fs.readFileSync(files.html, "utf8")).toBe(html);
+    expect(fs.readFileSync(files.ratings, "utf8")).toContain('"5","best"');
+  });
+
+  it("accepts a re-run that returned the same answer, which is what the cache does", async () => {
+    // A cache hit rewrites runMeta, usage and cost while the card stays identical. Refusing that
+    // would make `--reuse-key` useless on any file that had been re-run at all.
+    const cached = buildReviewFixture("review-command-rerun-same");
+    await review(cached, ["--blind"]);
+    const files = pathsFor(cached, "-blind");
+    const html = fs.readFileSync(files.html, "utf8");
+
+    const rows = fs.readFileSync(cached.resultsFile, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+    const replayed = rows.find((row) => row.docId === "alpha" && row.status === "success")!;
+    fs.appendFileSync(cached.resultsFile, `${JSON.stringify({
+      ...replayed,
+      runMeta: { ...replayed.runMeta, date: "2027-01-01T00:00:00.000Z" },
+      usage: { ...replayed.usage, source: "cache" },
+      cost: { modeledUsd: replayed.cost.modeledUsd, incurredThisRunUsd: 0 }
+    })}\n`);
+
+    await review(cached, ["--blind", "--reuse-key"]);
+    const regenerated = fs.readFileSync(files.html, "utf8");
+    // Every card, and every label on it, is where the judge left it.
+    const cards = (source: string) => source.split('<div class="card">').slice(1);
+    expect(cards(regenerated)).toEqual(cards(html));
+    // The header does move, and honestly so: the file now holds one more superseded row.
+    expect(html).toContain("1 superseded row(s)");
+    expect(regenerated).toContain("2 superseded row(s)");
+  });
+
   it("refuses a key from another corpus, experiment, mode or set of outcomes", async () => {
     const stored = JSON.parse(fs.readFileSync(paths.key, "utf8"));
     const edits: [string, unknown, RegExp][] = [

--- a/scripts/ai-harness/test/review-fixture.ts
+++ b/scripts/ai-harness/test/review-fixture.ts
@@ -35,6 +35,8 @@ export const kSentinels = {
   textRun: "zz-run-one",
   imageRun: "zz-run-two",
   mixedRun: "zz-run-three",
+  perTileRun: "zz-run-four",
+  visualTilesRun: "zz-run-five",
   unit: "zz-unit-sentinel",
   investigation: "zz-investigation-sentinel",
   problem: "zz-problem-sentinel",
@@ -44,11 +46,34 @@ export const kSentinels = {
 export const kCorpus = "review-corpus";
 export const kDocuments = ["alpha", "beta", "gamma"];
 
+/**
+ * `beta`'s content is real, and its hash is computed from it rather than made up.
+ *
+ * `visual-tiles-only` selects the tiles the *classifier* marks as needing a picture, so a report
+ * reconstructing what such a run sent has to classify the same content the run classified. That
+ * needs a document that actually classifies: a Text tile (student text, no picture needed) beside a
+ * Drawing tile (needs one), so the two image sets genuinely differ.
+ */
+const kBetaContent = {
+  rowOrder: ["row-1"],
+  rowMap: { "row-1": { id: "row-1", isSectionHeader: false,
+    tiles: [{ tileId: "beta-text" }, { tileId: "beta-drawing" }] } },
+  tileMap: {
+    "beta-text": { id: "beta-text", content: { type: "Text", text: "beta text" } },
+    "beta-drawing": { id: "beta-drawing", content: { type: "Drawing", objects: [] } }
+  }
+};
+
 const kContentSha = {
   alpha: "1".repeat(64),
-  beta: "2".repeat(64),
+  beta: sha256Canonical(kBetaContent),
   gamma: "3".repeat(64)
 };
+
+/** The tile the classifier marks as needing a picture — the only one `visual-tiles-only` sends. */
+export const kVisualTileId = "beta-drawing";
+/** The tile a per-tile capture also photographs, and `visual-tiles-only` does not send. */
+export const kNonVisualTileId = "beta-text";
 
 const origin = { date: "2026-08-11T00:00:00.000Z", modelReturned: "gpt-4o-mini", systemFingerprint: null };
 
@@ -60,8 +85,12 @@ export interface ReviewFixture {
   experimentSha256: string;
   resultsFile: string;
   rows: ResultRow[];
-  /** The sha256 of the one picture both image-carrying runs sent. */
+  /** The sha256 of the one picture both full-document runs sent. */
   imageSha256: string;
+  /** The per-tile render's two pictures, in envelope order. */
+  tileSha256s: string[];
+  /** The one of them a `visual-tiles-only` run sends. */
+  visualTileSha256: string;
   /** The `default` variant's summary for `alpha`, as it sits on disk. */
   alphaMarkdown: string;
 }
@@ -126,6 +155,32 @@ export function buildReviewFixture(name: string): ReviewFixture {
     });
   }
 
+  writeJsonFile(path.join(paths.documents, "beta.json"), kBetaContent);
+
+  // A per-tile render of both of `beta`'s tiles. `image-per-tile` sends both; `visual-tiles-only`
+  // sends only the drawing.
+  const perTileFile = imageRepresentationPath(paths, "puppeteer-per-tile", "beta");
+  writeImageRepresentation({
+    envelopeFile: perTileFile,
+    docId: "beta",
+    modeId: "puppeteer-per-tile",
+    backendId: "puppeteer",
+    backendVersion: 2,
+    renderTarget: {
+      clueUrl: "http://localhost:8080", unit: "harness-render", clueRevision: "abc1234",
+      shutterbugUrl: null, viewportWidthPx: 960, captureMode: "per-tile", captureHeightPx: null
+    },
+    sourceContentSha256: sha256Canonical(kBetaContent),
+    generatedAt: "2026-08-11T00:00:00.000Z",
+    images: [
+      { bytes: makeTestPng(30, 10), url: null, tileId: kNonVisualTileId, purpose: "tile" },
+      { bytes: makeTestPng(30, 14), url: null, tileId: kVisualTileId, purpose: "tile" }
+    ]
+  });
+  const perTile = readImageEnvelope(perTileFile).images;
+  const tileSha256s = perTile.map((image) => image.sha256);
+  const visualTileSha256 = perTile.find((image) => image.tileId === kVisualTileId)!.sha256;
+
   const envelopeFile = imageRepresentationPath(paths, "puppeteer-full-height", "beta");
   writeImageRepresentation({
     envelopeFile,
@@ -157,7 +212,11 @@ export function buildReviewFixture(name: string): ReviewFixture {
       { id: kSentinels.imageRun, message: "image-only", imageMode: "puppeteer-full-height",
         detail: "low", prompt: "categorize-design-default" },
       { id: kSentinels.mixedRun, message: "mixed", textVariant: "default",
-        imageMode: "puppeteer-full-height", extras: "none", prompt: "categorize-design-default" }
+        imageMode: "puppeteer-full-height", extras: "none", prompt: "categorize-design-default" },
+      { id: kSentinels.perTileRun, message: "image-only", imageMode: "puppeteer-per-tile",
+        imageSet: "per-tile", prompt: "categorize-design-default" },
+      { id: kSentinels.visualTilesRun, message: "image-only", imageMode: "puppeteer-per-tile",
+        imageSet: "visual-tiles-only", prompt: "categorize-design-default" }
     ]
   };
   const experimentFile = path.join(dataRoot, "experiment.json");
@@ -245,6 +304,24 @@ export function buildReviewFixture(name: string): ReviewFixture {
       promptImageTokensEstimated: 2833, textPartOmitted: true, status: "success",
       response: { parsed: {}, raw: {} }, usage, cost, responseOriginMeta: origin },
 
+    // The two per-tile runs, over the same render: one sends both tiles, the other only the tile
+    // the classifier marks as needing a picture. Both rows record every image the envelope holds,
+    // which is what makes `imageSet` the only thing that says what was sent.
+    { ...common, docId: "beta", runId: kSentinels.perTileRun, modality: "visual-only",
+      computedModality: "mixed", message: "image-only", requestKey: "beta-per-tile",
+      representation: { ...imageRepresentation, modeId: "puppeteer-per-tile",
+        imageSha256s: tileSha256s, imageSet: "per-tile" },
+      promptImageTokensEstimated: 5666, status: "success",
+      response: { parsed: { category: "function" }, raw: {} }, usage, cost,
+      responseOriginMeta: origin },
+    { ...common, docId: "beta", runId: kSentinels.visualTilesRun, modality: "visual-only",
+      computedModality: "mixed", message: "image-only", requestKey: "beta-visual-tiles",
+      representation: { ...imageRepresentation, modeId: "puppeteer-per-tile",
+        imageSha256s: tileSha256s, imageSet: "visual-tiles-only" },
+      promptImageTokensEstimated: 2833, status: "success",
+      response: { parsed: { category: "user" }, raw: {} }, usage, cost,
+      responseOriginMeta: origin },
+
     ...[kSentinels.textRun, kSentinels.imageRun, kSentinels.mixedRun].map((runId) => ({
       ...common, docId: "gamma", runId, modality: "empty" as const,
       computedModality: "empty" as const, message: "text-only" as const, requestKey: null,
@@ -259,12 +336,14 @@ export function buildReviewFixture(name: string): ReviewFixture {
   fs.writeFileSync(resultsFile, `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`);
 
   return {
+    visualTileSha256,
+    tileSha256s,
     dataRoot,
     paths,
     experimentFile,
     experiment: validateExperimentFile(experiment, experimentFile, {
       knownTextVariants: ["default"],
-      knownImageModes: ["puppeteer-full-height"],
+      knownImageModes: ["puppeteer-full-height", "puppeteer-per-tile"],
       promptExists: () => true
     }),
     experimentSha256,

--- a/scripts/ai-harness/test/review-fixture.ts
+++ b/scripts/ai-harness/test/review-fixture.ts
@@ -1,0 +1,282 @@
+/**
+ * A corpus, an experiment and a results file built for the review report's tests.
+ *
+ * Two things shape it. Everything a document can carry that the report must escape is present —
+ * `</script>`, an image tag with an `onerror` handler, markdown link syntax and a URL — in the
+ * summary, in a discussion, in a refusal and in an error message, because those are four different
+ * paths to the page. And every identifier the shareable and blind modes are supposed to remove is a
+ * **sentinel** (`zz-…`) rather than a realistic value: asserting that "default" or "text-only" is
+ * absent from a report would false-fail the day a student writes either word.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { corpusPaths, representationPath, writeJsonFile } from "../src/corpus.js";
+import {
+  imageRepresentationPath, readImageEnvelope, writeImageRepresentation
+} from "../src/represent-image.js";
+import {
+  ExperimentFile, ResultRow, kResultSchemaVersion, kSchemaVersion, sha256Canonical,
+  validateExperimentFile
+} from "../src/schemas.js";
+import { makeTestDataRoot, makeTestPng, testRunMeta } from "./helpers.js";
+
+/**
+ * Student-authored text that would end the page early, or run script, if it were not escaped.
+ *
+ * The last two are a line separator and a paragraph separator, written as escapes so this source
+ * file stays readable: they are legal in a document's text, and a report that reproduced them raw
+ * would be flagged by editors as having unusual line terminators.
+ */
+export const kAdversarial =
+  "</script><img src=x onerror=alert(1)> [link](https://evil.example.com/x) 'q' \"d\" A & B" +
+  " line\u2028sep para\u2029sep";
+
+export const kSentinels = {
+  textRun: "zz-run-one",
+  imageRun: "zz-run-two",
+  mixedRun: "zz-run-three",
+  unit: "zz-unit-sentinel",
+  investigation: "zz-investigation-sentinel",
+  problem: "zz-problem-sentinel",
+  contextId: "zz-context-sentinel"
+};
+
+export const kCorpus = "review-corpus";
+export const kDocuments = ["alpha", "beta", "gamma"];
+
+const kContentSha = {
+  alpha: "1".repeat(64),
+  beta: "2".repeat(64),
+  gamma: "3".repeat(64)
+};
+
+const origin = { date: "2026-08-11T00:00:00.000Z", modelReturned: "gpt-4o-mini", systemFingerprint: null };
+
+export interface ReviewFixture {
+  dataRoot: string;
+  paths: ReturnType<typeof corpusPaths>;
+  experimentFile: string;
+  experiment: ExperimentFile;
+  experimentSha256: string;
+  resultsFile: string;
+  rows: ResultRow[];
+  /** The sha256 of the one picture both image-carrying runs sent. */
+  imageSha256: string;
+  /** The `default` variant's summary for `alpha`, as it sits on disk. */
+  alphaMarkdown: string;
+}
+
+function manifestDocument(id: string, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    file: `documents/${id}.json`,
+    source: "qa",
+    contentSha256: kContentSha[id as keyof typeof kContentSha],
+    retrievedAt: "2026-08-11T00:00:00.000Z",
+    unit: null,
+    investigation: null,
+    problem: null,
+    contextId: null,
+    computedModality: "text-only",
+    modalityOverride: null,
+    expectedRenderFailure: null,
+    labels: {},
+    relatedSummaries: [],
+    historical: null,
+    ...overrides
+  };
+}
+
+/**
+ * Builds the fixture under its own data root. `name` is the scratch directory, so each suite that
+ * mutates the tree — a stale representation, a filled-in ratings template — gets its own copy.
+ */
+export function buildReviewFixture(name: string): ReviewFixture {
+  const dataRoot = makeTestDataRoot(name);
+  const paths = corpusPaths(dataRoot, kCorpus);
+
+  writeJsonFile(paths.manifest, {
+    schemaVersion: kSchemaVersion,
+    name: kCorpus,
+    createdAt: "2026-08-11T00:00:00.000Z",
+    documents: [
+      manifestDocument("alpha", {
+        unit: kSentinels.unit,
+        investigation: kSentinels.investigation,
+        problem: kSentinels.problem,
+        contextId: kSentinels.contextId
+      }),
+      // A human's override, so the report has one to flag the way the report's `overridden` column
+      // does; the rows below carry both modalities.
+      manifestDocument("beta", { computedModality: "mixed", modalityOverride: "visual-only" }),
+      manifestDocument("gamma", { computedModality: "empty" })
+    ]
+  });
+
+  const alphaMarkdown = `# Summary\n\nThe student wrote: ${kAdversarial}\n`;
+  for (const [docId, markdown] of [["alpha", alphaMarkdown], ["beta", "# Summary\n\nbeta text\n"]]) {
+    writeJsonFile(representationPath(paths, "default", docId), {
+      schemaVersion: kSchemaVersion,
+      docId,
+      variantId: "default",
+      variantVersion: 1,
+      sourceContentSha256: kContentSha[docId as keyof typeof kContentSha],
+      generatedAt: "2026-08-11T00:00:00.000Z",
+      markdown
+    });
+  }
+
+  const envelopeFile = imageRepresentationPath(paths, "puppeteer-full-height", "beta");
+  writeImageRepresentation({
+    envelopeFile,
+    docId: "beta",
+    modeId: "puppeteer-full-height",
+    backendId: "puppeteer",
+    backendVersion: 2,
+    renderTarget: {
+      clueUrl: "http://localhost:8080",
+      unit: "harness-render",
+      clueRevision: "abc1234",
+      shutterbugUrl: null,
+      viewportWidthPx: 960,
+      captureMode: "full-document",
+      captureHeightPx: null
+    },
+    sourceContentSha256: kContentSha.beta,
+    generatedAt: "2026-08-11T00:00:00.000Z",
+    images: [{ bytes: makeTestPng(24, 12), url: null, tileId: null, purpose: "full-document" }]
+  });
+  const imageSha256 = readImageEnvelope(envelopeFile).images[0].sha256;
+
+  const experiment = {
+    schemaVersion: kSchemaVersion,
+    name: "review-fixture",
+    runs: [
+      { id: kSentinels.textRun, message: "text-only", textVariant: "default",
+        prompt: "categorize-design-default" },
+      { id: kSentinels.imageRun, message: "image-only", imageMode: "puppeteer-full-height",
+        detail: "low", prompt: "categorize-design-default" },
+      { id: kSentinels.mixedRun, message: "mixed", textVariant: "default",
+        imageMode: "puppeteer-full-height", extras: "none", prompt: "categorize-design-default" }
+    ]
+  };
+  const experimentFile = path.join(dataRoot, "experiment.json");
+  writeJsonFile(experimentFile, experiment);
+  const experimentSha256 = sha256Canonical(experiment);
+
+  const textRepresentation = (docId: string) => ({
+    kind: "text" as const, variantId: "default", variantVersion: 1,
+    sourceContentSha256: kContentSha[docId as keyof typeof kContentSha]
+  });
+  const imageRepresentation = {
+    kind: "image" as const, modeId: "puppeteer-full-height", backendId: "puppeteer",
+    backendVersion: 2,
+    renderTarget: {
+      clueUrl: "http://localhost:8080", unit: "harness-render", clueRevision: "abc1234",
+      shutterbugUrl: null, viewportWidthPx: 960, captureMode: "full-document" as const,
+      captureHeightPx: null
+    },
+    sourceContentSha256: kContentSha.beta,
+    imageSha256s: [imageSha256],
+    imageSet: "full-document" as const
+  };
+
+  const common = {
+    schemaVersion: kResultSchemaVersion as 2,
+    experiment: experiment.name,
+    experimentSha256,
+    corpus: kCorpus,
+    prompt: { name: "categorize-design-default", sha256: "a".repeat(64) },
+    runMeta: testRunMeta
+  };
+  const usage = { promptTokens: 400, completionTokens: 40, source: "api" as const };
+  const cost = { modeledUsd: 0.0012, incurredThisRunUsd: 0.0012 };
+
+  const rows: ResultRow[] = [
+    // Superseded: an error that a later success replaced. It must not be rendered, and must be
+    // counted as superseded.
+    { ...common, docId: "alpha", runId: kSentinels.textRun, modality: "text-only",
+      computedModality: "text-only", message: "text-only", requestKey: "alpha-text-old",
+      representation: textRepresentation("alpha"), status: "error",
+      error: { type: "APIError", message: "superseded-error-marker", attempts: 3 } },
+    { ...common, docId: "alpha", runId: kSentinels.textRun, modality: "text-only",
+      computedModality: "text-only", message: "text-only", requestKey: "alpha-text",
+      representation: textRepresentation("alpha"), status: "success",
+      response: {
+        parsed: {
+          category: "form",
+          keyIndicators: [`indicator ${kAdversarial}`],
+          discussion: `discussion ${kAdversarial}`
+        },
+        raw: {}
+      },
+      usage, cost, responseOriginMeta: origin },
+    { ...common, docId: "alpha", runId: kSentinels.imageRun, modality: "text-only",
+      computedModality: "text-only", message: "image-only", requestKey: "alpha-image",
+      representation: { ...imageRepresentation, sourceContentSha256: kContentSha.alpha },
+      promptImageTokensEstimated: 2833, status: "refusal",
+      refusal: `refusal ${kAdversarial}`, usage, cost, responseOriginMeta: origin },
+    { ...common, docId: "alpha", runId: kSentinels.mixedRun, modality: "text-only",
+      computedModality: "text-only", message: "mixed", requestKey: "alpha-mixed",
+      representation: {
+        kind: "mixed", text: textRepresentation("alpha"),
+        image: { ...imageRepresentation, sourceContentSha256: kContentSha.alpha }
+      },
+      promptImageTokensEstimated: 2833, status: "error",
+      error: { type: "unparsed", message: `error ${kAdversarial}`, attempts: 1 } },
+
+    { ...common, docId: "beta", runId: kSentinels.textRun, modality: "visual-only",
+      computedModality: "mixed", message: "text-only", requestKey: null, status: "skipped",
+      skipReasons: [`text-only run: skipped ${kAdversarial}`],
+      decidedFromContentSha256: kContentSha.beta },
+    // Only `category` is set: every field of the response schema is optional, and an unrecognized
+    // one has to be shown rather than dropped by a renderer that assumed the shape.
+    { ...common, docId: "beta", runId: kSentinels.imageRun, modality: "visual-only",
+      computedModality: "mixed", message: "image-only", requestKey: "beta-image",
+      representation: imageRepresentation, promptImageTokensEstimated: 2833, status: "success",
+      response: { parsed: { category: "function", zzUnknownField: "zz-extra-field-marker" }, raw: {} },
+      usage: { ...usage, source: "cache" }, cost: { modeledUsd: 0.0012, incurredThisRunUsd: 0 },
+      responseOriginMeta: origin },
+    { ...common, docId: "beta", runId: kSentinels.mixedRun, modality: "visual-only",
+      computedModality: "mixed", message: "mixed", requestKey: "beta-mixed",
+      representation: {
+        kind: "mixed", text: textRepresentation("beta"), image: imageRepresentation
+      },
+      promptImageTokensEstimated: 2833, textPartOmitted: true, status: "success",
+      response: { parsed: {}, raw: {} }, usage, cost, responseOriginMeta: origin },
+
+    ...[kSentinels.textRun, kSentinels.imageRun, kSentinels.mixedRun].map((runId) => ({
+      ...common, docId: "gamma", runId, modality: "empty" as const,
+      computedModality: "empty" as const, message: "text-only" as const, requestKey: null,
+      status: "skipped" as const,
+      skipReasons: ["the document has no student content at all"],
+      decidedFromContentSha256: kContentSha.gamma
+    }))
+  ];
+
+  const resultsFile = path.join(dataRoot, "results", `${kCorpus}__${experiment.name}.jsonl`);
+  fs.mkdirSync(path.dirname(resultsFile), { recursive: true });
+  fs.writeFileSync(resultsFile, `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`);
+
+  return {
+    dataRoot,
+    paths,
+    experimentFile,
+    experiment: validateExperimentFile(experiment, experimentFile, {
+      knownTextVariants: ["default"],
+      knownImageModes: ["puppeteer-full-height"],
+      promptExists: () => true
+    }),
+    experimentSha256,
+    resultsFile,
+    rows,
+    imageSha256,
+    alphaMarkdown
+  };
+}
+
+/** Every tag name the report itself uses, so a test can say "and nothing else". */
+export function tagNamesIn(markup: string): string[] {
+  return [...new Set([...markup.matchAll(/<\s*\/?\s*([a-zA-Z][a-zA-Z0-9]*)/g)]
+    .map((match) => match[1].toLowerCase()))].sort();
+}

--- a/scripts/ai-harness/test/review-fixture.ts
+++ b/scripts/ai-harness/test/review-fixture.ts
@@ -40,7 +40,16 @@ export const kSentinels = {
   unit: "zz-unit-sentinel",
   investigation: "zz-investigation-sentinel",
   problem: "zz-problem-sentinel",
-  contextId: "zz-context-sentinel"
+  contextId: "zz-context-sentinel",
+  /**
+   * A tile id inside a skip reason.
+   *
+   * Skip reasons are not a fixed vocabulary: `imagesForSet` interpolates up to five tile ids into
+   * its warnings and `expectedRenderFailure` is author-written prose, and both end up in a skipped
+   * row. In this corpus a tile id contains the document id outright, so a shareable report that
+   * prints a skip reason prints a document identifier.
+   */
+  skipReasonTile: "zz-tile-sentinel"
 };
 
 export const kCorpus = "review-corpus";
@@ -286,7 +295,10 @@ export function buildReviewFixture(name: string): ReviewFixture {
 
     { ...common, docId: "beta", runId: kSentinels.textRun, modality: "visual-only",
       computedModality: "mixed", message: "text-only", requestKey: null, status: "skipped",
-      skipReasons: [`text-only run: skipped ${kAdversarial}`],
+      skipReasons: [`text-only run: skipped ${kAdversarial}`,
+        `1 tile(s) the classification marks as needing a picture have no per-tile capture ` +
+        `(${kSentinels.skipReasonTile}) — a tile nested inside a Question is drawn within its ` +
+        "parent's image rather than beside it"],
       decidedFromContentSha256: kContentSha.beta },
     // Only `category` is set: every field of the response schema is optional, and an unrecognized
     // one has to be shown rather than dropped by a renderer that assumed the shape.

--- a/scripts/ai-harness/test/review.test.ts
+++ b/scripts/ai-harness/test/review.test.ts
@@ -314,6 +314,83 @@ describe("every outcome a row can hold is rendered", () => {
   });
 });
 
+describe("a run whose rows used two different prompts says so", () => {
+  /**
+   * A prompt file's content is not part of the experiment hash, but it *is* part of the request
+   * key. So editing a prompt and re-running into the same results file re-runs every pair — and a
+   * re-run that stops early leaves some pairs on the new prompt and some on the old, all current.
+   */
+  const mixed = (modes: Partial<ReviewModes> = {}) => {
+    const fixture = buildReviewFixture(`review-prompt-${modes.blind ? "blind" : "plain"}`);
+    // `alpha`'s image row is re-run under an edited prompt; `beta`'s is not reached before the run
+    // stops. Both are current, and both produce a card.
+    const original = fixture.rows.find(
+      (row) => row.docId === "alpha" && row.runId === kSentinels.imageRun)!;
+    const reRun = {
+      ...original, requestKey: "alpha-image-new-prompt",
+      prompt: { name: "categorize-design-default", sha256: "b".repeat(64) }
+    } as ResultRow;
+    const model = buildReviewModel({
+      rows: [...fixture.rows, reRun], resultsFile: fixture.resultsFile,
+      experiment: fixture.experiment, experimentSha256: fixture.experimentSha256,
+      paths: fixture.paths, now: kNow, modes: { shareable: false, blind: false, ...modes },
+      seed: kSeed
+    });
+    return { model, html: renderReviewHtml(model) };
+  };
+
+  it("refuses to name one prompt for the run in the header", () => {
+    const { model, html } = mixed();
+    const run = model.runs!.find((entry) => entry.runId === kSentinels.imageRun)!;
+    // The last row's hash used to be reported as the run's, which was false for the other cards.
+    expect(run.promptSha256).toBeNull();
+    expect(run.promptVersions).toBe(2);
+    expect(html).toContain("2 versions — see each card");
+  });
+
+  it("gives each card its own prompt instead", () => {
+    const { model, html } = mixed();
+    const cards = model.documents.flatMap((document) => document.cards)
+      .filter((card) => card.runId === kSentinels.imageRun);
+    expect(new Set(cards.map((card) => card.promptSha256))).toEqual(new Set(["b".repeat(64), "a".repeat(64)]));
+    expect(html).toContain(`prompt ${"b".repeat(12)}`);
+    expect(html).toContain(`prompt ${"a".repeat(12)}`);
+  });
+
+  it("leaves a run whose rows agree exactly as it was", () => {
+    const { model, html } = mixed();
+    const settled = model.runs!.find((entry) => entry.runId === kSentinels.mixedRun)!;
+    expect(settled.promptVersions).toBe(1);
+    expect(settled.promptSha256).toBe("a".repeat(64));
+    // The hash appears once in the header, not once per card.
+    expect(html.split(`prompt ${"a".repeat(12)}`).length - 1).toBe(1);
+  });
+
+  it("does not count a skipped row, which sent no prompt at all", () => {
+    // A skipped row records the prompt its run would have used. Counting it flagged a run whose
+    // every card came from one prompt, because a lagging skipped row disagreed with them.
+    const fixture = buildReviewFixture("review-prompt-skipped");
+    const rows = fixture.rows.map((row) => (row.status === "skipped"
+      ? { ...row, prompt: { name: "categorize-design-default", sha256: "c".repeat(64) } }
+      : row)) as ResultRow[];
+    const model = buildReviewModel({
+      rows, resultsFile: fixture.resultsFile, experiment: fixture.experiment,
+      experimentSha256: fixture.experimentSha256, paths: fixture.paths, now: kNow,
+      modes: { shareable: false, blind: false }, seed: kSeed
+    });
+    expect(model.runs!.every((run) => run.promptVersions <= 1)).toBe(true);
+    expect(renderReviewHtml(model)).not.toContain("versions — see each card");
+  });
+
+  it("says none of it in a blinded report, where a prompt identifies the run", () => {
+    const { model, html } = mixed({ blind: true });
+    expect(model.documents.flatMap((document) => document.cards)
+      .every((card) => card.promptSha256 === null)).toBe(true);
+    expect(html).not.toContain("b".repeat(12));
+    expect(html).not.toContain("versions — see each card");
+  });
+});
+
 describe("the experiment file has to be the one the rows were produced with", () => {
   const fixture = buildReviewFixture("review-experiment-hash");
 

--- a/scripts/ai-harness/test/review.test.ts
+++ b/scripts/ai-harness/test/review.test.ts
@@ -348,6 +348,13 @@ describe("every outcome a row can hold is rendered", () => {
     expect(html).toContain("The response parsed to an empty object.");
   });
 
+  it("withholds skip reasons from a shareable report, and says so", () => {
+    const shareable = modelFor(buildReviewFixture("review-skip-reasons"), { shareable: true });
+    expect(shareable.documents.flatMap((document) => document.skipped)
+      .every((entry) => entry.skipReasons.length === 0)).toBe(true);
+    expect(renderReviewHtml(shareable)).toContain("can quote identifiers from the document");
+  });
+
   it("keeps skipped outcomes out of the cards and in their own strip, with reasons", () => {
     expect(gamma.cards).toHaveLength(0);
     expect(gamma.skipped).toHaveLength(3);
@@ -497,7 +504,9 @@ describe("--shareable", () => {
 
   it("omits every harness metadata identifier", () => {
     for (const sentinel of [kSentinels.unit, kSentinels.investigation, kSentinels.problem,
-      kSentinels.contextId]) {
+      kSentinels.contextId,
+      // A skip reason quotes tile ids, and a tile id contains the document id in this corpus.
+      kSentinels.skipReasonTile]) {
       expect(html).not.toContain(sentinel);
     }
     expect(html).not.toContain("documents/");

--- a/scripts/ai-harness/test/review.test.ts
+++ b/scripts/ai-harness/test/review.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import {
   BuildReviewOptions, ReviewModel, ReviewModes, assertExperimentMatchesRows, blindLabelsFor,
-  assertKeyIsReusable, buildReviewModel, escapeHtml, labelForIndex, ratingsTemplateCsv,
+  assertKeyIsReusable, buildReviewModel, compareLabels, escapeHtml, labelForIndex, ratingsTemplateCsv,
   renderReviewHtml, reviewKeyFactsOf, reviewKeyFileFor, reviewOutputPathFor, reviewSidecarPaths
 } from "../src/review.js";
 import { representationPath } from "../src/corpus.js";
@@ -597,6 +597,45 @@ describe("blind labels", () => {
   it("counts past Z rather than running out", () => {
     expect([0, 1, 25, 26, 27, 51, 52].map(labelForIndex))
       .toEqual(["A", "B", "Z", "AA", "AB", "AZ", "BA"]);
+  });
+
+  it("sorts the way it issues, which plain lexicographic ordering does not", () => {
+    const issued = Array.from({ length: 30 }, (_, index) => labelForIndex(index));
+    expect([...issued].sort(compareLabels)).toEqual(issued);
+    // What the report used to do: `AA` lands immediately after `A`.
+    expect([...issued].sort((a, b) => a.localeCompare(b))).not.toEqual(issued);
+    expect(["B", "AA", "A", "Z", "AB"].sort(compareLabels)).toEqual(["A", "B", "Z", "AA", "AB"]);
+  });
+
+  it("keeps a document with more than 26 outcomes in issued order, page and template alike", () => {
+    // 27 runs over one document: the case where the ordering rule stops being academic.
+    const fixture = buildReviewFixture("review-many-labels");
+    const template = fixture.rows.find(
+      (row) => row.docId === "alpha" && row.status === "success")!;
+    const runIds = Array.from({ length: 27 }, (_, index) => `zz-run-${String(index).padStart(2, "0")}`);
+    const experiment = {
+      ...fixture.experiment,
+      runs: runIds.map((id) => ({
+        id, message: "text-only" as const, textVariant: "default", extras: "all" as const,
+        prompt: "categorize-design-default"
+      }))
+    };
+    const rows = runIds.map((runId) => ({
+      ...template, runId, requestKey: `alpha-${runId}`
+    })) as ResultRow[];
+    const model = buildReviewModel({
+      rows, resultsFile: fixture.resultsFile, experiment, experimentSha256: fixture.experimentSha256,
+      paths: fixture.paths, now: kNow, modes: { shareable: false, blind: true }, seed: kSeed
+    });
+
+    const expected = Array.from({ length: 27 }, (_, index) => labelForIndex(index));
+    expect(expected[26]).toBe("AA");
+    expect(model.documents[0].cards.map((card) => card.label)).toEqual(expected);
+    const rendered = [...renderReviewHtml(model)
+      .matchAll(/<span class="card-title">([A-Z]+)<\/span>/g)].map((match) => match[1]);
+    expect(rendered).toEqual(expected);
+    expect(ratingsTemplateCsv(model).trim().split("\n").slice(1)
+      .map((line) => line.split(",")[1].replace(/"/g, ""))).toEqual(expected);
   });
 
   it("depends on the seed, the document and the run", () => {

--- a/scripts/ai-harness/test/review.test.ts
+++ b/scripts/ai-harness/test/review.test.ts
@@ -91,6 +91,31 @@ describe("escaping student-authored content", () => {
   });
 });
 
+describe("the page can be read with a keyboard", () => {
+  const fixture = buildReviewFixture("review-accessibility");
+  const html = renderReviewHtml(modelFor(fixture));
+
+  it("makes every clipped block focusable, so it can be scrolled without a mouse", () => {
+    // `pre` clips at 32rem and scrolls, and summaries routinely run past that. A scroll container
+    // without `tabindex` cannot be focused or scrolled by keyboard in Firefox or Safari, so a
+    // keyboard-only judge cannot read past the clip.
+    const blocks = [...html.matchAll(/<pre\b([^>]*)>/g)].map((match) => match[1]);
+    expect(blocks.length).toBeGreaterThan(0);
+    expect(blocks.every((attributes) => attributes.includes('tabindex="0"'))).toBe(true);
+    // And each announces what it is, rather than being an unnamed region.
+    expect(blocks.every((attributes) => /aria-label="[^"]+"/.test(attributes))).toBe(true);
+  });
+
+  it("never skips a heading level", () => {
+    const levels = [...html.matchAll(/<h([1-6])\b/g)].map((match) => Number(match[1]));
+    expect(levels[0]).toBe(1);
+    // A jump from h1 straight to h4 makes heading navigation lie about the structure.
+    for (let index = 1; index < levels.length; index += 1) {
+      expect(levels[index] - levels[index - 1]).toBeLessThanOrEqual(1);
+    }
+  });
+});
+
 describe("what the model was given", () => {
   const fixture = buildReviewFixture("review-inputs");
   const model = modelFor(fixture);

--- a/scripts/ai-harness/test/review.test.ts
+++ b/scripts/ai-harness/test/review.test.ts
@@ -1,0 +1,649 @@
+import fs from "node:fs";
+import path from "node:path";
+import {
+  BuildReviewOptions, ReviewModel, ReviewModes, assertExperimentMatchesRows, blindLabelsFor,
+  assertKeyIsReusable, buildReviewModel, escapeHtml, labelForIndex, ratingsTemplateCsv,
+  renderReviewHtml, reviewKeyFactsOf, reviewKeyFileFor, reviewOutputPathFor, reviewSidecarPaths
+} from "../src/review.js";
+import { representationPath } from "../src/corpus.js";
+import {
+  imageRepresentationPath, readImageEnvelope, resolveImageFile
+} from "../src/represent-image.js";
+import { ResultRow, validateReviewKeyFile } from "../src/schemas.js";
+import { ReviewFixture, buildReviewFixture, kAdversarial, kSentinels, tagNamesIn } from "./review-fixture.js";
+
+const kSeed = "a".repeat(64);
+const kOtherSeed = "b".repeat(64);
+const kNow = new Date("2026-08-20T00:00:00.000Z");
+
+function modelFor(
+  fixture: ReviewFixture, modes: Partial<ReviewModes> = {}, overrides: Partial<BuildReviewOptions> = {}
+): ReviewModel {
+  return buildReviewModel({
+    rows: fixture.rows,
+    resultsFile: fixture.resultsFile,
+    experiment: fixture.experiment,
+    experimentSha256: fixture.experimentSha256,
+    paths: fixture.paths,
+    now: kNow,
+    modes: { shareable: false, blind: false, ...modes },
+    seed: kSeed,
+    ...overrides
+  });
+}
+
+/** The report's own tags. Anything else in the output came from a document. */
+const kOwnTags = ["article", "body", "dd", "div", "dl", "dt", "h1", "h2", "h3", "h4", "head", "html",
+  "img", "li", "meta", "p", "pre", "span", "strong", "style", "table", "tbody", "td", "th", "thead",
+  "title", "tr", "ul"];
+
+describe("escaping student-authored content", () => {
+  const fixture = buildReviewFixture("review-escaping");
+  const html = renderReviewHtml(modelFor(fixture));
+
+  it("escapes at every path a document's text reaches the page by", () => {
+    // The summary, a discussion, a key indicator, a refusal, an error message and a skip reason are
+    // six different code paths, and each one carries the same adversarial string.
+    expect(html.split(escapeHtml(kAdversarial)).length - 1).toBeGreaterThanOrEqual(6);
+    expect(html).toContain("&lt;/script&gt;");
+    expect(html).toContain("&lt;img src=x onerror=alert(1)&gt;");
+  });
+
+  it("never lets student content become markup", () => {
+    expect(html).not.toContain("<script");
+    // A DOM-free check that nothing beyond the report's own elements was produced: a `<b>`, an `<a>`
+    // from the markdown link syntax, or a second `<img>` would each show up here.
+    expect(tagNamesIn(html)).toEqual(kOwnTags);
+  });
+
+  it("renders markdown in the summary as text rather than interpreting it", () => {
+    // Markdown rendering of student text is markup injection with extra steps, so the summary is
+    // preformatted text and its `[link](…)` stays visible as characters.
+    expect(html).toContain("[link](https://evil.example.com/x)");
+    expect(tagNamesIn(html)).not.toContain("a");
+  });
+
+  it("loads nothing from anywhere: every image is inline PNG bytes", () => {
+    const sources = [...html.matchAll(/<img[^>]*\ssrc="([^"]*)"/g)].map((match) => match[1]);
+    expect(sources.length).toBeGreaterThan(0);
+    expect(sources.every((source) => source.startsWith("data:image/png;base64,"))).toBe(true);
+    // The only URL in the file is the one inside the escaped student text.
+    expect([...html.matchAll(/https?:\/\//g)]).toHaveLength(html.split("evil.example.com").length - 1);
+    expect(html).not.toMatch(/<(link|iframe|object|embed|svg)\b/);
+  });
+
+  it("writes no raw line or paragraph separator, which editors flag as a damaged file", () => {
+    // Student text really does contain them — the `adversarial-text` fixture has one of each — and
+    // they are ordinary characters in HTML, so they are escaped rather than dropped: a browser
+    // decodes the reference back to the same character and renders the page identically.
+    const separators = renderReviewHtml(modelFor(buildReviewFixture("review-separators")));
+    expect(separators).not.toMatch(/[\u2028\u2029]/);
+    expect(escapeHtml("a\u2028b\u2029c")).toBe("a&#8232;b&#8233;c");
+    // The `&` of the reference is not itself re-escaped, which would print the reference as text.
+    expect(escapeHtml("\u2028")).not.toContain("&amp;");
+  });
+
+  it("carries the content-security-policy meta tag as defence in depth", () => {
+    expect(html).toContain(`<meta http-equiv="Content-Security-Policy" content="default-src 'none'; ` +
+      `img-src data:; style-src 'unsafe-inline'">`);
+  });
+});
+
+describe("what the model was given", () => {
+  const fixture = buildReviewFixture("review-inputs");
+  const model = modelFor(fixture);
+  const alpha = model.documents.find((document) => document.docId === "alpha")!;
+  const beta = model.documents.find((document) => document.docId === "beta")!;
+
+  it("shows the summary each run actually sent", () => {
+    expect(alpha.texts).toHaveLength(1);
+    expect(alpha.texts[0].markdown).toBe(fixture.alphaMarkdown);
+  });
+
+  it("shows one copy of a picture two runs both sent, labelled with both", () => {
+    expect(beta.images).toHaveLength(1);
+    expect(beta.images[0].sha256).toBe(fixture.imageSha256);
+    expect(beta.images[0].labels).toEqual(["puppeteer-full-height, full-document"]);
+  });
+
+  it("does not claim a mixed row sent a summary when its text half was dropped", () => {
+    // `beta`'s only text-carrying row is the mixed one, and it went without its summary.
+    expect(beta.texts).toHaveLength(0);
+    expect(beta.cards.find((card) => card.runId === kSentinels.mixedRun)!.textPartOmitted).toBe(true);
+  });
+});
+
+describe("an input that no longer matches the run is never shown in its place", () => {
+  const notices = (fixture: ReviewFixture, docId: string) => {
+    const model = modelFor(fixture);
+    return model.documents.find((document) => document.docId === docId)!;
+  };
+
+  it("refuses a summary regenerated from changed content", () => {
+    const fixture = buildReviewFixture("review-stale-content");
+    const file = representationPath(fixture.paths, "default", "alpha");
+    const envelope = JSON.parse(fs.readFileSync(file, "utf8"));
+    fs.writeFileSync(file, JSON.stringify({
+      ...envelope, sourceContentSha256: "9".repeat(64), markdown: "REGENERATED-SUMMARY-MARKER"
+    }));
+    const alpha = notices(fixture, "alpha");
+    expect(alpha.texts).toHaveLength(0);
+    expect(alpha.inputNotices.join(" ")).toContain("the document has changed since this run");
+    expect(renderReviewHtml(modelFor(fixture))).not.toContain("REGENERATED-SUMMARY-MARKER");
+  });
+
+  it("refuses a summary produced by a newer version of the variant", () => {
+    const fixture = buildReviewFixture("review-variant-version");
+    const file = representationPath(fixture.paths, "default", "alpha");
+    const envelope = JSON.parse(fs.readFileSync(file, "utf8"));
+    fs.writeFileSync(file, JSON.stringify({ ...envelope, variantVersion: 2 }));
+    const alpha = notices(fixture, "alpha");
+    expect(alpha.texts).toHaveLength(0);
+    expect(alpha.inputNotices.join(" "))
+      .toContain("regenerated by a newer version of its variant");
+  });
+
+  it("refuses a picture whose bytes are not the ones that were sent", () => {
+    const fixture = buildReviewFixture("review-image-bytes");
+    const envelopeFile = imageRepresentationPath(fixture.paths, "puppeteer-full-height", "beta");
+    const image = readImageEnvelope(envelopeFile).images[0];
+    const bytes = fs.readFileSync(resolveImageFile(envelopeFile, image));
+    // Same length, different pixels: the byte count alone would still match.
+    bytes[bytes.length - 20] = bytes[bytes.length - 20] === 0 ? 1 : 0;
+    fs.writeFileSync(resolveImageFile(envelopeFile, image), bytes);
+    const beta = notices(fixture, "beta");
+    expect(beta.images).toHaveLength(0);
+    // Damaged bytes trip the envelope's own hash check first, so the reason is the render no longer
+    // matching rather than the narrower "these are not the bytes that were sent".
+    expect(beta.inputNotices.join(" ")).toContain("no longer matches the one this run sent");
+  });
+
+  it("refuses a render of a document that has changed since", () => {
+    const fixture = buildReviewFixture("review-image-content");
+    const envelopeFile = imageRepresentationPath(fixture.paths, "puppeteer-full-height", "beta");
+    const envelope = JSON.parse(fs.readFileSync(envelopeFile, "utf8"));
+    fs.writeFileSync(envelopeFile,
+      JSON.stringify({ ...envelope, sourceContentSha256: "9".repeat(64) }));
+    expect(notices(fixture, "beta").images).toHaveLength(0);
+  });
+
+  it("degrades to a notice when the files are gone, rather than crashing", () => {
+    const fixture = buildReviewFixture("review-missing-files");
+    fs.rmSync(representationPath(fixture.paths, "default", "alpha"));
+    fs.rmSync(imageRepresentationPath(fixture.paths, "puppeteer-full-height", "beta"),
+      { recursive: true });
+    const model = modelFor(fixture);
+    const alpha = model.documents.find((document) => document.docId === "alpha")!;
+    const beta = model.documents.find((document) => document.docId === "beta")!;
+    expect(alpha.texts).toHaveLength(0);
+    expect(alpha.inputNotices.join(" ")).toContain("no longer on disk");
+    expect(beta.images).toHaveLength(0);
+    expect(beta.inputNotices.join(" ")).toContain("no longer on disk");
+    expect(() => renderReviewHtml(model)).not.toThrow();
+  });
+
+  it("degrades to a notice when an envelope is damaged", () => {
+    const fixture = buildReviewFixture("review-damaged-envelope");
+    fs.writeFileSync(imageRepresentationPath(fixture.paths, "puppeteer-full-height", "beta"),
+      "{ not json");
+    const beta = notices(fixture, "beta");
+    expect(beta.images).toHaveLength(0);
+    expect(beta.inputNotices.join(" ")).toContain("could not be read");
+  });
+});
+
+describe("a provenance notice never leaks what its mode is hiding", () => {
+  /** Damage every kind of input at once, so one report exercises every notice path. */
+  const damaged = (name: string) => {
+    const fixture = buildReviewFixture(name);
+    fs.writeFileSync(representationPath(fixture.paths, "default", "alpha"), "{ not json");
+    const envelopeFile = imageRepresentationPath(fixture.paths, "puppeteer-full-height", "beta");
+    const envelope = JSON.parse(fs.readFileSync(envelopeFile, "utf8"));
+    // A mode/backend mismatch, which is what puts a run configuration in a freshness reason.
+    fs.writeFileSync(envelopeFile, JSON.stringify({ ...envelope, backendVersion: 99 }));
+    return fixture;
+  };
+
+  it("keeps paths, filenames and document ids out of a shareable report", () => {
+    const fixture = damaged("review-notice-shareable");
+    const model = modelFor(fixture, { shareable: true });
+    const notices = model.documents.flatMap((document) => document.inputNotices).join(" ");
+    expect(notices).not.toBe("");
+    // The reader's own error names the file it could not read, which is an absolute path holding
+    // the corpus name and the document id.
+    for (const leak of ["alpha", "beta", "gamma", "/", ".json", ".png", "review-corpus"]) {
+      expect(notices).not.toContain(leak);
+    }
+    expect(renderReviewHtml(model)).not.toContain(fixture.dataRoot);
+  });
+
+  it("keeps run configurations out of a blinded report", () => {
+    const fixture = damaged("review-notice-blind");
+    const model = modelFor(fixture, { blind: true });
+    const notices = model.documents.flatMap((document) => document.inputNotices).join(" ");
+    expect(notices).not.toBe("");
+    // A freshness reason names the backend and version it expected; a filename names the document.
+    for (const leak of ["puppeteer", "backendVersion", "99", "default", "alpha", ".png"]) {
+      expect(notices).not.toContain(leak);
+    }
+  });
+
+  it("still tells the team-internal report exactly what went wrong", () => {
+    // The detail is what makes a notice actionable, so the one report allowed to carry it does.
+    const notices = modelFor(damaged("review-notice-plain"))
+      .documents.flatMap((document) => document.inputNotices).join(" ");
+    expect(notices).toContain("backendVersion");
+    expect(notices).toContain("could not be read");
+  });
+});
+
+describe("every outcome a row can hold is rendered", () => {
+  const fixture = buildReviewFixture("review-structure");
+  const model = modelFor(fixture);
+  const html = renderReviewHtml(model);
+  const alpha = model.documents.find((document) => document.docId === "alpha")!;
+  const beta = model.documents.find((document) => document.docId === "beta")!;
+  const gamma = model.documents.find((document) => document.docId === "gamma")!;
+
+  it("counts each status once, over current rows only", () => {
+    expect(model.counts).toEqual({ success: 3, refusal: 1, error: 1, skipped: 4 });
+  });
+
+  it("renders success, refusal and error as cards", () => {
+    expect(alpha.cards.map((card) => card.status)).toEqual(["success", "refusal", "error"]);
+    expect(html).toContain("badge-success");
+    expect(html).toContain("badge-refusal");
+    expect(html).toContain("badge-error");
+  });
+
+  it("renders whichever response fields exist, and keeps the ones it does not recognize", () => {
+    const [full] = alpha.cards;
+    expect(full.outcome).toMatchObject({ kind: "success", category: "form" });
+    const partial = beta.cards.find((card) => card.runId === kSentinels.imageRun)!;
+    expect(partial.outcome).toMatchObject({
+      kind: "success", category: "function", keyIndicators: null, discussion: null,
+      remainingJson: '{"zzUnknownField":"zz-extra-field-marker"}'
+    });
+    expect(html).toContain("zz-extra-field-marker");
+  });
+
+  it("says so plainly when a response parsed to nothing at all", () => {
+    const empty = beta.cards.find((card) => card.runId === kSentinels.mixedRun)!;
+    expect(empty.outcome)
+      .toEqual({ kind: "success", category: null, keyIndicators: null, discussion: null, remainingJson: null });
+    expect(html).toContain("The response parsed to an empty object.");
+  });
+
+  it("keeps skipped outcomes out of the cards and in their own strip, with reasons", () => {
+    expect(gamma.cards).toHaveLength(0);
+    expect(gamma.skipped).toHaveLength(3);
+    expect(beta.skipped.map((entry) => entry.runId)).toEqual([kSentinels.textRun]);
+    expect(html).toContain("declined to send this document");
+    expect(html).toContain(escapeHtml(`text-only run: skipped ${kAdversarial}`));
+  });
+
+  it("flags the mixed row that went without its text half", () => {
+    expect(html).toContain("no summary sent");
+  });
+
+  it("excludes superseded rows and counts them", () => {
+    expect(model.supersededRows).toBe(1);
+    expect(html).not.toContain("superseded-error-marker");
+    expect(html).toContain("1 superseded row(s)");
+  });
+
+  it("groups documents by the modality their rows were filed under, flagging overrides", () => {
+    expect(model.groups.map((group) => group.modality)).toEqual(["text-only", "visual-only", "empty"]);
+    expect(beta.overridden).toBe(true);
+    expect(html).toContain("modality overridden");
+  });
+
+  it("lists every run's configuration in experiment-file order", () => {
+    expect(model.runs!.map((run) => run.runId))
+      .toEqual([kSentinels.textRun, kSentinels.imageRun, kSentinels.mixedRun]);
+    expect(model.runs![1]).toMatchObject({ imageMode: "puppeteer-full-height", detail: "low" });
+    // Defaults are shown as what they are rather than left blank: `extras` is only absent from the
+    // experiment file, not from the request.
+    expect(model.runs![0].extras).toBe("all");
+    expect(model.runs![2].extras).toBe("none");
+  });
+
+  it("is stamped with the injected clock rather than the wall clock", () => {
+    expect(model.generatedAt).toBe(kNow.toISOString());
+    expect(html).toContain(kNow.toISOString());
+  });
+});
+
+describe("the experiment file has to be the one the rows were produced with", () => {
+  const fixture = buildReviewFixture("review-experiment-hash");
+
+  it("refuses a file whose hash does not match the rows", () => {
+    expect(() => assertExperimentMatchesRows(
+      fixture.rows, "edited-hash", fixture.experimentFile, fixture.resultsFile))
+      .toThrow(/has been edited since the run/);
+  });
+
+  it("accepts the matching one", () => {
+    expect(() => assertExperimentMatchesRows(
+      fixture.rows, fixture.experimentSha256, fixture.experimentFile, fixture.resultsFile))
+      .not.toThrow();
+  });
+});
+
+describe("--shareable", () => {
+  const fixture = buildReviewFixture("review-shareable");
+  const model = modelFor(fixture, { shareable: true });
+  const html = renderReviewHtml(model);
+
+  it("replaces document ids with stable per-report pseudonyms", () => {
+    expect(model.documents.map((document) => document.displayName))
+      .toEqual(["doc-01", "doc-02", "doc-03"]);
+    expect(model.pseudonyms).toEqual({ alpha: "doc-01", beta: "doc-02", gamma: "doc-03" });
+    for (const docId of ["alpha", "beta", "gamma"]) expect(html).not.toContain(docId);
+  });
+
+  it("omits every harness metadata identifier", () => {
+    for (const sentinel of [kSentinels.unit, kSentinels.investigation, kSentinels.problem,
+      kSentinels.contextId]) {
+      expect(html).not.toContain(sentinel);
+    }
+    expect(html).not.toContain("documents/");
+    expect(html).not.toContain(fixture.resultsFile);
+    expect(model.gitCommit).toBeNull();
+  });
+
+  it("keeps the run configurations and prompt identity, which are what a reader judges", () => {
+    expect(html).toContain(kSentinels.textRun);
+    expect(html).toContain("categorize-design-default");
+  });
+
+  it("says plainly that document content is not redacted", () => {
+    expect(html).toContain("Document content is not redacted");
+    // And it really is not: the student's own text is still there, escaped.
+    expect(html).toContain(escapeHtml(kAdversarial));
+  });
+
+  it("round-trips its key file", () => {
+    const key = validateReviewKeyFile(
+      JSON.parse(JSON.stringify(reviewKeyFileFor(model))), "key.json");
+    expect(key.pseudonyms).toEqual(model.pseudonyms);
+    expect(key.modes).toEqual({ shareable: true, blind: false });
+    expect(key.seed).toBeNull();
+    expect(key.labels).toBeNull();
+  });
+});
+
+describe("--blind", () => {
+  const fixture = buildReviewFixture("review-blind");
+  const model = modelFor(fixture, { blind: true });
+  const other = modelFor(fixture, { blind: true }, { seed: kOtherSeed });
+  const html = renderReviewHtml(model);
+
+  it("labels the judgeable cards and hides everything that identifies the run", () => {
+    const alpha = model.documents.find((document) => document.docId === "alpha")!;
+    expect(alpha.cards.map((card) => card.label)).toEqual(["A", "B", "C"]);
+    for (const card of alpha.cards) {
+      expect(card.runId).toBeNull();
+      expect(card.configuration).toBeNull();
+      expect(card.usage).toBeNull();
+      expect(card.modeledUsd).toBeNull();
+      expect(card.representationWarnings).toEqual([]);
+    }
+    // Status stays: a refusal is an outcome a judge rates.
+    expect(alpha.cards.map((card) => card.status).sort())
+      .toEqual(["error", "refusal", "success"]);
+  });
+
+  it("reduces the header's run list to a count", () => {
+    expect(model.runs).toBeNull();
+    expect(model.runCount).toBe(3);
+    expect(html).toContain("3 run(s)");
+  });
+
+  it("leaves no run id, variant, mode, detail, image set, extras or cost anywhere in the page", () => {
+    for (const sentinel of [kSentinels.textRun, kSentinels.imageRun, kSentinels.mixedRun]) {
+      expect(html).not.toContain(sentinel);
+    }
+    // Asserted against the structure rather than by searching for "default" or "low", which a
+    // student could legitimately write; the run ids above are sentinels precisely so they can be
+    // searched for.
+    expect(model.documents.flatMap((document) => document.cards)
+      .every((card) => !card.configuration && !card.usage && card.modeledUsd === null)).toBe(true);
+    expect(html).not.toContain("puppeteer-full-height");
+    expect(html).not.toContain("modeled");
+    expect(html).not.toContain("$");
+  });
+
+  it("still shows the document: every image and summary its runs used", () => {
+    const alpha = model.documents.find((document) => document.docId === "alpha")!;
+    const beta = model.documents.find((document) => document.docId === "beta")!;
+    expect(alpha.texts.map((text) => text.markdown)).toEqual([fixture.alphaMarkdown]);
+    expect(beta.images).toHaveLength(1);
+    // Without the labels, which would name a configuration.
+    expect(alpha.texts[0].labels).toEqual([]);
+    expect(beta.images[0].labels).toEqual([]);
+  });
+
+  it("keeps skipped outcomes unlabelled, outside the key and outside the ratings template", () => {
+    const gamma = model.documents.find((document) => document.docId === "gamma")!;
+    expect(gamma.cards).toHaveLength(0);
+    expect(gamma.skipped.every((entry) => entry.runId === null)).toBe(true);
+    expect(model.judgeable.some((pair) => pair.docId === "gamma")).toBe(false);
+    expect(ratingsTemplateCsv(model)).not.toContain("gamma");
+  });
+
+  it("gives a complete decoding: every judgeable pair appears in the key exactly once", () => {
+    const key = reviewKeyFileFor(model);
+    const mapped = Object.entries(key.labels!)
+      .flatMap(([docId, byLabel]) => Object.values(byLabel).map((runId) => `${docId} ${runId}`));
+    expect(mapped.sort())
+      .toEqual(model.judgeable.map((pair) => `${pair.docId} ${pair.runId}`).sort());
+    expect(new Set(mapped).size).toBe(mapped.length);
+    for (const byLabel of Object.values(key.labels!)) {
+      expect(new Set(Object.keys(byLabel)).size).toBe(Object.keys(byLabel).length);
+    }
+  });
+
+  it("orders the cards from a secret seed, so the page alone does not decode them", () => {
+    // Two reports over identical data, differing only in the seed. The pages hold the same cards in
+    // a different order, and nothing in either page says which is which.
+    expect(model.labels).not.toEqual(other.labels);
+    const cardsOf = (source: string) =>
+      [...source.matchAll(/<div class="card">([\s\S]*?)<\/div>\s*<\/div>/g)]
+        .map((match) => match[1].replace(/<span class="card-title">[A-Z]+<\/span>/, "")).sort();
+    expect(cardsOf(html)).toEqual(cardsOf(renderReviewHtml(other)));
+    expect(html).not.toBe(renderReviewHtml(other));
+  });
+
+  it("regenerates the same order from the same seed", () => {
+    expect(renderReviewHtml(modelFor(fixture, { blind: true }))).toBe(html);
+  });
+
+  it("writes one row per labelled outcome in the ratings template, and no rubric of its own", () => {
+    const csv = ratingsTemplateCsv(model).trim().split("\n");
+    expect(csv[0]).toBe("document,label,rating,notes");
+    expect(csv).toHaveLength(model.judgeable.length + 1);
+    expect(csv[1]).toBe('"alpha","A","",""');
+  });
+
+  it("uses the pseudonym in the template when the report is also shareable", () => {
+    const both = modelFor(fixture, { blind: true, shareable: true });
+    expect(ratingsTemplateCsv(both).split("\n")[1]).toBe('"doc-01","A","",""');
+    const key = reviewKeyFileFor(both);
+    expect(key.modes).toEqual({ shareable: true, blind: true });
+    expect(key.pseudonyms).not.toBeNull();
+    expect(key.labels).not.toBeNull();
+    expect(key.seed).toBe(kSeed);
+  });
+});
+
+describe("a response field the typed renderer cannot show is kept, not dropped", () => {
+  const withParsed = (parsed: unknown) => {
+    const fixture = buildReviewFixture(`review-parsed-${Math.abs(JSON.stringify(parsed).length)}`);
+    const rows = fixture.rows.map((row) => (
+      row.docId === "beta" && row.runId === kSentinels.imageRun && row.status === "success"
+        ? { ...row, response: { parsed, raw: {} } }
+        : row)) as ResultRow[];
+    const model = buildReviewModel({
+      rows, resultsFile: fixture.resultsFile, experiment: fixture.experiment,
+      experimentSha256: fixture.experimentSha256, paths: fixture.paths, now: kNow,
+      modes: { shareable: false, blind: false }, seed: kSeed
+    });
+    return model.documents.find((document) => document.docId === "beta")!
+      .cards.find((card) => card.runId === kSentinels.imageRun)!;
+  };
+
+  it("puts a wrong-typed recognized field in the JSON fallback rather than losing it", () => {
+    // Dropping these by name rendered "the response parsed to an empty object" — a card that says
+    // something untrue about what came back.
+    const card = withParsed({ category: 42, keyIndicators: "not a list", discussion: { a: 1 } });
+    expect(card.outcome).toEqual({
+      kind: "success", category: null, keyIndicators: null, discussion: null,
+      remainingJson: '{"category":42,"discussion":{"a":1},"keyIndicators":"not a list"}'
+    });
+  });
+
+  it("keeps the ones it can show out of the fallback, so nothing is printed twice", () => {
+    const card = withParsed({ category: "form", discussion: 7, other: "kept" });
+    expect(card.outcome).toMatchObject({
+      category: "form", discussion: null, remainingJson: '{"discussion":7,"other":"kept"}'
+    });
+  });
+
+  it("shows the whole value when the response is not an object at all", () => {
+    expect(withParsed("just a string").outcome)
+      .toMatchObject({ category: null, remainingJson: '"just a string"' });
+  });
+});
+
+describe("blind labels", () => {
+  it("counts past Z rather than running out", () => {
+    expect([0, 1, 25, 26, 27, 51, 52].map(labelForIndex))
+      .toEqual(["A", "B", "Z", "AA", "AB", "AZ", "BA"]);
+  });
+
+  it("depends on the seed, the document and the run", () => {
+    const runs = ["one", "two", "three", "four"];
+    const labels = (seed: string, docId: string) =>
+      [...blindLabelsFor(seed, docId, runs).entries()].map(([runId, label]) => `${runId}=${label}`).sort();
+    expect(labels(kSeed, "alpha")).not.toEqual(labels(kOtherSeed, "alpha"));
+    expect(labels(kSeed, "alpha")).not.toEqual(labels(kSeed, "beta"));
+    expect(labels(kSeed, "alpha")).toEqual(labels(kSeed, "alpha"));
+    expect(new Set(blindLabelsFor(kSeed, "alpha", runs).values()).size).toBe(runs.length);
+  });
+});
+
+describe("a key that would not decode the report is refused", () => {
+  const fixture = buildReviewFixture("review-key-validation");
+  const blind = modelFor(fixture, { blind: true, shareable: true });
+  const key = reviewKeyFileFor(blind);
+  const facts = reviewKeyFactsOf(blind);
+
+  it("accepts the key it just wrote", () => {
+    expect(() => assertKeyIsReusable(key, facts, "k.json")).not.toThrow();
+  });
+
+  it("refuses pseudonyms that are not the ones the report renders", () => {
+    // Nothing else compares the two: the report always numbers documents from the presentation
+    // order, so a key naming `doc-99` decodes nothing however well formed it is.
+    expect(() => assertKeyIsReusable(
+      { ...key, pseudonyms: { alpha: "doc-99", beta: "doc-02", gamma: "doc-03" } }, facts, "k.json"))
+      .toThrow(/pseudonyms are not the ones this report renders/);
+  });
+
+  it("refuses a second label aliased onto a run that is already mapped", () => {
+    // The set of *runs* still looks complete, so counting runs alone accepted this — and converting
+    // it back to run→label silently picked whichever alias came last.
+    const alpha = key.labels!.alpha;
+    const aliased = { ...alpha, Z: Object.values(alpha)[0] };
+    expect(() => assertKeyIsReusable(
+      { ...key, labels: { ...key.labels, alpha: aliased } }, facts, "k.json"))
+      .toThrow(/do not cover exactly the outcomes this report renders, one label each/);
+  });
+
+  it("refuses the same mapping on read, before anything can reuse it", () => {
+    const alpha = key.labels!.alpha;
+    const raw = JSON.parse(JSON.stringify(
+      { ...key, labels: { ...key.labels, alpha: { ...alpha, Z: Object.values(alpha)[0] } } }));
+    expect(() => validateReviewKeyFile(raw, "k.json")).toThrow(/more than one label/);
+    const duplicated = JSON.parse(JSON.stringify(
+      { ...key, pseudonyms: { alpha: "doc-01", beta: "doc-01", gamma: "doc-03" } }));
+    expect(() => validateReviewKeyFile(duplicated, "k.json"))
+      .toThrow(/more than one document the pseudonym "doc-01"/);
+  });
+});
+
+describe("one order runs through the report, the key and the ratings template", () => {
+  it("numbers pseudonyms by the order the page presents, not by manifest order", () => {
+    // The page groups by modality, so manifest order is not reading order. A judge working down the
+    // page has to be working down the spreadsheet at the same time.
+    const fixture = buildReviewFixture("review-presentation-order");
+    const orphan = { ...fixture.rows[1], docId: "delta", requestKey: "delta-text" } as ResultRow;
+    const model = buildReviewModel({
+      rows: [...fixture.rows, orphan], resultsFile: fixture.resultsFile,
+      experiment: fixture.experiment, experimentSha256: fixture.experimentSha256,
+      paths: fixture.paths, now: kNow, modes: { shareable: true, blind: true }, seed: kSeed
+    });
+    const page = model.groups.flatMap((group) => group.documents.map((document) => document.displayName));
+    expect(page).toEqual(["doc-01", "doc-02", "doc-03", "doc-04"]);
+    expect(model.documents.map((document) => document.displayName)).toEqual(page);
+    expect(reviewKeyFileFor(model).documents).toEqual(["alpha", "delta", "beta", "gamma"]);
+    const csv = ratingsTemplateCsv(model).trim().split("\n").slice(1)
+      .map((line) => line.split(",")[0].replace(/"/g, ""));
+    expect([...new Set(csv)]).toEqual(page.filter((name) => csv.includes(name)));
+    // And the HTML really does present them in that order.
+    const rendered = [...renderReviewHtml(model).matchAll(/<h3>(doc-\d+)<\/h3>/g)].map((m) => m[1]);
+    expect(rendered).toEqual(page);
+  });
+});
+
+describe("output and sidecar paths", () => {
+  const results = path.join("data", "results", "corpus__experiment.jsonl");
+
+  it("names a distinct file per mode, so no variant can overwrite another", () => {
+    const names = ([
+      { shareable: false, blind: false }, { shareable: true, blind: false },
+      { shareable: false, blind: true }, { shareable: true, blind: true }
+    ] as ReviewModes[]).map((modes) => path.basename(reviewOutputPathFor(results, modes)));
+    expect(names).toEqual([
+      "corpus__experiment.review.html",
+      "corpus__experiment.review-shareable.html",
+      "corpus__experiment.review-blind.html",
+      "corpus__experiment.review-blind-shareable.html"
+    ]);
+    expect(new Set(names).size).toBe(4);
+  });
+
+  it("derives both sidecars from the output path, not from the results basename", () => {
+    // Two `--out` targets over one results file must not share a key.
+    expect(reviewSidecarPaths("/d/one.html"))
+      .toEqual({ key: "/d/one.key.json", ratings: "/d/one.ratings-template.csv" });
+    expect(reviewSidecarPaths("/d/two.html").key).not.toBe(reviewSidecarPaths("/d/one.html").key);
+  });
+});
+
+describe("a document the manifest no longer lists is still shown", () => {
+  it("renders after the manifest's own, flagged, rather than disappearing", () => {
+    const fixture = buildReviewFixture("review-unknown-document");
+    const orphan: ResultRow = {
+      ...fixture.rows[1], docId: "delta", requestKey: "delta-text"
+    } as ResultRow;
+    const model = buildReviewModel({
+      rows: [...fixture.rows, orphan],
+      resultsFile: fixture.resultsFile,
+      experiment: fixture.experiment,
+      experimentSha256: fixture.experimentSha256,
+      paths: fixture.paths,
+      now: kNow,
+      modes: { shareable: false, blind: false },
+      seed: kSeed
+    });
+    const delta = model.documents.find((document) => document.docId === "delta")!;
+    // Presentation order, not manifest order: `delta` is text-only, so it reads with the other
+    // text-only document rather than after the empty one.
+    expect(model.documents.map((document) => document.docId)).toEqual(["alpha", "delta", "beta", "gamma"]);
+    expect(delta.missingFromManifest).toBe(true);
+    expect(delta.metadata).toBeNull();
+    expect(renderReviewHtml(model)).toContain("no longer in the corpus manifest");
+  });
+});

--- a/scripts/ai-harness/test/review.test.ts
+++ b/scripts/ai-harness/test/review.test.ts
@@ -11,7 +11,7 @@ import {
 } from "../src/represent-image.js";
 import { ResultRow, validateReviewKeyFile } from "../src/schemas.js";
 import {
-  ReviewFixture, buildReviewFixture, kAdversarial, kNonVisualTileId, kSentinels, tagNamesIn
+  ReviewFixture, buildReviewFixture, kAdversarial, kCorpus, kNonVisualTileId, kSentinels, tagNamesIn
 } from "./review-fixture.js";
 
 const kSeed = "a".repeat(64);
@@ -506,9 +506,17 @@ describe("--shareable", () => {
     for (const sentinel of [kSentinels.unit, kSentinels.investigation, kSentinels.problem,
       kSentinels.contextId,
       // A skip reason quotes tile ids, and a tile id contains the document id in this corpus.
-      kSentinels.skipReasonTile]) {
+      kSentinels.skipReasonTile,
+      // The corpus name is free-form and chosen at import; a production pull could be named after a
+      // class. It rendered in the heading and the browser tab of every shareable report.
+      kCorpus]) {
       expect(html).not.toContain(sentinel);
     }
+    expect(model.displayCorpus).toBeNull();
+    // The key still records it, so the report is decodable.
+    expect(reviewKeyFileFor(model).corpus).toBe(kCorpus);
+    // The heading falls back to the experiment name, which describes the experiment.
+    expect(html).toContain("<h1>Review: review-fixture</h1>");
     expect(html).not.toContain("documents/");
     expect(html).not.toContain(fixture.resultsFile);
     expect(model.gitCommit).toBeNull();
@@ -825,6 +833,36 @@ describe("output and sidecar paths", () => {
     expect(reviewSidecarPaths("/d/one.html"))
       .toEqual({ key: "/d/one.key.json", ratings: "/d/one.ratings-template.csv" });
     expect(reviewSidecarPaths("/d/two.html").key).not.toBe(reviewSidecarPaths("/d/one.html").key);
+  });
+});
+
+describe("one row decides a document's modality", () => {
+  it("groups and orders by the same answer when two rows disagree", () => {
+    // A re-run appends out of experiment order, so the first row in the file and the first row in
+    // experiment order are different rows — and a `modalityOverride` edited between two appends
+    // makes them disagree. Ordering used to read one and the document itself the other, which would
+    // group the page by one answer and order it by the other.
+    const fixture = buildReviewFixture("review-modality-disagreement");
+    const rerun = {
+      ...fixture.rows.find(
+        (row) => row.docId === "alpha" && row.runId === kSentinels.textRun && row.status === "success")!,
+      requestKey: "alpha-text-rerun",
+      modality: "mixed" as const
+    } as ResultRow;
+    const model = buildReviewModel({
+      rows: [...fixture.rows, rerun], resultsFile: fixture.resultsFile,
+      experiment: fixture.experiment, experimentSha256: fixture.experimentSha256,
+      paths: fixture.paths, now: kNow, modes: { shareable: true, blind: false }, seed: kSeed
+    });
+
+    const alpha = model.documents.find((document) => document.docId === "alpha")!;
+    const group = model.groups.find(
+      (entry) => entry.documents.some((document) => document.docId === "alpha"))!;
+    expect(group.modality).toBe(alpha.modality);
+    // Flattening the groups gives back the presentation order exactly — the property the pseudonyms,
+    // the key and the ratings template are all numbered from.
+    expect(model.groups.flatMap((entry) => entry.documents.map((document) => document.displayName)))
+      .toEqual(model.documents.map((document) => document.displayName));
   });
 });
 

--- a/scripts/ai-harness/test/review.test.ts
+++ b/scripts/ai-harness/test/review.test.ts
@@ -10,7 +10,9 @@ import {
   imageRepresentationPath, readImageEnvelope, resolveImageFile
 } from "../src/represent-image.js";
 import { ResultRow, validateReviewKeyFile } from "../src/schemas.js";
-import { ReviewFixture, buildReviewFixture, kAdversarial, kSentinels, tagNamesIn } from "./review-fixture.js";
+import {
+  ReviewFixture, buildReviewFixture, kAdversarial, kNonVisualTileId, kSentinels, tagNamesIn
+} from "./review-fixture.js";
 
 const kSeed = "a".repeat(64);
 const kOtherSeed = "b".repeat(64);
@@ -101,9 +103,19 @@ describe("what the model was given", () => {
   });
 
   it("shows one copy of a picture two runs both sent, labelled with both", () => {
-    expect(beta.images).toHaveLength(1);
-    expect(beta.images[0].sha256).toBe(fixture.imageSha256);
-    expect(beta.images[0].labels).toEqual(["puppeteer-full-height, full-document"]);
+    // The whole-document capture, the two tile captures, and nothing repeated.
+    expect(beta.images.map((image) => image.sha256))
+      .toEqual([fixture.imageSha256, ...fixture.tileSha256s]);
+    const visual = beta.images.find((image) => image.sha256 === fixture.visualTileSha256)!;
+    expect(visual.labels)
+      .toEqual(["puppeteer-per-tile, per-tile", "puppeteer-per-tile, visual-tiles-only"]);
+  });
+
+  it("shows a tile picture only under the sets that actually sent it", () => {
+    // `imageSha256s` records every image in the envelope and `imageSet` says which were sent, so
+    // reading the hashes alone showed a `visual-tiles-only` run sending tiles it never received.
+    const nonVisual = beta.images.find((image) => image.tileId === kNonVisualTileId)!;
+    expect(nonVisual.labels).toEqual(["puppeteer-per-tile, per-tile"]);
   });
 
   it("does not claim a mixed row sent a summary when its text half was dropped", () => {
@@ -152,7 +164,8 @@ describe("an input that no longer matches the run is never shown in its place", 
     bytes[bytes.length - 20] = bytes[bytes.length - 20] === 0 ? 1 : 0;
     fs.writeFileSync(resolveImageFile(envelopeFile, image), bytes);
     const beta = notices(fixture, "beta");
-    expect(beta.images).toHaveLength(0);
+    // The damaged full-document render is withheld; the per-tile one is untouched and still shown.
+    expect(beta.images.map((shown) => shown.sha256)).toEqual(fixture.tileSha256s);
     // Damaged bytes trip the envelope's own hash check first, so the reason is the render no longer
     // matching rather than the narrower "these are not the bytes that were sent".
     expect(beta.inputNotices.join(" ")).toContain("no longer matches the one this run sent");
@@ -164,7 +177,8 @@ describe("an input that no longer matches the run is never shown in its place", 
     const envelope = JSON.parse(fs.readFileSync(envelopeFile, "utf8"));
     fs.writeFileSync(envelopeFile,
       JSON.stringify({ ...envelope, sourceContentSha256: "9".repeat(64) }));
-    expect(notices(fixture, "beta").images).toHaveLength(0);
+    expect(notices(fixture, "beta").images.map((image) => image.sha256))
+      .toEqual(fixture.tileSha256s);
   });
 
   it("degrades to a notice when the files are gone, rather than crashing", () => {
@@ -177,7 +191,7 @@ describe("an input that no longer matches the run is never shown in its place", 
     const beta = model.documents.find((document) => document.docId === "beta")!;
     expect(alpha.texts).toHaveLength(0);
     expect(alpha.inputNotices.join(" ")).toContain("no longer on disk");
-    expect(beta.images).toHaveLength(0);
+    expect(beta.images.map((image) => image.sha256)).toEqual(fixture.tileSha256s);
     expect(beta.inputNotices.join(" ")).toContain("no longer on disk");
     expect(() => renderReviewHtml(model)).not.toThrow();
   });
@@ -187,8 +201,68 @@ describe("an input that no longer matches the run is never shown in its place", 
     fs.writeFileSync(imageRepresentationPath(fixture.paths, "puppeteer-full-height", "beta"),
       "{ not json");
     const beta = notices(fixture, "beta");
-    expect(beta.images).toHaveLength(0);
+    expect(beta.images.map((image) => image.sha256)).toEqual(fixture.tileSha256s);
     expect(beta.inputNotices.join(" ")).toContain("could not be read");
+  });
+});
+
+describe("only the pictures a run's image set actually sent", () => {
+  const fixture = buildReviewFixture("review-image-sets");
+  const model = modelFor(fixture);
+  const beta = model.documents.find((document) => document.docId === "beta")!;
+
+  it("sends the whole envelope's hashes but shows only the selected subset", () => {
+    // Both per-tile rows record every image the envelope holds — that is the render's provenance —
+    // and only `imageSet` says which of them went. The two runs must not look alike here.
+    const sentBy = (runId: string) => {
+      const row = fixture.rows.find((entry) => entry.runId === runId)!;
+      if (row.status === "skipped") throw new Error(`${runId} sent nothing`);
+      return row.representation;
+    };
+    expect(sentBy(kSentinels.perTileRun)).toMatchObject({ imageSha256s: fixture.tileSha256s });
+    expect(sentBy(kSentinels.visualTilesRun)).toMatchObject({ imageSha256s: fixture.tileSha256s });
+
+    const visual = beta.images.find((image) => image.sha256 === fixture.visualTileSha256)!;
+    const other = beta.images.find((image) => image.tileId === kNonVisualTileId)!;
+    expect(visual.labels).toContain("puppeteer-per-tile, visual-tiles-only");
+    expect(other.labels).not.toContain("puppeteer-per-tile, visual-tiles-only");
+  });
+
+  it("says it cannot tell when the document no longer classifies the same way", () => {
+    // `visual-tiles-only` is the one set whose membership is not structural: it is whatever the
+    // classifier marked. Reconstructing it from an edited document would be a confident wrong
+    // answer, so the report declines instead.
+    const edited = buildReviewFixture("review-image-sets-edited");
+    fs.writeFileSync(path.join(edited.paths.documents, "beta.json"),
+      JSON.stringify({ rowOrder: [], rowMap: {}, tileMap: {} }));
+    const changed = modelFor(edited).documents.find((document) => document.docId === "beta")!;
+    expect(changed.inputNotices.join(" ")).toContain("cannot be established");
+    // The per-tile run's own pictures are structural, so they are unaffected.
+    expect(changed.images.map((image) => image.sha256))
+      .toEqual([edited.imageSha256, ...edited.tileSha256s]);
+    expect(changed.images.every((image) =>
+      !image.labels.includes("puppeteer-per-tile, visual-tiles-only"))).toBe(true);
+  });
+
+  it("keeps that notice safe in a shareable or blinded report", () => {
+    const edited = buildReviewFixture("review-image-sets-redacted");
+    fs.writeFileSync(path.join(edited.paths.documents, "beta.json"),
+      JSON.stringify({ rowOrder: [], rowMap: {}, tileMap: {} }));
+    const noticesIn = (modes: Partial<ReviewModes>) => modelFor(edited, modes).documents
+      .flatMap((document) => document.inputNotices).join(" ");
+
+    // Shareable keeps run configurations — they are what a reader judges — so the mode and set may
+    // be named. What must not appear is anything identifying the document.
+    const shareable = noticesIn({ shareable: true });
+    expect(shareable).toContain("cannot be established");
+    for (const leak of ["beta", "/", ".json", ".png"]) expect(shareable).not.toContain(leak);
+
+    // Blind hides the configuration as well, so the notice says only that an input is missing.
+    const blind = noticesIn({ blind: true });
+    expect(blind).toContain("cannot be established");
+    for (const leak of ["beta", "puppeteer", "visual-tiles-only", "/"]) {
+      expect(blind).not.toContain(leak);
+    }
   });
 });
 
@@ -246,7 +320,7 @@ describe("every outcome a row can hold is rendered", () => {
   const gamma = model.documents.find((document) => document.docId === "gamma")!;
 
   it("counts each status once, over current rows only", () => {
-    expect(model.counts).toEqual({ success: 3, refusal: 1, error: 1, skipped: 4 });
+    expect(model.counts).toEqual({ success: 5, refusal: 1, error: 1, skipped: 4 });
   });
 
   it("renders success, refusal and error as cards", () => {
@@ -299,8 +373,10 @@ describe("every outcome a row can hold is rendered", () => {
   });
 
   it("lists every run's configuration in experiment-file order", () => {
-    expect(model.runs!.map((run) => run.runId))
-      .toEqual([kSentinels.textRun, kSentinels.imageRun, kSentinels.mixedRun]);
+    expect(model.runs!.map((run) => run.runId)).toEqual([
+      kSentinels.textRun, kSentinels.imageRun, kSentinels.mixedRun, kSentinels.perTileRun,
+      kSentinels.visualTilesRun
+    ]);
     expect(model.runs![1]).toMatchObject({ imageMode: "puppeteer-full-height", detail: "low" });
     // Defaults are shown as what they are rather than left blank: `extras` is only absent from the
     // experiment file, not from the request.
@@ -473,8 +549,8 @@ describe("--blind", () => {
 
   it("reduces the header's run list to a count", () => {
     expect(model.runs).toBeNull();
-    expect(model.runCount).toBe(3);
-    expect(html).toContain("3 run(s)");
+    expect(model.runCount).toBe(5);
+    expect(html).toContain("5 run(s)");
   });
 
   it("leaves no run id, variant, mode, detail, image set, extras or cost anywhere in the page", () => {
@@ -495,7 +571,7 @@ describe("--blind", () => {
     const alpha = model.documents.find((document) => document.docId === "alpha")!;
     const beta = model.documents.find((document) => document.docId === "beta")!;
     expect(alpha.texts.map((text) => text.markdown)).toEqual([fixture.alphaMarkdown]);
-    expect(beta.images).toHaveLength(1);
+    expect(beta.images).toHaveLength(3);
     // Without the labels, which would name a configuration.
     expect(alpha.texts[0].labels).toEqual([]);
     expect(beta.images[0].labels).toEqual([]);
@@ -525,10 +601,15 @@ describe("--blind", () => {
     // Two reports over identical data, differing only in the seed. The pages hold the same cards in
     // a different order, and nothing in either page says which is which.
     expect(model.labels).not.toEqual(other.labels);
-    const cardsOf = (source: string) =>
-      [...source.matchAll(/<div class="card">([\s\S]*?)<\/div>\s*<\/div>/g)]
-        .map((match) => match[1].replace(/<span class="card-title">[A-Z]+<\/span>/, "")).sort();
-    expect(cardsOf(html)).toEqual(cardsOf(renderReviewHtml(other)));
+    // Compared against the model rather than by carving cards out of the markup: a card body holds
+    // nested elements, so a regex boundary shifts with the order and would compare fragments.
+    const outcomes = (source: ReviewModel) => source.documents.map(
+      (document) => document.cards.map((card) => JSON.stringify(card.outcome)).sort());
+    const labelled = (source: ReviewModel) => source.documents.map(
+      (document) => document.cards.map((card) => `${card.label} ${JSON.stringify(card.outcome)}`));
+    // The same cards in both, paired with different labels — and neither page says which is which.
+    expect(outcomes(model)).toEqual(outcomes(other));
+    expect(labelled(model)).not.toEqual(labelled(other));
     expect(html).not.toBe(renderReviewHtml(other));
   });
 

--- a/scripts/ai-harness/test/review.test.ts
+++ b/scripts/ai-harness/test/review.test.ts
@@ -2,7 +2,8 @@ import fs from "node:fs";
 import path from "node:path";
 import {
   BuildReviewOptions, ReviewModel, ReviewModes, assertExperimentMatchesRows, blindLabelsFor,
-  assertKeyIsReusable, buildReviewModel, compareLabels, escapeHtml, labelForIndex, ratingsTemplateCsv,
+  assertKeyIsReusable, buildReviewModel, compareLabels, csvField, escapeHtml, labelForIndex,
+  ratingsTemplateCsv,
   renderReviewHtml, reviewKeyFactsOf, reviewKeyFileFor, reviewOutputPathFor, reviewSidecarPaths
 } from "../src/review.js";
 import { representationPath } from "../src/corpus.js";
@@ -605,8 +606,10 @@ describe("--blind", () => {
     expect(model.documents.flatMap((document) => document.cards)
       .every((card) => !card.configuration && !card.usage && card.modeledUsd === null)).toBe(true);
     expect(html).not.toContain("puppeteer-full-height");
+    // Not `not.toContain("$")`: a student can type a dollar sign, and a cost rendered without a
+    // currency symbol would slip past it anyway. The structural check above is the real one.
     expect(html).not.toContain("modeled");
-    expect(html).not.toContain("$");
+    expect(html).not.toMatch(/\d+ in \/ \d+ out tokens/);
   });
 
   it("still shows the document: every image and summary its runs used", () => {
@@ -666,6 +669,18 @@ describe("--blind", () => {
     expect(csv[1]).toBe('"alpha","A","",""');
   });
 
+  it("defuses a ratings template against spreadsheet formula evaluation", () => {
+    // Excel and LibreOffice evaluate a field beginning `=`, `+`, `-` or `@` even inside quotes, and
+    // this file is opened in a spreadsheet by a judge. Nothing writes such a value today; the
+    // `document` column carries whatever a corpus calls its documents.
+    expect(csvField("=1+1")).toBe(`"'=1+1"`);
+    expect(csvField("@SUM(A1)")).toBe(`"'@SUM(A1)"`);
+    expect(csvField("-2")).toBe(`"'-2"`);
+    // Ordinary values are untouched, and quoting still escapes quotes.
+    expect(csvField("doc-01")).toBe('"doc-01"');
+    expect(csvField('a "b"')).toBe('"a ""b"""');
+  });
+
   it("uses the pseudonym in the template when the report is also shareable", () => {
     const both = modelFor(fixture, { blind: true, shareable: true });
     expect(ratingsTemplateCsv(both).split("\n")[1]).toBe('"doc-01","A","",""');
@@ -678,8 +693,13 @@ describe("--blind", () => {
 });
 
 describe("a response field the typed renderer cannot show is kept, not dropped", () => {
+  let parsedFixtures = 0;
   const withParsed = (parsed: unknown) => {
-    const fixture = buildReviewFixture(`review-parsed-${Math.abs(JSON.stringify(parsed).length)}`);
+    // A counter, not a hash of the input: naming the directory after the serialized length gave two
+    // different values of equal length the same scratch directory, which `makeTestDataRoot` clears
+    // on entry — the exact hazard `buildReviewFixture`'s own comment warns about.
+    parsedFixtures += 1;
+    const fixture = buildReviewFixture(`review-parsed-${parsedFixtures}`);
     const rows = fixture.rows.map((row) => (
       row.docId === "beta" && row.runId === kSentinels.imageRun && row.status === "success"
         ? { ...row, response: { parsed, raw: {} } }


### PR DESCRIPTION
Adds `harness.ts review` — the side-by-side HTML report a human judge reads. One section per document, showing the input each run was given (the picture(s) and the summary) beside what every run said about it.

`report` answers aggregate questions: tokens, cost, category counts per group. It cannot answer the question put to a human judge: for this document, which output is better? That takes seeing the document the way the model saw it, next to each run's actual feedback.

```bash
npx tsx harness.ts review --results data/results/<corpus>__<experiment>.jsonl \
                          --experiment experiments/<experiment>.json \
                          [--out <file>.html] [--shareable] [--blind] [--reuse-key]
```

No network, no API key. It reads the results file, the experiment file and the corpus tree.

| Mode | Writes | For |
|---|---|---|
| (none) | `.review.html` | The team-internal report. |
| `--shareable` | `.review-shareable.html` + `.key.json` | Reports that leave the team. |
| `--blind` | `.review-blind.html` + `.key.json` + `.ratings-template.csv` | Milestone 5's judging round. |
| `--blind --shareable` | `.review-blind-shareable.html` + one **combined** key + template | Both at once. |

`--experiment` is required and hash-checked. Result rows don't carry `detail`, `imageSet` or `extras`, a skipped row carries no representation descriptor at all, and run order lives only in the experiment file — so the report needs that file, and refuses unless its hash equals every row's `experimentSha256`. A name match proves nothing; the file can be edited after a run.

## Three things worth reviewing closely

**Everything student-authored is escaped, everywhere.** Document text reaches the page through summaries, through model outputs quoting it, through refusals and through error messages. Markup is built with a tagged template that escapes every interpolated value unless it is already an escaped fragment, so forgetting to escape is not something the renderer can do by omission — it would take deliberately building a fragment from raw text, which happens once, for the stylesheet constant. Summaries render as preformatted text, never as interpreted markdown. The file is self-contained and inert: inline CSS, **no JavaScript**, images as `data:` URLs, plus a CSP meta tag as defence in depth.

**An input is shown only if it is still the input that was sent.** A representation is displayed when its *whole* descriptor matches — variant, variant version and content hash for a summary; mode, backend, version, content and every recorded image hash (with the bytes on disk re-hashed) for a render. Anything else renders a notice, and the current file is **not** shown in its place. Pairing today's screenshot with last week's output invites a judgement about the wrong thing.

**The blind mapping exists only in the key file.** Card order comes from `HMAC(seed, docId + runId)` with 32 random bytes generated at report time and stored only there. A seedless hash of the row data would be reconstructible by anyone who reads the code; `Math.random()` would not regenerate.

## Sidecar rules

Both sidecars are named from the **resolved** output path, `--out` included, so no two reports can collide on a key.

- Every collision is checked **before anything is written** — a refused run leaves nothing behind.
- An existing key is never overwritten. Without `--reuse-key`, its existence is an error: rotating a key orphans every rating already written against the old labels.
- `--reuse-key` reads and validates the key and never rewrites it. Reuse is refused if the corpus, experiment hash, mode flags, document set or judgeable run set differs, if the pseudonyms are not the ones the report renders, or if the labels are not exactly one per outcome.
- An existing ratings template is preserved byte-for-byte under `--reuse-key`; it may hold a judge's half-entered answers.

`--shareable` removes harness metadata identifiers — document ids become `doc-01`… numbered in presentation order, and unit, investigation, problem, `contextId`, source, file paths and tile ids are omitted.

## Also here: four fixtures that rendered as blank tiles

Reading the first real report surfaced a problem that had been distorting image-mode results since milestone 2. CLUE cannot draw a text tile authored as markdown — `asSlate()` returns `[]` for that format, behind a `// TODO` — so the summarizer saw full content while the screenshot showed an empty rectangle. Four fixtures used it, and `text` and `adversarial-text` rendered byte-identically.

`text`, `mixed` and `question` are now `format: "html"`, matching `tall` and the format real CLUE content overwhelmingly uses. `adversarial-text` carries no `format` at all and renders as plain text: authoring it as HTML would let CLUE interpret the `<b>bold</b>` and `<img onerror=…>` the fixture exists to carry through as characters.

**This moved the recorded results, and one conclusion reversed.** The recorded run previously said image-only "lost 4 of 7 to `unknown` — the picture alone was worse". With pictures that actually show the text, image-only reproduces text-only's category on **all 7** shared documents and mixed on 6 of 7. The old result was measuring four blank rectangles. Category totals move from 90/41/14/1 to 81 `unknown`, 47 `function`, 17 `user`, 1 `form`. The README's recorded-run section is re-recorded throughout; the re-run cost $0.0538 across 33 API calls, with the other 113 rows served from cache.

Worth knowing: nothing in the aggregate table would ever have shown this. Looking at the report did.

## Verifying it yourself

```bash
cd scripts/ai-harness
npx tsx harness.ts review --results data/results/mixed-run__mixed-vs-baselines.jsonl \
                          --experiment experiments/mixed-vs-baselines.json
open data/results/mixed-run__mixed-vs-baselines.review.html
```

Add `--shareable`, `--blind`, or both, for the other three. Look at `adversarial-text` first: its `</script>`, `<img onerror=…>` and markdown link should all be visible as characters, in the pictures as well as the summary.

## Checks

- `npm run typecheck`, `npm run lint`, `npm test` pass in `scripts/ai-harness` (904 tests, 79 new).
- Root `npm test` passes (340 suites, 3771 tests).
- No changes under `shared/`, none to `execute.ts`, and no change to the result-row schema.
- All four combinations generated from the recorded `mixed-vs-baselines` run and read in a browser: 26 documents, 146 judgeable outcomes, 114 skips, 56 embedded pictures, ~1.4 MB each.
- Everything generated lives in `data/` (gitignored); `--out` is refused if it points elsewhere.

## DEVIATIONS from the plan (README entries 31–34)

1. `review` is its own command over a results file plus its experiment file, rather than the plan's `report --runs <ids> [--shareable]`, which predates the results-file conventions.
2. A blinded report withholds skip reasons: a reason names the shape and settings of the run that declined, which is a configuration standing beside labelled cards.
3. `--shareable` also drops tile ids and representation warnings — a tile id contains the document id outright in this corpus (`wave-runner-tile`).
4. `--out` must name a `.html` file, since both sidecars are named from it.
