### PR TITLE
Fix the standalone teacher cypress test [CLUE-651]

### DIFF
--- a/cypress/e2e/functional/standalone_tests/standalone_teacher_load_spec.js
+++ b/cypress/e2e/functional/standalone_tests/standalone_teacher_load_spec.js
@@ -18,9 +18,10 @@ context('Standalone CLUE Teacher', () => {
   it('should load standalone teacher page and show teacher-specific UI', () => {
     standaloneHelper.visitStandalone('/standalone/?unit=msa');
     cy.get('[data-testid=standalone-get-started-button]').click();
-    // Verify that teacher elements are visible
+    // Teacher Guide is a teacher-only tab. Class Work only appears once the standalone auth
+    // handoff finishes, since standalone mode shows just the curriculum tabs until then.
     cy.get('[data-testid=nav-tab-teacher-guide]').should('be.visible');
-    cy.get('[data-testid=nav-tab-student-work]').should('be.visible');
+    cy.get('[data-testid=nav-tab-sort-work]').should('be.visible');
 
     // Verify we're logged in by checking for the user menu
     cy.get("[data-testid=custom-select-header]")

--- a/src/components/navigation/nav-tab-panel.tsx
+++ b/src/components/navigation/nav-tab-panel.tsx
@@ -79,6 +79,7 @@ export class NavTabPanel extends BaseComponent<IProps> {
                     if (tabSpec.tab === 'teacher-guide') dataTestId = 'nav-tab-teacher-guide';
                     if (tabSpec.tab === 'student-work') dataTestId = 'nav-tab-student-work';
                     if (tabSpec.tab === 'class-work') dataTestId = 'nav-tab-class-work';
+                    if (tabSpec.tab === 'sort-work') dataTestId = 'nav-tab-sort-work';
                     return (
                       <Tab key={tabSpec.tab} className={tabClass} data-testid={dataTestId}>
                         {tabSpec.label}


### PR DESCRIPTION
CLUE-651

Fixes the `standalone_teacher_load_spec.js` failure that has been red on every master run since the 2026-08-22 daily regression. Root cause analysis originally by @kswenson in CLUE-649; discussion in [this Slack thread](https://concord-consortium.slack.com/archives/CCHKYUW3S/p1787614289356659).

## Why it was failing

Not a code regression. The spec asserts `[data-testid=nav-tab-student-work]`, but that tab is hidden by the msa unit's authored config.

CLUE fetches unit config at runtime from `models-resources.concord.org/clue-curriculum/branch/main/msa/content.json`. `clue-curriculum` [PR #283](https://github.com/concord-consortium/clue-curriculum/pull/283) ("New CMP author content"), merged to `main` **2026-08-21 13:58 UTC**, added `"hidden": true` to the `student-work` tab. `Stores.tabsToDisplay` filters hidden tabs out, so it can never render. The same PR hid `class-work`, leaving `sort-work` (label "Class Work") as the visible one.

A standalone teacher now sees: Problems | Teacher Guide | My Work | Class Work.

| When | Event | Nightly |
| --- | --- | --- |
| 2026-08-21 00:19 | — | pass |
| **2026-08-21 13:58** | **clue-curriculum #283 merged and deployed** | — |
| 2026-08-22 00:18 onward | — | fail |

The Daily Regression ran the identical master commit (`e4a5cc1b`) on both sides of that boundary, which rules out any code change in this repo.

## The change

Assert Class Work instead of Student Work. This keeps the check meaningful: `sort-work` is absent while standalone mode shows only the curriculum tabs, so seeing it proves the standalone auth handoff completed. `nav-tab-teacher-guide` still covers the teacher-only case.

`sort-work` had no `data-testid` — `nav-tab-panel.tsx` only assigned them to `teacher-guide`, `student-work` and `class-work` — so this adds one.

`nav-tab-student-work` and `nav-tab-class-work` are left in place; they remain valid selectors for units that don't hide those tabs.

## Why this fix and not insulation from the curriculum

The obvious alternative is to point the spec at content this repo controls — a fixture unit, or `demo/units/qa` — so no authoring change can ever break it. That was considered and deliberately not taken:

> I think there is value to testing the actual curriculum. If we only test our own copies of the content we can miss things that the code breaks in the real content. But these kinds of tests should be clear, and probably they should only run on master.
>
> It is tempting to have tests like this prevent deployment of the clue-curriculum repo, but that would be confusing to authors. It would only work if the authors had control of the tests and could update them when they change the content. That isn't something that is reasonable now. With AI I think we could come up with a system that would enable that though.

So the inter-repo dependency is intentional. Insulating the spec would trade away exactly the coverage it exists to provide — catching cases where code breaks real content.

## Known gap this does not close

Any authoring change to any unit CLUE's specs load can still turn CI red, with a green check on the PR that caused it. Per @kswenson's analysis, `clue-curriculum` PR #283 ran exactly one check — `S3 Deploy` — which is that repo's entire CI: `npm ci` plus a push to the `models-resources` bucket. No schema validation, no content checks, none of CLUE's specs. A content edit merges green, the same job deploys it, and the first signal is a nightly roughly ten hours later attributed to nothing in particular.

Narrowing options, roughly by cost: run curriculum-dependent specs only on master; add schema validation to `clue-curriculum` CI (catches malformed config, not a deliberate valid change like this one); give authors control of the specs so they can update them alongside content. Nobody is picking this up now — captured in CLUE-651 so it isn't lost.

## Verification

- `standalone_teacher_load_spec.js` — 1 passing in 14s (previously failed at 2m against all 3 attempts)
- `nav-tab-panel.test.tsx` — 3 passing
- eslint clean on both changed files

Unrelated: `document_tests/tiles_copy_test_spec.js` also fails intermittently (`Not enough elements found. Found '22', expected '32'`). Much older — on and off since at least 2026-08-04 — and untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
