### PR TITLE
feat: screenshots from production with doc's own unit (CLUE-371)

### DIFF
--- a/functions-v2/src/on-analysis-document-pending.ts
+++ b/functions-v2/src/on-analysis-document-pending.ts
@@ -115,10 +115,18 @@ export const onAnalysisDocumentPending =
     // The document's unit, from its Firestore metadata. It picks the unit the screenshot is
     // rendered with, and until the unit configuration includes the summarizer it also picks the
     // text summarizer for the cas unit.
+    // A failure here has to go through error() like the other failures: it removes the pending
+    // queue entry, and without that the entry stays put and later edits of the document, which
+    // only update it, never trigger this function again.
     let documentUnit: unknown;
     if (queueDoc?.firestoreDocumentPath) {
+      try {
       const firestoreDoc = await firestore.doc(queueDoc.firestoreDocumentPath).get();
       documentUnit = firestoreDoc.data()?.unit;
+      } catch (err) {
+        await error(`Could not retrieve Firestore document ${queueDoc.firestoreDocumentPath}: ${err}`, event);
+        return;
+      }
     }
 
     // determine the summarizer to use, defaulting to "image"

--- a/functions-v2/src/on-analysis-document-pending.ts
+++ b/functions-v2/src/on-analysis-document-pending.ts
@@ -12,14 +12,31 @@ import {escapeHtmlAttribute, escapeJsonForScript} from "../../shared/escape-for-
 // 2. (This function) Create screenshots of those documents
 // 3. Send those screenshots to the AI service for processing, and create document comments with the results
 
-const clueURL = "https://collaborative-learning.concord.org/branch/shutterbug-support";
-const clueUnit = "mods";
+// The released CLUE build. The release workflow copies only a few entry points to the top level
+// (see .github/workflows/release.yml), and `iframe.html` is not one of them, so the document
+// iframe is reached through the `authoring-iframe` entry point, which is built from the same
+// source (src/iframe/iframe.tsx). Rendering against the release means screenshots keep up with
+// tiles added or changed in later releases.
+export const clueIframeURL = "https://collaborative-learning.concord.org/authoring-iframe/index.html";
+// The unit to render with when the document's own unit is unknown or unusable.
+export const fallbackClueUnit = "mods";
 const shutterbugURL = "https://api.concord.org/shutterbug-production";
+
+// Tile types are registered from the loaded unit's configuration, not globally, so the render
+// has to use the document's own unit: any tile type the unit does not list is drawn as an
+// "unknown tile" placeholder, silently, and the screenshot is a valid image of the wrong thing.
+// Only a plain unit code is accepted. The metadata's unit is sometimes null, and a unit loaded
+// from a custom URL has a code that does not exist on the curriculum site; either would make
+// CLUE load its default unit or show an error page, which Shutterbug would capture just the same.
+export function renderUnitFor(unit: unknown) {
+  return typeof unit === "string" && /^[A-Za-z0-9_+-]+$/.test(unit) ? unit : fallbackClueUnit;
+}
 
 // scripts/shutterbug.ts has a near-copy of this page for rendering a document by hand during
 // development. Keep fixes to one in step with the other until they are unified.
-export function generateHtml(clueDocument: unknown) {
-  const source = escapeHtmlAttribute(`${clueURL}/iframe.html?unit=${clueUnit}&unwrapped&readOnly`);
+export function generateHtml(clueDocument: unknown, unit = fallbackClueUnit) {
+  const source = escapeHtmlAttribute(
+    `${clueIframeURL}?unit=${encodeURIComponent(unit)}&unwrapped&readOnly`);
   return `
     <script>const initialValue=${escapeJsonForScript(JSON.stringify(clueDocument))}</script>
     <!-- height will be updated when iframe sends updateHeight message -->
@@ -95,18 +112,20 @@ export const onAnalysisDocumentPending =
       return;
     }
 
+    // The document's unit, from its Firestore metadata. It picks the unit the screenshot is
+    // rendered with, and until the unit configuration includes the summarizer it also picks the
+    // text summarizer for the cas unit.
+    let documentUnit: unknown;
+    if (queueDoc?.firestoreDocumentPath) {
+      const firestoreDoc = await firestore.doc(queueDoc.firestoreDocumentPath).get();
+      documentUnit = firestoreDoc.data()?.unit;
+    }
+
     // determine the summarizer to use, defaulting to "image"
     let summarizer = queueDoc?.aiPrompt?.summarizer;
-    if (!summarizer && queueDoc?.firestoreDocumentPath) {
-      logger.info(`No summarizer specified, checking Firestore doc ${queueDoc.firestoreDocumentPath}`);
-      // until the unit configuration is updated to include the summarizer use the Firestore
-      // doc unit to see if we want to use the text summarizer (for the cas unit)
-      const firestoreDoc = await firestore.doc(queueDoc.firestoreDocumentPath).get();
-      const firestoreData = firestoreDoc.data();
-      if (firestoreData?.unit === "cas") {
-        logger.info(`Firestore doc ${queueDoc.firestoreDocumentPath} has unit "cas", using text summarizer`);
-        summarizer = "text";
-      }
+    if (!summarizer && documentUnit === "cas") {
+      logger.info(`Firestore doc ${queueDoc?.firestoreDocumentPath} has unit "cas", using text summarizer`);
+      summarizer = "text";
     }
     summarizer = summarizer ?? "image";
     let nextQueueDoc: Record<string, unknown> = {...queueDoc, summarizer};
@@ -120,7 +139,11 @@ export const onAnalysisDocumentPending =
       // Generate screenshot with Shutterbug service
       let responseJSON;
       try {
-        const html = generateHtml(JSON.parse(content));
+        const unit = renderUnitFor(documentUnit);
+        if (unit !== documentUnit) {
+          logger.info(`Document unit ${JSON.stringify(documentUnit)} is not usable for rendering, using "${unit}"`);
+        }
+        const html = generateHtml(JSON.parse(content), unit);
         const response = await fetch(shutterbugURL,
           {
             method: "POST",

--- a/functions-v2/src/on-analysis-document-pending.ts
+++ b/functions-v2/src/on-analysis-document-pending.ts
@@ -16,7 +16,10 @@ import {escapeHtmlAttribute, escapeJsonForScript} from "../../shared/escape-for-
 // (see .github/workflows/release.yml), and `iframe.html` is not one of them, so the document
 // iframe is reached through the `authoring-iframe` entry point, which is built from the same
 // source (src/iframe/iframe.tsx). Rendering against the release means screenshots keep up with
-// tiles added or changed in later releases.
+// tiles added or changed in later releases. The cost is that every CLUE release can change the
+// screenshots: the page below starts the iframe at 500px and only grows it on a positive
+// updateHeight, so a release that breaks height reporting in unwrapped mode (src/iframe) yields
+// truncated screenshots, and nothing here can tell.
 export const clueIframeURL = "https://collaborative-learning.concord.org/authoring-iframe/index.html";
 // The unit to render with when the document's own unit is unknown or unusable.
 export const fallbackClueUnit = "mods";
@@ -121,8 +124,8 @@ export const onAnalysisDocumentPending =
     let documentUnit: unknown;
     if (queueDoc?.firestoreDocumentPath) {
       try {
-      const firestoreDoc = await firestore.doc(queueDoc.firestoreDocumentPath).get();
-      documentUnit = firestoreDoc.data()?.unit;
+        const firestoreDoc = await firestore.doc(queueDoc.firestoreDocumentPath).get();
+        documentUnit = firestoreDoc.data()?.unit;
       } catch (err) {
         await error(`Could not retrieve Firestore document ${queueDoc.firestoreDocumentPath}: ${err}`, event);
         return;

--- a/functions-v2/test/on-analysis-document-pending.test.ts
+++ b/functions-v2/test/on-analysis-document-pending.test.ts
@@ -106,11 +106,26 @@ describe("functions", () => {
   });
 
   describe("onAnalysisDocumentPending", () => {
+    // Capture what is posted to Shutterbug instead of calling the real service.
+    const stubImageUrl = "https://shutterbug.example/image.png";
+    let fetchSpy: jest.SpiedFunction<typeof fetch>;
+    beforeEach(() => {
+      fetchSpy = jest.spyOn(global, "fetch").mockResolvedValue(
+        {json: async () => ({url: stubImageUrl})} as Response);
+    });
+    afterEach(() => {
+      fetchSpy.mockRestore();
+    });
+
     test("runs when queued document is pending", async () => {
       // Set up document with some content to be imaged.
       await getDatabase().ref("demo/AI/portals/demo/classes/democlass1/users/1/documents/testdoc1").set({
         content: sampleDoc,
       });
+      // The metadata document's unit is null, as it sometimes is in Firestore, so the render has
+      // to fall back to the default unit.
+      const firestoreDocumentPath = "demo/AI/documents/testdoc1";
+      await admin.firestore().doc(firestoreDocumentPath).set({unit: null});
 
       const wrapped = fft.wrap(onAnalysisDocumentPending);
 
@@ -119,6 +134,7 @@ describe("functions", () => {
           metadataPath: "demo/AI/portals/demo/classes/democlass1/users/1/documentMetadata/testdoc1",
           documentPath: "demo/AI/portals/demo/classes/democlass1/users/1/documents/testdoc1",
           commentsPath: "demo/AI/documents/testdoc1/comments",
+          firestoreDocumentPath,
           docUpdated: "1001",
           evaluator: "categorize-design",
         }, "analysis/queue/pending/testdoc1"),
@@ -129,6 +145,11 @@ describe("functions", () => {
       });
 
       expect(logger.warn).not.toHaveBeenCalled();
+
+      // The render was posted with the fallback unit, not the null one.
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const body = JSON.parse(fetchSpy.mock.calls[0][1]?.body as string);
+      expect(body.content).toContain(`?unit=${fallbackClueUnit}&amp;unwrapped&amp;readOnly"`);
 
       // Document should have been removed from pending queue, and added to "imaged" queue.
 
@@ -143,10 +164,11 @@ describe("functions", () => {
           metadataPath: "demo/AI/portals/demo/classes/democlass1/users/1/documentMetadata/testdoc1",
           documentPath: "demo/AI/portals/demo/classes/democlass1/users/1/documents/testdoc1",
           commentsPath: "demo/AI/documents/testdoc1/comments",
+          firestoreDocumentPath,
           docUpdated: "1001",
           evaluator: "categorize-design",
           docImaged: expect.any(Object),
-          docImageUrl: expect.stringContaining("shutterbug"),
+          docImageUrl: stubImageUrl,
           summarizer: "image",
         });
       });
@@ -159,7 +181,7 @@ describe("functions", () => {
 
       const failedImagingQueue = admin.firestore().collection("analysis/queue/failedImaging");
       expect(await failedImagingQueue.count().get().then((result) => result.data().count)).toEqual(0);
-    }, 10000);
+    });
 
     test("renders with the unit from the document's Firestore metadata", async () => {
       await getDatabase().ref("demo/AI/portals/demo/classes/democlass1/users/1/documents/testdoc2").set({
@@ -169,41 +191,33 @@ describe("functions", () => {
       const firestoreDocumentPath = "demo/AI/documents/testdoc2";
       await admin.firestore().doc(firestoreDocumentPath).set({unit: "s+s"});
 
-      // Capture what is posted to Shutterbug instead of calling the real service.
-      const fetchSpy = jest.spyOn(global, "fetch").mockResolvedValue(
-        {json: async () => ({url: "https://shutterbug.example/testdoc2.png"})} as Response);
+      const wrapped = fft.wrap(onAnalysisDocumentPending);
+      await wrapped({
+        data: makeDocumentSnapshot({
+          metadataPath: "demo/AI/portals/demo/classes/democlass1/users/1/documentMetadata/testdoc2",
+          documentPath: "demo/AI/portals/demo/classes/democlass1/users/1/documents/testdoc2",
+          commentsPath: "demo/AI/documents/testdoc2/comments",
+          firestoreDocumentPath,
+          docUpdated: "1001",
+          evaluator: "categorize-design",
+        }, "analysis/queue/pending/testdoc2"),
+        params: {
+          docId: "testdoc2",
+        },
+        document: "analysis/queue/pending/testdoc2",
+      });
 
-      try {
-        const wrapped = fft.wrap(onAnalysisDocumentPending);
-        await wrapped({
-          data: makeDocumentSnapshot({
-            metadataPath: "demo/AI/portals/demo/classes/democlass1/users/1/documentMetadata/testdoc2",
-            documentPath: "demo/AI/portals/demo/classes/democlass1/users/1/documents/testdoc2",
-            commentsPath: "demo/AI/documents/testdoc2/comments",
-            firestoreDocumentPath,
-            docUpdated: "1001",
-            evaluator: "categorize-design",
-          }, "analysis/queue/pending/testdoc2"),
-          params: {
-            docId: "testdoc2",
-          },
-          document: "analysis/queue/pending/testdoc2",
-        });
+      expect(logger.warn).not.toHaveBeenCalled();
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const body = JSON.parse(fetchSpy.mock.calls[0][1]?.body as string);
+      expect(body.content).toContain(`src="${clueIframeURL}?unit=s%2Bs&amp;unwrapped&amp;readOnly"`);
+      expect(body.content).not.toContain(`unit=${fallbackClueUnit}`);
 
-        expect(logger.warn).not.toHaveBeenCalled();
-        expect(fetchSpy).toHaveBeenCalledTimes(1);
-        const body = JSON.parse(fetchSpy.mock.calls[0][1]?.body as string);
-        expect(body.content).toContain(`src="${clueIframeURL}?unit=s%2Bs&amp;unwrapped&amp;readOnly"`);
-        expect(body.content).not.toContain(`unit=${fallbackClueUnit}`);
-
-        const imaged = await admin.firestore().doc("analysis/queue/imaged/testdoc2").get();
-        expect(imaged.data()).toMatchObject({
-          summarizer: "image",
-          docImageUrl: "https://shutterbug.example/testdoc2.png",
-        });
-      } finally {
-        fetchSpy.mockRestore();
-      }
+      const imaged = await admin.firestore().doc("analysis/queue/imaged/testdoc2").get();
+      expect(imaged.data()).toMatchObject({
+        summarizer: "image",
+        docImageUrl: stubImageUrl,
+      });
     });
 
     test("does not process doc with unknown evaluator", async () => {

--- a/functions-v2/test/on-analysis-document-pending.test.ts
+++ b/functions-v2/test/on-analysis-document-pending.test.ts
@@ -6,7 +6,9 @@ import * as logger from "firebase-functions/logger";
 import {getDatabase} from "firebase-admin/database";
 import * as admin from "firebase-admin";
 import {initialize, projectConfig} from "./initialize";
-import {generateHtml, onAnalysisDocumentPending} from "../src/on-analysis-document-pending";
+import {
+  clueIframeURL, fallbackClueUnit, generateHtml, onAnalysisDocumentPending, renderUnitFor,
+} from "../src/on-analysis-document-pending";
 
 jest.mock("firebase-functions/logger");
 
@@ -66,7 +68,34 @@ describe("generateHtml", () => {
 
   test("escapes the ampersands in the iframe source", () => {
     const html = generateHtml(JSON.parse(sampleDoc));
-    expect(html).toMatch(/src="[^"]+\/iframe\.html\?unit=[^"&]+&amp;unwrapped&amp;readOnly"/);
+    expect(html).toMatch(/src="[^"]+\/authoring-iframe\/index\.html\?unit=[^"&]+&amp;unwrapped&amp;readOnly"/);
+  });
+
+  test("renders through the released CLUE build, not a branch", () => {
+    expect(clueIframeURL).toBe("https://collaborative-learning.concord.org/authoring-iframe/index.html");
+    expect(generateHtml(JSON.parse(sampleDoc))).not.toContain("/branch/");
+  });
+
+  test("renders with the unit it is given, falling back to the default unit", () => {
+    expect(generateHtml(JSON.parse(sampleDoc), "msa")).toContain(`src="${clueIframeURL}?unit=msa&amp;`);
+    expect(generateHtml(JSON.parse(sampleDoc))).toContain(`?unit=${fallbackClueUnit}&amp;`);
+  });
+});
+
+describe("renderUnitFor", () => {
+  test("accepts a plain unit code", () => {
+    expect(renderUnitFor("msa")).toBe("msa");
+    expect(renderUnitFor("s+s")).toBe("s+s");
+    expect(renderUnitFor("bio4community")).toBe("bio4community");
+  });
+
+  test("falls back to the default unit for anything else", () => {
+    expect(renderUnitFor(undefined)).toBe(fallbackClueUnit);
+    expect(renderUnitFor(null)).toBe(fallbackClueUnit);
+    expect(renderUnitFor("")).toBe(fallbackClueUnit);
+    expect(renderUnitFor("https://example.com/content.json")).toBe(fallbackClueUnit);
+    expect(renderUnitFor("some/path")).toBe(fallbackClueUnit);
+    expect(renderUnitFor(42)).toBe(fallbackClueUnit);
   });
 });
 

--- a/functions-v2/test/on-analysis-document-pending.test.ts
+++ b/functions-v2/test/on-analysis-document-pending.test.ts
@@ -161,6 +161,51 @@ describe("functions", () => {
       expect(await failedImagingQueue.count().get().then((result) => result.data().count)).toEqual(0);
     }, 10000);
 
+    test("renders with the unit from the document's Firestore metadata", async () => {
+      await getDatabase().ref("demo/AI/portals/demo/classes/democlass1/users/1/documents/testdoc2").set({
+        content: sampleDoc,
+      });
+      // The metadata document's unit is a plain code with a character that has to be URL-encoded.
+      const firestoreDocumentPath = "demo/AI/documents/testdoc2";
+      await admin.firestore().doc(firestoreDocumentPath).set({unit: "s+s"});
+
+      // Capture what is posted to Shutterbug instead of calling the real service.
+      const fetchSpy = jest.spyOn(global, "fetch").mockResolvedValue(
+        {json: async () => ({url: "https://shutterbug.example/testdoc2.png"})} as Response);
+
+      try {
+        const wrapped = fft.wrap(onAnalysisDocumentPending);
+        await wrapped({
+          data: makeDocumentSnapshot({
+            metadataPath: "demo/AI/portals/demo/classes/democlass1/users/1/documentMetadata/testdoc2",
+            documentPath: "demo/AI/portals/demo/classes/democlass1/users/1/documents/testdoc2",
+            commentsPath: "demo/AI/documents/testdoc2/comments",
+            firestoreDocumentPath,
+            docUpdated: "1001",
+            evaluator: "categorize-design",
+          }, "analysis/queue/pending/testdoc2"),
+          params: {
+            docId: "testdoc2",
+          },
+          document: "analysis/queue/pending/testdoc2",
+        });
+
+        expect(logger.warn).not.toHaveBeenCalled();
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        const body = JSON.parse(fetchSpy.mock.calls[0][1]?.body as string);
+        expect(body.content).toContain(`src="${clueIframeURL}?unit=s%2Bs&amp;unwrapped&amp;readOnly"`);
+        expect(body.content).not.toContain(`unit=${fallbackClueUnit}`);
+
+        const imaged = await admin.firestore().doc("analysis/queue/imaged/testdoc2").get();
+        expect(imaged.data()).toMatchObject({
+          summarizer: "image",
+          docImageUrl: "https://shutterbug.example/testdoc2.png",
+        });
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
+
     test("does not process doc with unknown evaluator", async () => {
       const wrapped = fft.wrap(onAnalysisDocumentPending);
 

--- a/scripts/ai-harness/README.md
+++ b/scripts/ai-harness/README.md
@@ -307,9 +307,10 @@ point `--shutterbug-url` at the new address. The download that follows *does* fo
 because it is a plain GET for a hosted image and the URL it lands on is checked instead.
 
 **`puppeteer-full-height` renders through the same iframe pathway** production's screenshots use —
-the same HTML, the same `iframe.html?unwrapped&readOnly` entry point, the same `initialValue`
-message. Only two things differ: who takes the picture, and that it captures the whole document
-rather than production's first 1500 pixels. The harness captures reality; production's clipping is a
+the same HTML, the same CLUE iframe entry point with `unwrapped&readOnly` (a local build's
+`iframe.html`; the released build's `authoring-iframe/index.html`, built from the same source), the
+same `initialValue` message. Only two things differ: who takes the picture, and that it captures the
+whole document rather than production's first 1500 pixels. The harness captures reality; production's clipping is a
 production concern.
 
 Three details of *how* it does that were established by running it against a real CLUE server, and

--- a/scripts/ai-harness/README.md
+++ b/scripts/ai-harness/README.md
@@ -256,13 +256,14 @@ modes are named and separate, and an improvement never gets folded into the base
 | Mode | Network | CLUE URL | unit | Capture |
 |---|---|---|---|---|
 | `puppeteer-full-height` (default) | local | `--clue-url`, default `http://localhost:8080` | harness's own | full document, 960px wide |
-| `shutterbug-production-current` | yes | production's `branch/shutterbug-support` | `mods` | `height: 1500`, no `fullPage` |
-| `shutterbug-parameterized` | yes | `--clue-url`, default production's `branch/shutterbug-support` | `--unit`, default `mods` | `--capture-height`, default 1500; `--shutterbug-url`, default **staging** |
+| `shutterbug-production-current` | yes | production's released `authoring-iframe/index.html` | `mods` (production's fallback) | `height: 1500`, no `fullPage` |
+| `shutterbug-parameterized` | yes | `--clue-url`, default production's released `authoring-iframe/index.html` | `--unit`, default `mods` | `--capture-height`, default 1500; `--shutterbug-url`, default **staging** |
 | `puppeteer-per-tile` | local | `--clue-url`, default `http://localhost:8080` | harness's own | one image per top-level tile |
-| `shutterbug-accurate-height` | yes | `--clue-url`, default production's branch | `--unit`, default `mods` | each document's **own measured height** — needs a `puppeteer-full-height` render of the same corpus first |
+| `shutterbug-accurate-height` | yes | `--clue-url`, default production's released page | `--unit`, default `mods` | each document's **own measured height** — needs a `puppeteer-full-height` render of the same corpus first |
 
 **`shutterbug-production-current` is the parity baseline.** It matches production's request envelope
-— the production endpoint, the `branch/shutterbug-support` CLUE URL, `unit=mods`, `height: 1500`, no
+— the production endpoint, the released build's `authoring-iframe/index.html` page, `unit=mods`
+(production's fallback; production itself renders with each document's own unit), `height: 1500`, no
 `fullPage`, and a bare string body with no `content-type`. A snapshot test pins what this mode posts
 so it cannot drift while the other modes evolve, and it has been verified by hand against the real
 service.
@@ -954,6 +955,12 @@ Things this milestone surfaced that are not the harness's to fix.
   rebuilt from current CLUE code, every screenshot collapses to a 0px iframe.** That makes it worth
   fixing before the branch is refreshed, not after — and an explicit "document rendered" message
   would remove the dependency on `scrollHeight` altogether.
+
+  *Since resolved.* The CLUE iframe now measures `#app` in unwrapped mode and posts a
+  `documentRendered` message (`src/iframe/iframe-messages.ts`), the production page ignores a
+  non-positive height, and production's render target is the released build's
+  `authoring-iframe/index.html` (from v7.5.0), rendered with each document's own unit and `mods`
+  as the fallback. The paragraphs above describe the state the harness was built against.
 - **The `generateHtml()` script injection exists in production.** That same file interpolates
   `JSON.stringify(content)` into a `<script>` element with real student work. Text containing
   `</script>` can inject markup into the render page. The harness fixed its own copy

--- a/scripts/ai-harness/debug-render.ts
+++ b/scripts/ai-harness/debug-render.ts
@@ -27,7 +27,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { corpusPaths, defaultDataRoot, readCorpusDocument, readManifest } from "./src/corpus.js";
 import { kDocumentIdPattern } from "./src/schemas.js";
-import { generateRenderHtml, kInitialFrameHeightPx } from "./src/backends/render-html.js";
+import { generateRenderHtml, isClueFrameUrl, kInitialFrameHeightPx } from "./src/backends/render-html.js";
 import {
   FrameLike, PageLike, launchPuppeteer, startRenderPageServer, viewportPageOffset
 } from "./src/backends/puppeteer.js";
@@ -194,7 +194,7 @@ async function main() {
   await page.goto(served.url, { waitUntil: "domcontentloaded" });
 
   const clueFrame = (): FrameLike | undefined =>
-    page.frames().find((frame) => frame.url().includes("iframe.html"));
+    page.frames().find((frame) => isClueFrameUrl(frame.url()));
 
   // Poll until nothing changes for a while or the timeout lapses — deliberately no early success
   // exit, because "what happens after it looks done" is part of what this tool is for. The budget

--- a/scripts/ai-harness/src/backends/puppeteer.ts
+++ b/scripts/ai-harness/src/backends/puppeteer.ts
@@ -12,7 +12,7 @@
  */
 import { CaptureMode, RenderTarget } from "../schemas.js";
 import { readPngInfo } from "../png.js";
-import { generateRenderHtml, iframeUrlFor, kInitialFrameHeightPx } from "./render-html.js";
+import { generateRenderHtml, iframeUrlFor, isClueFrameUrl, kInitialFrameHeightPx } from "./render-html.js";
 import {
   RenderBackend, RenderDiagnostics, RenderLimits, RenderOutcome, RenderRequest, checkCaptureSize,
   checkEncodedSize, kDefaultRenderLimits
@@ -510,7 +510,7 @@ async function waitForClueFrame(
 ): Promise<FrameLike> {
   for (;;) {
     deadline.requireRemaining(docId, "the CLUE iframe appeared", contextOf());
-    const frame = page.frames().find((candidate) => /iframe(\.html|\/index\.html)/.test(candidate.url()));
+    const frame = page.frames().find((candidate) => isClueFrameUrl(candidate.url()));
     if (frame) return frame;
     await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
   }

--- a/scripts/ai-harness/src/backends/puppeteer.ts
+++ b/scripts/ai-harness/src/backends/puppeteer.ts
@@ -510,7 +510,7 @@ async function waitForClueFrame(
 ): Promise<FrameLike> {
   for (;;) {
     deadline.requireRemaining(docId, "the CLUE iframe appeared", contextOf());
-    const frame = page.frames().find((candidate) => candidate.url().includes("iframe.html"));
+    const frame = page.frames().find((candidate) => /iframe(\.html|\/index\.html)/.test(candidate.url()));
     if (frame) return frame;
     await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
   }

--- a/scripts/ai-harness/src/backends/render-html.ts
+++ b/scripts/ai-harness/src/backends/render-html.ts
@@ -50,7 +50,7 @@ export const kInitialFrameHeightPx = 500;
 export interface RenderHtmlOptions {
   /** The document content, as an object — not a string of JSON. */
   content: unknown;
-  /** The CLUE deployment to render through, without a trailing slash. */
+  /** The CLUE build root (or an `.html` iframe page) to render through, without a trailing slash. */
   clueUrl: string;
   /**
    * The unit to load. Tile types are registered from the *unit's* configuration, so omitting this
@@ -65,10 +65,16 @@ export interface RenderHtmlOptions {
 /**
  * Builds the iframe URL. `unit` is percent-encoded because it may be a full URL to a `content.json`,
  * which contains characters that would otherwise end the query parameter.
+ *
+ * `clueUrl` is normally a CLUE build root, and `iframe.html` is appended. The released build has no
+ * top-level `iframe.html` — the release workflow copies only a few entry points to the top level —
+ * so production reaches the same page through `authoring-iframe/index.html`. A `clueUrl` that
+ * already names an `.html` page is therefore used as it is.
  */
 export function iframeUrlFor(clueUrl: string, unit: string): string {
   const base = clueUrl.replace(/\/+$/, "");
-  return `${base}/iframe.html?unit=${encodeURIComponent(unit)}&unwrapped&readOnly`;
+  const page = /\.html$/.test(base) ? base : `${base}/iframe.html`;
+  return `${page}?unit=${encodeURIComponent(unit)}&unwrapped&readOnly`;
 }
 
 /**

--- a/scripts/ai-harness/src/backends/render-html.ts
+++ b/scripts/ai-harness/src/backends/render-html.ts
@@ -78,6 +78,14 @@ export function iframeUrlFor(clueUrl: string, unit: string): string {
 }
 
 /**
+ * Whether a frame URL is the CLUE document iframe built by `iframeUrlFor`: `iframe.html` on a build
+ * root, or the released build's `authoring-iframe/index.html`.
+ */
+export function isClueFrameUrl(url: string): boolean {
+  return /\/(iframe\.html|authoring-iframe\/index\.html)(\?|$)/.test(url);
+}
+
+/**
  * The same page production posts to Shutterbug, with the injection hole closed and one addition: the
  * page records on `window` that it handed the document to the iframe, which is the one thing a local
  * capture cannot observe from outside. Readiness itself is measured inside the CLUE frame — the

--- a/scripts/ai-harness/src/backends/shutterbug.ts
+++ b/scripts/ai-harness/src/backends/shutterbug.ts
@@ -2,12 +2,15 @@
  * The two Shutterbug modes: the production-parity baseline and the parameterized one.
  *
  * `shutterbug-production-current` matches production's request envelope — the production endpoint,
- * the `branch/shutterbug-support` CLUE URL, `unit=mods`, `height: 1500`, and no `fullPage` — and
- * renders against production's target, clipping included. It is not byte-for-byte production: the
- * page inside the request body comes from the generator this file shares with the other modes,
- * which escapes the document rather than interpolating it raw and guards a zero `updateHeight`. The
- * README lists every difference under "differences from production's HTML". A snapshot test pins
- * what this mode posts, so it cannot drift while the other modes evolve.
+ * the released build's `authoring-iframe/index.html` page, `unit=mods`, `height: 1500`, and no
+ * `fullPage` — and renders against production's target, clipping included. Production renders
+ * each document with the unit from its Firestore metadata and uses `mods` only as the fallback;
+ * the harness corpus has no such metadata, so this mode renders everything with the fallback. It
+ * is not byte-for-byte production: the page inside the request body comes from the generator this
+ * file shares with the other modes, which escapes the document rather than interpolating it raw
+ * and guards a zero `updateHeight`. The README lists every difference under "differences from
+ * production's HTML". A snapshot test pins what this mode posts, so it cannot drift while the
+ * other modes evolve.
  *
  * It is a **baseline**, not a recommendation: improvements go into `shutterbug-parameterized`,
  * which is the shape the eventual production fix will take.
@@ -25,7 +28,8 @@ import {
 } from "./types.js";
 
 /** Exactly what production uses today. Changing any of these changes what "parity" means. */
-export const kProductionClueUrl = "https://collaborative-learning.concord.org/branch/shutterbug-support";
+export const kProductionClueUrl = "https://collaborative-learning.concord.org/authoring-iframe/index.html";
+/** Production's fallback unit, used when a document's metadata has no usable unit code. */
 export const kProductionUnit = "mods";
 export const kProductionShutterbugUrl = "https://api.concord.org/shutterbug-production";
 export const kProductionCaptureHeightPx = 1500;

--- a/scripts/ai-harness/src/backends/shutterbug.ts
+++ b/scripts/ai-harness/src/backends/shutterbug.ts
@@ -16,7 +16,7 @@
  * which is the shape the eventual production fix will take.
  *
  * Note that `scripts/shutterbug.ts` is *not* a production baseline, whatever the harness plan says:
- * it posts `height: 500, fullPage: true` and omits the unit.
+ * it posts `height: 500, fullPage: true`.
  */
 import { RenderTarget } from "../schemas.js";
 import { NotAPngError, readPngInfo } from "../png.js";

--- a/scripts/ai-harness/test/hosted-images.test.ts
+++ b/scripts/ai-harness/test/hosted-images.test.ts
@@ -38,7 +38,7 @@ function hostedTask(docId: string, url: string, sha256 = kSha): RunTask {
       backendId: "shutterbug",
       backendVersion: 1,
       renderTarget: {
-        clueUrl: "https://collaborative-learning.concord.org/branch/shutterbug-support",
+        clueUrl: "https://collaborative-learning.concord.org/authoring-iframe/index.html",
         unit: "mods",
         clueRevision: null,
         shutterbugUrl: "https://api.concord.org/shutterbug-production",

--- a/scripts/ai-harness/test/render-html.test.ts
+++ b/scripts/ai-harness/test/render-html.test.ts
@@ -60,6 +60,11 @@ describe("the iframe URL", () => {
       .toBe("http://localhost:8080/iframe.html?unit=qa&unwrapped&readOnly");
   });
 
+  it("uses a clueUrl that already names an .html page as the page itself", () => {
+    expect(iframeUrlFor("https://collaborative-learning.concord.org/authoring-iframe/index.html", "mods"))
+      .toBe("https://collaborative-learning.concord.org/authoring-iframe/index.html?unit=mods&unwrapped&readOnly");
+  });
+
   it("percent-encodes a unit given as a URL", () => {
     expect(iframeUrlFor("http://localhost:8080/", "http://127.0.0.1:5000/content.json"))
       .toBe("http://localhost:8080/iframe.html?unit=http%3A%2F%2F127.0.0.1%3A5000%2Fcontent.json" +

--- a/scripts/ai-harness/test/render-html.test.ts
+++ b/scripts/ai-harness/test/render-html.test.ts
@@ -1,5 +1,5 @@
 import {
-  escapeHtmlAttribute, escapeJsonForScript, generateRenderHtml, iframeUrlFor
+  escapeHtmlAttribute, escapeJsonForScript, generateRenderHtml, iframeUrlFor, isClueFrameUrl
 } from "../src/backends/render-html.js";
 
 /**
@@ -69,6 +69,22 @@ describe("the iframe URL", () => {
     expect(iframeUrlFor("http://localhost:8080/", "http://127.0.0.1:5000/content.json"))
       .toBe("http://localhost:8080/iframe.html?unit=http%3A%2F%2F127.0.0.1%3A5000%2Fcontent.json" +
         "&unwrapped&readOnly");
+  });
+});
+
+describe("recognising the CLUE frame", () => {
+  it("matches both the build-root and the released iframe pages", () => {
+    expect(isClueFrameUrl("http://localhost:8080/iframe.html?unit=qa&unwrapped&readOnly")).toBe(true);
+    expect(isClueFrameUrl(
+      "https://collaborative-learning.concord.org/authoring-iframe/index.html?unit=mods&unwrapped&readOnly"
+    )).toBe(true);
+    expect(isClueFrameUrl("https://collaborative-learning.concord.org/branch/master/iframe.html")).toBe(true);
+  });
+
+  it("does not match the render page or other CLUE entry points", () => {
+    expect(isClueFrameUrl("about:blank")).toBe(false);
+    expect(isClueFrameUrl("http://127.0.0.1:5000/render.html")).toBe(false);
+    expect(isClueFrameUrl("https://collaborative-learning.concord.org/index.html")).toBe(false);
   });
 });
 

--- a/scripts/ai-harness/test/shutterbug.test.ts
+++ b/scripts/ai-harness/test/shutterbug.test.ts
@@ -93,7 +93,7 @@ describe("production parity", () => {
     expect(body.height).toBe(1500);
     expect(body).not.toHaveProperty("fullPage");
     expect(body.content).toContain(
-      "https://collaborative-learning.concord.org/branch/shutterbug-support/iframe.html?unit=mods");
+      "https://collaborative-learning.concord.org/authoring-iframe/index.html?unit=mods");
     expect(body.content).toContain("&amp;unwrapped&amp;readOnly");
     // Targeted rather than a second copy of the whole page: render-html.test.ts already snapshots
     // the template, and two byte-identical snapshots meant every template change needed both

--- a/scripts/shutterbug.ts
+++ b/scripts/shutterbug.ts
@@ -10,9 +10,11 @@ import fs from "fs";
 
 import { escapeHtmlAttribute, escapeJsonForScript } from "../shared/escape-for-html";
 
-const clueCodebase = "https://collaborative-learning.concord.org/branch/shutterbug-support";
-// const clueCodebase = "http://localhost:8080";
-// const clueCodebase = "https://reimagined-journey-v6q9774jwh6pr4-4000.app.github.dev/";
+// The released CLUE build does not include a top-level iframe.html; the authoring-iframe entry
+// point is built from the same source. Branch and local builds have iframe.html directly.
+const clueIframePage = "https://collaborative-learning.concord.org/authoring-iframe/index.html";
+// const clueIframePage = "http://localhost:8080/iframe.html";
+// const clueIframePage = "https://collaborative-learning.concord.org/branch/master/iframe.html";
 
 // const shutterbugServer = "https://api.concord.org/shutterbug-production";
 // const shutterbugServer = "http://localhost:4000";
@@ -23,7 +25,7 @@ const shutterbugServer = "https://api.concord.org/shutterbug-staging";
 // targets a different CLUE build and Shutterbug server and asks for a full-page capture. Keep
 // fixes to one in step with the other until they are unified.
 function generateHtml(clueDocument: any) {
-  const source = escapeHtmlAttribute(`${clueCodebase}/iframe.html?unwrapped&readOnly`);
+  const source = escapeHtmlAttribute(`${clueIframePage}?unwrapped&readOnly`);
   return `
     <script>const initialValue=${escapeJsonForScript(JSON.stringify(clueDocument))}</script>
     <!-- height will be updated when iframe sends updateHeight message -->

--- a/scripts/shutterbug.ts
+++ b/scripts/shutterbug.ts
@@ -5,6 +5,9 @@
 //
 // Generate shutterbug.html for checking page locally:
 //   npx tsx shutterbug.ts /Users/scytacki/Development/ai/dataset1720819925834-mods/documents/document-NePawLNjq3wEjk58TiW.txt html
+//
+// Render with a specific unit (defaults to "mods"); pass "" as the second argument to skip the html output:
+//   npx tsx shutterbug.ts /path/to/document.txt "" msa
 
 import fs from "fs";
 
@@ -24,8 +27,9 @@ const shutterbugServer = "https://api.concord.org/shutterbug-staging";
 // which is the one the AI analysis pipeline actually uses. They are separate because this script
 // targets a different CLUE build and Shutterbug server and asks for a full-page capture. Keep
 // fixes to one in step with the other until they are unified.
-function generateHtml(clueDocument: any) {
-  const source = escapeHtmlAttribute(`${clueIframePage}?unwrapped&readOnly`);
+function generateHtml(clueDocument: any, unit: string) {
+  const source = escapeHtmlAttribute(
+    `${clueIframePage}?unit=${encodeURIComponent(unit)}&unwrapped&readOnly`);
   return `
     <script>const initialValue=${escapeJsonForScript(JSON.stringify(clueDocument))}</script>
     <!-- height will be updated when iframe sends updateHeight message -->
@@ -74,10 +78,13 @@ export async function postToShutterbug(body: any) {
 
 const fileName = process.argv[2];
 const outputHtml = process.argv[3];
+// Tile types are registered from the loaded unit, so the document renders correctly only with a
+// unit whose toolbar lists every tile type it uses. Defaults to production's fallback unit.
+const clueUnit = process.argv[4] || "mods";
 
 const documentString = fs.readFileSync(fileName, "utf8");
 const docObject = JSON.parse(documentString);
-const html = generateHtml(docObject);
+const html = generateHtml(docObject, clueUnit);
 
 if (outputHtml) {
   fs.writeFileSync("shutterbug.html", html);


### PR DESCRIPTION
## Summary

The AI screenshot pipeline rendered documents through the `branch/shutterbug-support` build, an old fixed snapshot of CLUE, so tiles added or changed since then did not render in the images sent to the AI. It also rendered every document with `unit=mods`, which silently drew any tile type outside that unit's toolbar as a placeholder.

## Changes

- `on-analysis-document-pending.ts` renders through the released build at `authoring-iframe/index.html` (the release workflow does not copy `iframe.html` to the top level; both are built from the same source).
- The render uses the unit from the document's Firestore metadata, falling back to `mods` when it is missing or not a plain unit code, since either would make CLUE load its default unit or show an error page that Shutterbug would capture anyway.
- `scripts/shutterbug.ts` and the ai-harness production constants, tests, and README are updated to match. `iframeUrlFor()` accepts a `clueUrl` that already names an `.html` page.

## Notes

- Requires CLUE v7.5.0 or later at the top level (it reports the rendered height from `#app` in unwrapped mode).
- Takes effect when `functions-v2` is deployed.
- Follow-up: Shutterbug has no readiness hook, so a render that never posts `documentRendered` still produces an image. Detecting that needs a change on the Shutterbug side.