### PR TITLE
CLUE-652: send the portal firebase app that matches the selected environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ There are a number of URL parameters that can aid in testing:
 |`studentDocument`|string                  |If set to the ID of a document, this will be displayed as the left-side content.|
 |`studentDocumentHistoryId`|string         |Open the history slider and move to the specified revision in the `studentDocument`.|
 |`portalDomain`  |string                   |Used for dev/qa of standalone auth, this overrides which portal is used for auth|
-|`firebaseEnv`   |`production`,`staging`   |Target Firebase project for data and functions|
+|`firebaseEnv`   |`production`,`staging`   |Target Firebase project for data and functions. Also selects which `firebase_apps` row CLUE asks the portal to sign its JWT with — see below.|
 |`showAiSummary` |`true`                   |When set to true the "ai summary" button in the document editor is shown|
 |`includeModelInAiSummary`|`true`          |When set to true the JSON.stringified raw model is included in the AI summary|
 |`fakeAuthoringAuth`|`true`                |When set to true the authoring system fakes the GitHub login|
@@ -186,6 +186,27 @@ There are a number of URL parameters that can aid in testing:
 |`iframeUrl`        |string (escaped url)  |Used as the url for iframe interactive tiles, overriding the url specified in the unit's config.
 |`mockSeismicData`  |none                  |Seismic tiles fetch pre-staged sample miniSEED files from S3 instead of live EarthScope data via the CloudFront proxy, ignoring the requested station.|
 |`tokenServiceEnv`  |`staging`             |Seismic envelope uploads request credentials from the staging token-service and read/write envelope tiles in the staging bucket (`models-resources-qa`) instead of production.|
+
+### `firebaseEnv` and portal authentication
+
+When CLUE is launched from a portal it asks that portal for a Firebase JWT, naming the row of the
+portal's `firebase_apps` table whose service account should sign it. The portal signs with that row's
+credentials and the Firebase project verifies the signature, so the row has to belong to the project
+`firebaseEnv` selects. Both are declared together in `src/lib/firebase-config.ts`:
+
+| `firebaseEnv` | Firebase project | portal `firebase_apps` row |
+|---|---|---|
+| `production` (default) | `collaborative-learning-ec215` | `collaborative-learning` |
+| `staging` | `collaborative-learning-staging` | `collaborative-learning-staging` |
+
+**Running a portal locally against the staging Firebase project** therefore needs a `firebase_apps`
+row named `collaborative-learning-staging`, holding a service account for that project. A portal with
+no row of that name rejects the request with "Unknown firebase app name", which is the error to look
+for. A portal with the credentials under the *wrong* name is worse: the token is signed by one
+project and verified by another, and the resulting failure says nothing about the cause.
+
+This only applies to portal-authenticated sessions. The `dev`, `demo`, `qa` and `test` app modes
+never request a JWT from a portal, so they are unaffected.
 
 The `unit` parameter can be in 3 forms:
 

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -136,8 +136,21 @@ const PARTIAL_RAW_OFFERING_INFO = {
 const curriculumConfig = CurriculumConfig.create({curriculumSiteUrl: ""});
 
 describe("getFirebaseJWTParams", () => {
+  const originalUrlParams = UrlParams.urlParams;
+
+  afterEach(() => {
+    (UrlParams as any).urlParams = originalUrlParams;
+  });
+
   it("defaults to the collaborative-learning firebase app", () => {
     expect(getFirebaseJWTParams()).toBe("?firebase_app=collaborative-learning");
+  });
+
+  it("defaults to the firebase app of the environment firebaseEnv selects", () => {
+    // Without this the client would talk to the staging project while asking the portal for a token
+    // signed by production's service account, and the staging project would reject every login.
+    (UrlParams as any).urlParams = { firebaseEnv: "staging" };
+    expect(getFirebaseJWTParams()).toBe("?firebase_app=collaborative-learning-staging");
   });
 
   it("supports requesting a JWT for another firebase app", () => {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -7,6 +7,7 @@ import { NUM_FAKE_STUDENTS, NUM_FAKE_TEACHERS } from "../components/demo/demo-cr
 import { AppConfigModelType } from "../models/stores/app-config-model";
 import { UserType } from "../models/stores/user-types";
 import { getErrorMessage } from "../utilities/super-agent-helpers";
+import { portalFirebaseApp } from "./firebase-config";
 import { getPortalOfferings, getPortalClassOfferings,  getProblemIdForAuthenticatedUser,
    } from "./portal-api";
 import { PortalJWT, PortalFirebaseJWT, PortalUserJWT } from "./portal-types";
@@ -21,7 +22,6 @@ import { UserModelType } from "../models/stores/user";
 
 export const PORTAL_JWT_URL_SUFFIX = "api/v1/jwt/portal";
 export const FIREBASE_JWT_URL_SUFFIX = "api/v1/jwt/firebase";
-export const FIREBASE_APP_NAME = "collaborative-learning";
 
 export const DEV_STUDENT: StudentUser = {
   type: "student",
@@ -101,7 +101,7 @@ export const getPortalJWTWithBearerToken = (basePortalUrl: string, type: string,
   });
 };
 
-export const getFirebaseJWTParams = (classHash?: string, firebaseApp = FIREBASE_APP_NAME) => {
+export const getFirebaseJWTParams = (classHash?: string, firebaseApp = portalFirebaseApp()) => {
   const params: Record<string,string> = {
     firebase_app: firebaseApp
   };

--- a/src/lib/firebase-config.test.ts
+++ b/src/lib/firebase-config.test.ts
@@ -9,6 +9,15 @@ const getConfigWithEnv = (env?: string) => {
   return require("./firebase-config").firebaseConfig();
 };
 
+const getPortalFirebaseAppWithEnv = (env?: string) => {
+  jest.resetModules();
+  jest.doMock("../utilities/url-params", () => ({
+    urlParams: { firebaseEnv: env }
+  }));
+
+  return require("./firebase-config").portalFirebaseApp();
+};
+
 const prodAuthDomain = "collaborative-learning-ec215.firebaseapp.com";
 const prodDatabaseURL = "https://collaborative-learning-ec215.firebaseio.com";
 const prodProjectId = "collaborative-learning-ec215";
@@ -51,5 +60,41 @@ describe("firebaseConfig", () => {
     expect(config.authDomain).toBe(prodAuthDomain);
     expect(config.databaseURL).toBe(prodDatabaseURL);
     expect(config.projectId).toBe(prodProjectId);
+  });
+});
+
+describe("portalFirebaseApp", () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  // The portal signs CLUE's Firebase JWT with the service account of the `firebase_apps` row it is
+  // asked for by name. That row has to belong to the project the client is talking to, or the token
+  // is signed by one project and verified by another. These cases are what keep the two halves of
+  // each environment together.
+  it("asks for the production app by default", () => {
+    expect(getPortalFirebaseAppWithEnv()).toBe("collaborative-learning");
+  });
+
+  it("asks for the production app when production is specified by URL param", () => {
+    expect(getPortalFirebaseAppWithEnv("production")).toBe("collaborative-learning");
+  });
+
+  it("asks for the staging app when staging is specified by URL param", () => {
+    expect(getPortalFirebaseAppWithEnv("staging")).toBe("collaborative-learning-staging");
+  });
+
+  it("asks for the production app when an unrecognized value is provided", () => {
+    expect(getPortalFirebaseAppWithEnv("does-not-exist")).toBe("collaborative-learning");
+  });
+
+  it("keeps the client config and the portal app on the same environment", () => {
+    // The failure this rules out: the client talking to staging while the JWT is signed by the
+    // production service account, which is what the two-table version of this allowed.
+    expect(getConfigWithEnv("staging").projectId).toBe("collaborative-learning-staging");
+    expect(getPortalFirebaseAppWithEnv("staging")).toBe("collaborative-learning-staging");
+
+    expect(getConfigWithEnv("production").projectId).toBe("collaborative-learning-ec215");
+    expect(getPortalFirebaseAppWithEnv("production")).toBe("collaborative-learning");
   });
 });

--- a/src/lib/firebase-config.ts
+++ b/src/lib/firebase-config.ts
@@ -19,36 +19,59 @@ const keys = {
   staging: atob("QUl6YVN5Q0dKRjQybE15XzhjSFpkU0lQa0FvWE9WWFBHMmotSHAw")
 };
 
-const configs = {
+/**
+ * Everything that has to agree about which Firebase project this session talks to.
+ *
+ * `config` is the client's connection to the project. `portalFirebaseApp` is the name of the row in
+ * the portal's `firebase_apps` table whose service account signs our JWT — the portal signs with that
+ * row's credentials and the project in `config` verifies the signature, so the two must name the same
+ * project. They are declared together for that reason: held apart, they can drift, and a drifted pair
+ * fails at login with nothing to say which half is wrong.
+ *
+ * A portal that has no row of the given name refuses the request outright ("Unknown firebase app
+ * name"), which is the failure worth having — a portal that has a row under the *wrong* name signs a
+ * token the project then rejects for reasons that look nothing like the cause.
+ */
+const environments = {
   production: {
-    apiKey: keys.production,
-    authDomain: "collaborative-learning-ec215.firebaseapp.com",
-    databaseURL: "https://collaborative-learning-ec215.firebaseio.com",
-    projectId: "collaborative-learning-ec215",
-    storageBucket: "collaborative-learning-ec215.appspot.com",
-    messagingSenderId: "112537088884",
-    appId: "1:112537088884:web:c51b1b8432fff36faff221",
-    measurementId: "G-XP472LRY18"
+    portalFirebaseApp: "collaborative-learning",
+    config: {
+      apiKey: keys.production,
+      authDomain: "collaborative-learning-ec215.firebaseapp.com",
+      databaseURL: "https://collaborative-learning-ec215.firebaseio.com",
+      projectId: "collaborative-learning-ec215",
+      storageBucket: "collaborative-learning-ec215.appspot.com",
+      messagingSenderId: "112537088884",
+      appId: "1:112537088884:web:c51b1b8432fff36faff221",
+      measurementId: "G-XP472LRY18"
+    }
   },
   staging: {
-    apiKey: keys.staging,
-    authDomain: "collaborative-learning-staging.firebaseapp.com",
-    databaseURL: "https://collaborative-learning-staging-default-rtdb.firebaseio.com",
-    projectId: "collaborative-learning-staging",
-    storageBucket: "collaborative-learning-staging.firebasestorage.app",
-    messagingSenderId: "822807055414",
-    appId: "1:822807055414:web:9e08fe0f4ffaf6130f9c97"
+    portalFirebaseApp: "collaborative-learning-staging",
+    config: {
+      apiKey: keys.staging,
+      authDomain: "collaborative-learning-staging.firebaseapp.com",
+      databaseURL: "https://collaborative-learning-staging-default-rtdb.firebaseio.com",
+      projectId: "collaborative-learning-staging",
+      storageBucket: "collaborative-learning-staging.firebasestorage.app",
+      messagingSenderId: "822807055414",
+      appId: "1:822807055414:web:9e08fe0f4ffaf6130f9c97"
+    }
   }
 };
 
+function currentEnvironment() {
+  const { firebaseEnv } = urlParams;
+  return environments[isFirebaseEnv(firebaseEnv) ? firebaseEnv : "production"];
+}
+
 export function firebaseConfig() {
-  let { firebaseEnv } = urlParams;
+  return currentEnvironment().config;
+}
 
-  if (!isFirebaseEnv(firebaseEnv)) {
-    firebaseEnv = "production";
-  }
-
-  return configs[firebaseEnv];
+/** The portal `firebase_apps` row to request a JWT from. See `environments` above. */
+export function portalFirebaseApp() {
+  return currentEnvironment().portalFirebaseApp;
 }
 
 export const localFunctionsHost = "http://localhost:5001";


### PR DESCRIPTION
[CLUE-652](https://concord-consortium.atlassian.net/browse/CLUE-652)

`firebaseEnv=staging` points the client at the staging Firebase project but does not change which Firebase app CLUE asks the portal to sign its JWT with. `FIREBASE_APP_NAME` was a module constant, and although `getFirebaseJWTParams` accepted a `firebaseApp` argument, no production call site ever passed one — only tests did.

So CLUE could not authenticate against the staging Firebase project from any portal. The token came back signed by the production service account and `collaborative-learning-staging` rejected it.

## How this surfaced

The staging portal's `firebase_apps` row named `collaborative-learning` holds credentials for the **production** project (`collaborative-learning-ec215`). A correct staging row exists, named `collaborative-learning-staging` — CLUE just had no way to ask for it. Found while trying to test the CLUE-610 Firestore rules against staging.

## The change

The Firebase project and the JWT audience have to agree: the portal signs with the named row's credentials and the project verifies that signature. They are now declared together, one entry per environment, instead of living in two places:

```ts
staging: {
  portalFirebaseApp: "collaborative-learning-staging",
  config: { projectId: "collaborative-learning-staging", ... }
}
```

Deriving the app name from the environment by string concatenation was the alternative. It was rejected because it reintroduces the same drift in a shorter form — two things that must agree, expressed separately.

`firebaseConfig()` and the new `portalFirebaseApp()` resolve through one `currentEnvironment()`, so the unrecognized-value fallback exists once rather than twice. `FIREBASE_APP_NAME` had no other callers and is now the value on the production entry.

## What does not change

**No currently-working case is lost.** The JWT request only happens on the `appMode === "authed"` path — `authenticate()` returns earlier for `dev`, `demo`, `qa` and `test`, which never ask a portal for a token. Local testing without a portal is untouched, structurally rather than incidentally.

The one row of the matrix that changes behaviour is production-portal + `firebaseEnv=staging`, which is broken today (production credentials, staging project). It now fails loudly instead, and becomes fixable by adding the row to that portal.

## Failure modes

A portal with no row of the requested name raises `Unknown firebase app name` from `SignedJwt.create_firebase_token`. That is better than the failure it replaces, where a token signed by the wrong project produces an opaque Firebase rejection that points nowhere near the cause.

## Testing

Six tests, written before the change and each watched failing first — the `auth.ts` one failed with `Received: "?firebase_app=collaborative-learning"` where staging was expected, which is the bug itself.

| Check | Result |
|---|---|
| `npm run check:types` | clean |
| `npm run lint:build` | 0 errors |
| Full jest suite | 346 suites, 3862 passed (5 skipped) |

## Docs

The README URL-param table now points at a new section giving the environment → project → `firebase_apps` row mapping, what a locally-run portal needs in order to target the staging project, and the note that the non-portal app modes are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CLUE-652]: https://concord-consortium.atlassian.net/browse/CLUE-652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ