### PR TITLE
fix: escape document JSON in the AI-analysis render page (CLUE-371)

### DIFF
--- a/functions-v2/src/on-analysis-document-pending.ts
+++ b/functions-v2/src/on-analysis-document-pending.ts
@@ -5,6 +5,7 @@ import * as admin from "firebase-admin";
 import * as logger from "firebase-functions/logger";
 import {type AnalysisQueueDocument} from "./on-analyzable-doc-written";
 import {documentSummarizer} from "../../shared/ai-summarizer/ai-summarizer";
+import {escapeHtmlAttribute, escapeJsonForScript} from "../../shared/escape-for-html";
 
 // This is one of three functions for AI analysis of documents:
 // 1. Watch for changes to the lastUpdatedAt metadata field and write into the queue of docs to process
@@ -15,22 +16,24 @@ const clueURL = "https://collaborative-learning.concord.org/branch/shutterbug-su
 const clueUnit = "mods";
 const shutterbugURL = "https://api.concord.org/shutterbug-production";
 
-function generateHtml(clueDocument: unknown) {
+export function generateHtml(clueDocument: unknown) {
+  const source = escapeHtmlAttribute(`${clueURL}/iframe.html?unit=${clueUnit}&unwrapped&readOnly`);
   return `
-    <script>const initialValue=${JSON.stringify(clueDocument)}</script>
+    <script>const initialValue=${escapeJsonForScript(JSON.stringify(clueDocument))}</script>
     <!-- height will be updated when iframe sends updateHeight message -->
     <iframe id='clue-frame' width='100%' height='500px' style='border:0px'
       allow='serial'
-      src='${clueURL}/iframe.html?unit=${clueUnit}&unwrapped&readOnly'
+      src="${source}"
     ></iframe>
     <script>
       const clueFrame = document.getElementById('clue-frame')
       function sendInitialValueToEditor() {
         if (!clueFrame.contentWindow) {
-          console.warning("iframe doesn't have contentWindow");
+          console.warn("iframe doesn't have contentWindow");
+          return;
         }
         window.addEventListener("message", (event) => {
-          if (event.data.type === "updateHeight") {
+          if (event.data?.type === "updateHeight") {
             document.getElementById("clue-frame").height = event.data.height + "px";
           }
         })

--- a/functions-v2/test/on-analysis-document-pending.test.ts
+++ b/functions-v2/test/on-analysis-document-pending.test.ts
@@ -6,7 +6,7 @@ import * as logger from "firebase-functions/logger";
 import {getDatabase} from "firebase-admin/database";
 import * as admin from "firebase-admin";
 import {initialize, projectConfig} from "./initialize";
-import {onAnalysisDocumentPending} from "../src/on-analysis-document-pending";
+import {generateHtml, onAnalysisDocumentPending} from "../src/on-analysis-document-pending";
 
 jest.mock("firebase-functions/logger");
 
@@ -35,6 +35,40 @@ const sampleDoc = `{
   "sharedModelMap": {},
   "annotations": {}
 }`;
+
+// The text a student could type that would end the script element early if it were not escaped.
+const scriptBreakout = "</script><img src=x onerror=alert(1)>";
+
+// The sample document with the breakout text typed into its Text tile.
+function docWithScriptBreakout() {
+  const doc = JSON.parse(sampleDoc);
+  doc.tileMap["3EkhEN1cWCZ6SQ9X"].content.text = JSON.stringify({
+    object: "value",
+    document: {children: [{type: "paragraph", children: [{text: scriptBreakout}]}]},
+  });
+  return doc;
+}
+
+describe("generateHtml", () => {
+  test("escapes document content so it cannot break out of the script element", () => {
+    const doc = docWithScriptBreakout();
+    const html = generateHtml(doc);
+
+    // The page's own two script elements, and no others.
+    expect(html.match(/<script/g)).toHaveLength(2);
+    expect(html.match(/<\/script>/g)).toHaveLength(2);
+    expect(html).not.toContain("<img");
+
+    // The escaped JSON still parses back to the document that was passed in.
+    const initialValue = html.match(/const initialValue=(.*)<\/script>/)?.[1];
+    expect(JSON.parse(initialValue as string)).toEqual(doc);
+  });
+
+  test("escapes the ampersands in the iframe source", () => {
+    const html = generateHtml(JSON.parse(sampleDoc));
+    expect(html).toMatch(/src="[^"]+\/iframe\.html\?unit=[^"&]+&amp;unwrapped&amp;readOnly"/);
+  });
+});
 
 describe("functions", () => {
   beforeEach(async () => {

--- a/shared/escape-for-html.test.ts
+++ b/shared/escape-for-html.test.ts
@@ -1,0 +1,37 @@
+import { escapeHtmlAttribute, escapeJsonForScript } from "./escape-for-html";
+
+describe("escapeJsonForScript", () => {
+  it("removes the characters that could close the script element", () => {
+    const original = { text: "</script><img src=x onerror=alert(1)>" };
+    const escaped = escapeJsonForScript(JSON.stringify(original));
+    expect(escaped).not.toContain("<");
+    expect(escaped).not.toContain(">");
+    expect(JSON.parse(escaped)).toEqual(original);
+  });
+
+  it("escapes the JavaScript line terminators that are legal in JSON", () => {
+    const original = { text: "line\u2028separator\u2029paragraph" };
+    const escaped = escapeJsonForScript(JSON.stringify(original));
+    expect(escaped).not.toContain("\u2028");
+    expect(escaped).not.toContain("\u2029");
+    expect(JSON.parse(escaped)).toEqual(original);
+  });
+
+  it("escapes ampersands", () => {
+    const original = { text: "salt & pepper &amp; more" };
+    const escaped = escapeJsonForScript(JSON.stringify(original));
+    expect(escaped).not.toContain("&");
+    expect(JSON.parse(escaped)).toEqual(original);
+  });
+});
+
+describe("escapeHtmlAttribute", () => {
+  it("replaces the five special characters with entities", () => {
+    expect(escapeHtmlAttribute(`&<>"'`)).toBe("&amp;&lt;&gt;&quot;&#39;");
+  });
+
+  it("escapes the ampersands in a query string", () => {
+    expect(escapeHtmlAttribute("https://example.com/iframe.html?unit=mods&unwrapped&readOnly"))
+      .toBe("https://example.com/iframe.html?unit=mods&amp;unwrapped&amp;readOnly");
+  });
+});

--- a/shared/escape-for-html.ts
+++ b/shared/escape-for-html.ts
@@ -1,0 +1,33 @@
+/**
+ * Makes a JSON string safe to place inside a <script> element.
+ *
+ * HTML ends a script element at the first `</script>` it sees, even one inside a JavaScript
+ * string, so a document containing that text would otherwise break out of the script and inject
+ * markup into the page. Escaping `<` and `>` makes that impossible, and also prevents `<!--`
+ * from starting a comment. `&` is escaped so the result is still read correctly if the page is
+ * ever parsed as XHTML. U+2028 and U+2029 are legal inside a JSON string but are line
+ * terminators in JavaScript source, where an unescaped one is a syntax error.
+ *
+ * All five escapes are JSON string escapes, so `JSON.parse` reads the result back to the
+ * identical value.
+ */
+export function escapeJsonForScript(json: string): string {
+  return json
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e")
+    .replace(/&/g, "\\u0026")
+    // Written as regex escapes rather than literal characters: an invisible line separator
+    // in source would be impossible to review and easy to delete by accident.
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+}
+
+/** Escapes a value for use inside a double-quoted HTML attribute. */
+export function escapeHtmlAttribute(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}


### PR DESCRIPTION
[CLUE-371](https://concord-consortium.atlassian.net/browse/CLUE-371)

The page that Shutterbug renders for AI document analysis writes the student document into a `<script>` element with plain `JSON.stringify`. HTML ends a script element at the first `</script>` it sees, even inside a JavaScript string, so a document containing that text broke out of the script and injected markup into the page.

New `shared/escape-for-html.ts` escapes `<`, `>`, `&`, `U+2028` and `U+2029` as JSON string escapes, which parse back to the identical value, so only a document that would have triggered the bug renders differently. It also escapes values for double-quoted HTML attributes. The iframe `src` now uses it instead of writing a raw `&` into a single-quoted attribute.

Also in the render page: `console.warning` is not a function, so a missing `contentWindow` threw instead of warning. It is now `console.warn` followed by a return. The message listener checks that `event.data` exists before reading its type. `generateHtml` is exported so the new test can call it directly.

This came out of the [CLUE-371 AI harness work](https://github.com/concord-consortium/collaborative-learning/pull/2958). It should go into `master` on its own, ahead of that work, because the bug fix stands on its own and is required for the (mostly) separate work of making CLUE send text+image representations to AI by default. The new file lives in `shared/` rather than `functions-v2/` because the `CLUE-371` evaluation harness has its own copy of the same escaping code, and will switch to importing this one after `master` is next merged into the `CLUE-371` branch. The two `functions-v2` files this changes are identical on `master` and on the `CLUE-371` branch today, so it will not conflict when that branch merges.

NOTE: `standalone_tests/standalone_teacher_load_spec.js` is failing but it fails in the same way on `master` and pre-exists these changes.

[CLUE-371]: https://concord-consortium.atlassian.net/browse/CLUE-371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ