### PR TITLE
fix: page height from unwrapped document renderers (CLUE-371)

### DIFF
--- a/functions-v2/src/on-analysis-document-pending.ts
+++ b/functions-v2/src/on-analysis-document-pending.ts
@@ -34,7 +34,12 @@ export function generateHtml(clueDocument: unknown) {
         }
         window.addEventListener("message", (event) => {
           if (event.data?.type === "updateHeight") {
-            document.getElementById("clue-frame").height = event.data.height + "px";
+            // A height of 0, or anything that is not a positive number, would collapse the
+            // iframe and hide the document the screenshot is meant to show. Ignoring it
+            // leaves the iframe at its starting height.
+            const height = Number(event.data.height);
+            if (!Number.isFinite(height) || height <= 0) return;
+            document.getElementById("clue-frame").height = height + "px";
           }
         })
         clueFrame.contentWindow.postMessage(

--- a/functions-v2/src/on-analysis-document-pending.ts
+++ b/functions-v2/src/on-analysis-document-pending.ts
@@ -37,7 +37,7 @@ export function generateHtml(clueDocument: unknown) {
             // A height of 0, or anything that is not a positive number, would collapse the
             // iframe and hide the document the screenshot is meant to show. Ignoring it
             // leaves the iframe at its starting height.
-            const height = Number(event.data.height);
+            const height = event.data.height;
             if (!Number.isFinite(height) || height <= 0) return;
             document.getElementById("clue-frame").height = height + "px";
           }

--- a/functions-v2/src/on-analysis-document-pending.ts
+++ b/functions-v2/src/on-analysis-document-pending.ts
@@ -16,6 +16,8 @@ const clueURL = "https://collaborative-learning.concord.org/branch/shutterbug-su
 const clueUnit = "mods";
 const shutterbugURL = "https://api.concord.org/shutterbug-production";
 
+// scripts/shutterbug.ts has a near-copy of this page for rendering a document by hand during
+// development. Keep fixes to one in step with the other until they are unified.
 export function generateHtml(clueDocument: unknown) {
   const source = escapeHtmlAttribute(`${clueURL}/iframe.html?unit=${clueUnit}&unwrapped&readOnly`);
   return `

--- a/scripts/shutterbug.ts
+++ b/scripts/shutterbug.ts
@@ -8,6 +8,8 @@
 
 import fs from "fs";
 
+import { escapeHtmlAttribute, escapeJsonForScript } from "../shared/escape-for-html";
+
 const clueCodebase = "https://collaborative-learning.concord.org/branch/shutterbug-support";
 // const clueCodebase = "http://localhost:8080";
 // const clueCodebase = "https://reimagined-journey-v6q9774jwh6pr4-4000.app.github.dev/";
@@ -16,24 +18,34 @@ const clueCodebase = "https://collaborative-learning.concord.org/branch/shutterb
 // const shutterbugServer = "http://localhost:4000";
 const shutterbugServer = "https://api.concord.org/shutterbug-staging";
 
+// This page is a near-copy of generateHtml in functions-v2/src/on-analysis-document-pending.ts,
+// which is the one the AI analysis pipeline actually uses. They are separate because this script
+// targets a different CLUE build and Shutterbug server and asks for a full-page capture. Keep
+// fixes to one in step with the other until they are unified.
 function generateHtml(clueDocument: any) {
+  const source = escapeHtmlAttribute(`${clueCodebase}/iframe.html?unwrapped&readOnly`);
   return `
-    <script>const initialValue=${JSON.stringify(clueDocument)}</script>
+    <script>const initialValue=${escapeJsonForScript(JSON.stringify(clueDocument))}</script>
     <!-- height will be updated when iframe sends updateHeight message -->
     <iframe id='clue-frame' width='100%' height='500px' style='border:0px'
       allow='serial'
-      src='${clueCodebase}/iframe.html?unwrapped&readOnly'
+      src="${source}"
     ></iframe>
     <script>
       const clueFrame = document.getElementById('clue-frame')
       function sendInitialValueToEditor() {
         if (!clueFrame.contentWindow) {
-          console.warning("iframe doesn't have contentWindow");
+          console.warn("iframe doesn't have contentWindow");
+          return;
         }
 
         window.addEventListener("message", (event) => {
-          if (event.data.type === "updateHeight") {
-            document.getElementById("clue-frame").height = event.data.height + "px";
+          if (event.data?.type === "updateHeight") {
+            // A height of 0, or anything that is not a positive number, would collapse the
+            // iframe and hide the document the screenshot is meant to show.
+            const height = event.data.height;
+            if (!Number.isFinite(height) || height <= 0) return;
+            document.getElementById("clue-frame").height = height + "px";
           }
         })
 

--- a/src/components/doc-editor/doc-editor-app.scss
+++ b/src/components/doc-editor/doc-editor-app.scss
@@ -1,3 +1,5 @@
+@import "../document/unwrapped-document";
+
 #doc-editor-app {
   display: flex;
   height: 100vh;

--- a/src/components/doc-editor/doc-editor-app.tsx
+++ b/src/components/doc-editor/doc-editor-app.tsx
@@ -235,9 +235,10 @@ export const DocEditorApp = observer(function DocEditorApp() {
   }, [loadDocument]);
 
   if (unwrapped) {
-    // Let the window do the scrolling. If the body scrolls and shows the full content
-    // then puppeteer's screenshot function can capture the full content easily.
-    window.document.body.style.overflow = "visible";
+    // Let the content determine the page's height rather than filling the viewport, so the
+    // whole document is on the scrolling page and puppeteer's full-page screenshot captures
+    // all of it. See the .unwrapped rules in components/document/unwrapped-document.scss.
+    window.document.body.classList.add("unwrapped");
     return (
       <CanvasComponent
         document={document}

--- a/src/components/document/unwrapped-document.scss
+++ b/src/components/document/unwrapped-document.scss
@@ -1,0 +1,27 @@
+// Layout for the "unwrapped" URL parameter, which renders a document on its own with no CLUE
+// interface around it. Both callers need the page's height to come from the document's content:
+// the iframe reports that height to the page embedding it, and the standalone document editor is
+// screenshotted by a headless browser, which captures the scrolling page rather than a scrolling
+// element inside it.
+//
+// By default nothing in the page can supply that height. `body` is set to overflow hidden by
+// clue.scss, `#app` is positioned fixed and pinned to the viewport's four edges by app.scss, and
+// .document-content scrolls inside that fixed box. Every one of those is sized by the viewport,
+// so the body ends up with no in-flow content and a scrollHeight of 0.
+body.unwrapped {
+  overflow: visible;
+
+  #app {
+    position: static;
+    height: auto;
+  }
+
+  .canvas,
+  .document-content {
+    height: auto;
+  }
+
+  .document-content {
+    overflow: visible;
+  }
+}

--- a/src/components/document/unwrapped-document.scss
+++ b/src/components/document/unwrapped-document.scss
@@ -16,12 +16,12 @@ body.unwrapped {
     height: auto;
   }
 
-  .canvas,
-  .document-content {
+  .canvas {
     height: auto;
   }
 
   .document-content {
+    height: auto;
     overflow: visible;
   }
 }

--- a/src/iframe/iframe-document-editor.scss
+++ b/src/iframe/iframe-document-editor.scss
@@ -1,25 +1,4 @@
-// In unwrapped mode the embedding page sizes the iframe from the height this window reports,
-// so the height has to come from the document's content. By default the content cannot supply
-// it: `body` is set to overflow hidden by clue.scss, `#app` is positioned fixed and pinned to
-// the viewport by app.scss, and .document-content scrolls inside that fixed box. Every one of
-// those is sized by the viewport, which leaves the body with a scrollHeight of 0.
-body.unwrapped {
-  overflow: visible;
-
-  #app {
-    position: static;
-    height: auto;
-  }
-
-  .canvas,
-  .document-content {
-    height: auto;
-  }
-
-  .document-content {
-    overflow: visible;
-  }
-}
+@import "../components/document/unwrapped-document";
 
 .loading-box {
   align-items: center;

--- a/src/iframe/iframe-document-editor.scss
+++ b/src/iframe/iframe-document-editor.scss
@@ -1,3 +1,26 @@
+// In unwrapped mode the embedding page sizes the iframe from the height this window reports,
+// so the height has to come from the document's content. By default the content cannot supply
+// it: `body` is set to overflow hidden by clue.scss, `#app` is positioned fixed and pinned to
+// the viewport by app.scss, and .document-content scrolls inside that fixed box. Every one of
+// those is sized by the viewport, which leaves the body with a scrollHeight of 0.
+body.unwrapped {
+  overflow: visible;
+
+  #app {
+    position: static;
+    height: auto;
+  }
+
+  .canvas,
+  .document-content {
+    height: auto;
+  }
+
+  .document-content {
+    overflow: visible;
+  }
+}
+
 .loading-box {
   align-items: center;
   display: flex;

--- a/src/iframe/iframe-document-editor.tsx
+++ b/src/iframe/iframe-document-editor.tsx
@@ -19,6 +19,7 @@ import "./iframe-document-editor.scss";
 interface IProps {
   initialValue?: DocumentModelType;
   handleUpdateContent: (json: Record<string, any>) => void;
+  onDocumentRendered?: () => void; // called once, after the document's first render
   fullHeight?: boolean;
   noBorder?: boolean; // if true don't show border around the editor
 }
@@ -99,16 +100,24 @@ export class IframeDocumentEditor extends React.Component<IProps, IState>  {
     });
   }
 
+  componentDidUpdate(prevProps: IProps, prevState: IState) {
+    // The document is created asynchronously, once the unit has loaded, so the first render
+    // shows the loading box. This is the render that first shows the document itself.
+    if (!prevState.document && this.state.document) {
+      this.props.onDocumentRendered?.();
+    }
+  }
+
   componentWillUnmount() {
     this.disposer?.();
   }
 
   renderDocumentComponent(document: DocumentModelType) {
     if (unwrapped) {
-      // Let the window do the scrolling. This makes it possible for a resize observer
-      // to monitor the body and send height changes to the parent window. That way the
-      // parent window can resize the iframe to just fit its content.
-      window.document.body.style.overflow = "visible";
+      // Let the content determine the page's height rather than filling the viewport, so a
+      // resize observer can send that height to the parent window and the parent can size the
+      // iframe to just fit the document. See the .unwrapped rules in iframe-document-editor.scss.
+      window.document.body.classList.add("unwrapped");
       return (
         <CanvasComponent
           document={document}

--- a/src/iframe/iframe-document-editor.tsx
+++ b/src/iframe/iframe-document-editor.tsx
@@ -116,7 +116,8 @@ export class IframeDocumentEditor extends React.Component<IProps, IState>  {
     if (unwrapped) {
       // Let the content determine the page's height rather than filling the viewport, so a
       // resize observer can send that height to the parent window and the parent can size the
-      // iframe to just fit the document. See the .unwrapped rules in iframe-document-editor.scss.
+      // iframe to just fit the document. See the .unwrapped rules in
+      // components/document/unwrapped-document.scss.
       window.document.body.classList.add("unwrapped");
       return (
         <CanvasComponent

--- a/src/iframe/iframe-messages.test.ts
+++ b/src/iframe/iframe-messages.test.ts
@@ -1,0 +1,56 @@
+import { postContentHeight, postDocumentRendered } from "./iframe-messages";
+
+// jsdom does no layout, so every element reports a scrollHeight of 0. These tests set the
+// property directly to stand in for a laid-out page.
+function setScrollHeight(element: HTMLElement, height: number) {
+  Object.defineProperty(element, "scrollHeight", { configurable: true, value: height });
+}
+
+describe("postContentHeight", () => {
+  let target: { postMessage: jest.Mock };
+
+  beforeEach(() => {
+    target = { postMessage: jest.fn() };
+    document.body.innerHTML = `<div id="app"></div>`;
+  });
+
+  it("posts the height of the rendered content", () => {
+    setScrollHeight(document.getElementById("app")!, 314);
+
+    postContentHeight(target as unknown as Window, document);
+
+    expect(target.postMessage).toHaveBeenCalledTimes(1);
+    expect(target.postMessage).toHaveBeenCalledWith({ type: "updateHeight", height: 314 }, "*");
+  });
+
+  it("measures the content rather than the body", () => {
+    // The bug this guards against: the body has no in-flow content, so its scrollHeight is 0.
+    setScrollHeight(document.body, 0);
+    setScrollHeight(document.getElementById("app")!, 250);
+
+    postContentHeight(target as unknown as Window, document);
+
+    expect(target.postMessage).toHaveBeenCalledWith({ type: "updateHeight", height: 250 }, "*");
+  });
+
+  it("posts nothing when there is no content element", () => {
+    document.body.innerHTML = "";
+
+    postContentHeight(target as unknown as Window, document);
+
+    expect(target.postMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe("postDocumentRendered", () => {
+  it("posts the message only once", () => {
+    const target = { postMessage: jest.fn() };
+
+    postDocumentRendered(target as unknown as Window);
+    postDocumentRendered(target as unknown as Window);
+    postDocumentRendered(target as unknown as Window);
+
+    expect(target.postMessage).toHaveBeenCalledTimes(1);
+    expect(target.postMessage).toHaveBeenCalledWith({ type: "documentRendered" }, "*");
+  });
+});

--- a/src/iframe/iframe-messages.ts
+++ b/src/iframe/iframe-messages.ts
@@ -8,8 +8,9 @@
 // and its scrollHeight is 0. `#app` itself is no better on its own: pinned to the viewport, its
 // height is the viewport's height, not the content's.
 //
-// The rule in iframe-document-editor.scss puts `#app` back in the normal flow in unwrapped mode
-// and lets the document content size it. Measuring `#app` then gives the content's height.
+// The rules in components/document/unwrapped-document.scss put `#app` back in the normal flow in
+// unwrapped mode and let the document content size it. Measuring `#app` then gives the content's
+// height.
 
 const contentElementId = "app";
 

--- a/src/iframe/iframe-messages.ts
+++ b/src/iframe/iframe-messages.ts
@@ -1,0 +1,33 @@
+// Messages this iframe posts to the page that embeds it.
+//
+// The embedding page sizes the iframe from the height in the "updateHeight" message, so that
+// height has to be the height of the rendered document. `document.body.scrollHeight` cannot
+// supply it. The body's only two children are a hidden `<svg>` of icons, which is positioned
+// absolutely, and `#app`, which `src/components/app.scss` positions fixed and pins to all four
+// edges of the viewport. Both are out of the normal flow, so the body has no in-flow content
+// and its scrollHeight is 0. `#app` itself is no better on its own: pinned to the viewport, its
+// height is the viewport's height, not the content's.
+//
+// The rule in iframe-document-editor.scss puts `#app` back in the normal flow in unwrapped mode
+// and lets the document content size it. Measuring `#app` then gives the content's height.
+
+const contentElementId = "app";
+
+/** Posts the height of the rendered document so the embedding page can size the iframe to fit. */
+export function postContentHeight(target: Window, doc: Document): void {
+  const content = doc.getElementById(contentElementId);
+  if (!content) return;
+  target.postMessage({ type: "updateHeight", height: content.scrollHeight }, "*");
+}
+
+let documentRenderedPosted = false;
+
+/**
+ * Posts a single "documentRendered" message once the document has been rendered for the first
+ * time. A consumer that waits for this does not have to infer readiness from the height.
+ */
+export function postDocumentRendered(target: Window): void {
+  if (documentRenderedPosted) return;
+  documentRenderedPosted = true;
+  target.postMessage({ type: "documentRendered" }, "*");
+}

--- a/src/iframe/iframe.tsx
+++ b/src/iframe/iframe.tsx
@@ -41,13 +41,8 @@ const handleDocumentRendered = () => {
   // has rendered there is nothing to measure but the loading box, and in unwrapped mode the
   // stylesheet rules that make the content determine the height are not in effect yet, so an
   // earlier measurement would report the viewport's height instead of the document's.
-  const content = document.getElementById("app");
-  if (!content) {
-    // Nothing to measure, but a consumer waiting on the message should not wait forever.
-    postDocumentRendered(window.parent);
-    return;
-  }
-  resizeObserver.observe(content);
+  // #app is guaranteed here: renderEditor would have thrown at createRoot without it.
+  resizeObserver.observe(document.getElementById("app")!);
 };
 
 let root: Root | undefined;

--- a/src/iframe/iframe.tsx
+++ b/src/iframe/iframe.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { createRoot, Root } from "react-dom/client";
 
 import { IframeDocumentEditor } from "./iframe-document-editor";
+import { postContentHeight, postDocumentRendered } from "./iframe-messages";
 import { DocumentModelType } from "../models/document/document";
 
 let initialValue = undefined as DocumentModelType | undefined;
@@ -10,15 +11,18 @@ const urlParams = new URLSearchParams(window.location.search);
 const noBorder = urlParams.get("noBorder") === "true";
 const fullHeight = urlParams.get("fullHeight") === "true";
 
-const resizeObserver = new ResizeObserver((elements) => {
-  window.parent.postMessage({ type: "updateHeight", height: document.body.scrollHeight}, "*");
+const resizeObserver = new ResizeObserver(() => {
+  postContentHeight(window.parent, document);
+  // The observer's first callback runs at the browser's next rendering step, once the document
+  // has been laid out, so this is the first moment a measurement is worth having. Announcing the
+  // render here rather than earlier means a consumer that waits for documentRendered has always
+  // received a real height by the time it arrives.
+  postDocumentRendered(window.parent);
 });
 
 (window as any).addEventListener("message", (event: MessageEvent) => {
   if (event.data.initialValue) {
     initialValue = JSON.parse(event.data.initialValue);
-    // add a resize observer to send the height the iframe needs
-    resizeObserver.observe(document.body);
     if (initialValue) {
       renderEditor();
     }
@@ -32,6 +36,20 @@ const handleUpdateContent = (json: Record<string, any>) => {
   window.parent.postMessage({ type: "updateContent", content: stringifiedJson }, "*");
 };
 
+const handleDocumentRendered = () => {
+  // Start reporting the height now rather than when the document arrives. Until the document
+  // has rendered there is nothing to measure but the loading box, and in unwrapped mode the
+  // stylesheet rules that make the content determine the height are not in effect yet, so an
+  // earlier measurement would report the viewport's height instead of the document's.
+  const content = document.getElementById("app");
+  if (!content) {
+    // Nothing to measure, but a consumer waiting on the message should not wait forever.
+    postDocumentRendered(window.parent);
+    return;
+  }
+  resizeObserver.observe(content);
+};
+
 let root: Root | undefined;
 
 const renderEditor = () => {
@@ -43,6 +61,7 @@ const renderEditor = () => {
     <IframeDocumentEditor
       initialValue={initialValue}
       handleUpdateContent={handleUpdateContent}
+      onDocumentRendered={handleDocumentRendered}
       fullHeight={fullHeight}
       noBorder={noBorder}
     />


### PR DESCRIPTION
[CLUE-371](https://concord-consortium.atlassian.net/browse/CLUE-371)

Two entry points render a CLUE document on its own, with no interface around it: the iframe at `iframe.html?unwrapped`, which the AI-analysis screenshot path embeds, and the standalone document editor at `/editor/?unwrapped`, which a headless browser screenshots directly. Both need the height of the page to come from the document's content. In both, that height was 0.

## The cause

The cause is the same in both, and it is not what the existing code assumed.

The body has two children: a hidden `<svg>` of icons, which is positioned absolutely, and `#app`, which `app.scss` positions fixed and pins to all four edges of the viewport. Both are out of the normal flow, so the body has no in-flow content and no height.

`#app` cannot stand in for the body either. Pinned to the viewport, its height *is* the viewport's: it measured 800px at an 800px viewport and 1500px at a 1500px viewport, for the same one-tile document. Below it, `.canvas` and `.document-content` are `height: 100%`, and `.document-content` scrolls inside that fixed box. Nothing in the chain is sized by the content.

Each renderer had a `body.style.overflow = "visible"` line meant to fix this. It could never have worked properly, because the obstacle was never the body's overflow. That line was undoing `body { overflow: hidden }` from `clue.scss`, which is a real but separate problem.

## The fix

A shared stylesheet, `src/components/document/unwrapped-document.scss`, returns `#app` to the normal flow and lets the document size it. Both renderers now add an `unwrapped` class to the body, which is what the rules are scoped to, in place of the inline overflow style.

The iframe measures `#app` rather than the body, through a new `src/iframe/iframe-messages.ts`. Results, all independent of viewport height:

| document | real content | height reported before | after |
|---|---|---|---|
| 1 tile | 56px of rows | 0 | 60 |
| 12 tiles | 672px of rows | 0 | 698 |

For the document editor, the effect is on capture rather than on a message: at a 400px viewport, a headless browser's full-page screenshot of a 698px document went from a 1000x400 area to 1000x698. That is exactly what the comment on the old fix said it was there to prevent.

## When the height is sent

Two ordering details, both found by measuring what a parent window actually receives.

The observer starts once the document has first rendered, not when the document arrives. Observing earlier posted one viewport-sized height first, because the stylesheet rules do not apply until the unwrapped branch renders.

The iframe also posts a single `documentRendered` message, so a consumer can wait for the render without watching heights. That message is sent from the observer's first callback rather than straight from the React render. The callback does not run until the browser's next rendering step, by which point the document has been laid out and its height already sent. Announcing the render any earlier delivers it before any height at all, and measuring synchronously at that moment reports the document mid-layout: 242px for one that settles at 698px. A parent now always has the real height by the time `documentRendered` arrives.

`updateHeight` keeps its name and shape.

## The render page

`on-analysis-document-pending.ts` now ignores an `updateHeight` whose value is not a finite positive number, so a stray 0 leaves the iframe at its starting height instead of collapsing it. This is a guard, not the fix. It sits in the same message listener that #2974 changed, and the two changes are combined here.

## What does not change

Nothing changes without the `unwrapped` parameter.

The authoring app never sets it, so its layout is untouched, and it acts only on `updateContent` messages. We confirmed editing still works there and that the new messages are ignored.

The normal document editor is unchanged in both computed layout and appearance: body overflow still hidden, `#app` still fixed at the viewport height, `.document-content` still scrolling inside it.

## Related

Follows #2974, which touched the same message listener in the render page.

[CLUE-371]: https://concord-consortium.atlassian.net/browse/CLUE-371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ