### PR TITLE
CLUE-578: test the tutor's drain and fence off what a provider may write

### DIFF
--- a/functions-v2/.env.example
+++ b/functions-v2/.env.example
@@ -1,9 +1,10 @@
-# Copy to `.env` (gitignored) for local emulator runs.
+# Copy to `.env.local` (gitignored) for local emulator runs.
+#
+# `.env.local` is the file Firebase reserves for emulation and never deploys. A plain `.env` IS read
+# at deploy time and applied to the deployed functions of whichever project is selected — for
+# OPENAI_MODEL that means a local value would decide which model production calls. Use `.env.local`.
 #
 # This file is for non-secret configuration. API keys go in `.secret.local` instead — see README.md.
-#
-# Deployed environments get these values from Firebase params rather than from a `.env` in the repo,
-# so changing this file does not change staging or production.
 
 # The model chatTutorOnWrite calls. It is a defineString with no default: leave it unset and the
 # function sends `model: ""`, OpenAI 400s, and the conversation document ends up status:"error".

--- a/functions-v2/.env.example
+++ b/functions-v2/.env.example
@@ -1,0 +1,11 @@
+# Copy to `.env` (gitignored) for local emulator runs.
+#
+# This file is for non-secret configuration. API keys go in `.secret.local` instead — see README.md.
+#
+# Deployed environments get these values from Firebase params rather than from a `.env` in the repo,
+# so changing this file does not change staging or production.
+
+# The model chatTutorOnWrite calls. It is a defineString with no default: leave it unset and the
+# function sends `model: ""`, OpenAI 400s, and the conversation document ends up status:"error".
+# Every other function in this folder hard-codes its model; only the tutor reads this.
+OPENAI_MODEL=gpt-5.5

--- a/functions-v2/README.md
+++ b/functions-v2/README.md
@@ -49,7 +49,9 @@ To run `on-analysis-document-imaged.test.ts` you also need to create a `function
 
 The chat tutor (`chatTutorOnWrite`) uses its own `OPENAI_TUTOR_API_KEY` secret — a separate key under its own OpenAI project so tutor usage is tracked apart from the comments/analysis functions. It does **not** read `OPENAI_API_KEY`, so having that one set is not enough. To exercise the tutor against the local emulator, add `OPENAI_TUTOR_API_KEY=[secret_key]` to `.secret.local` as well.
 
-The tutor also reads its model from an `OPENAI_MODEL` param, which every other function hard-codes instead. It is a `defineString` with **no default**, so if you don't supply one the function sends `model: ""`, OpenAI rejects the request, and the conversation document ends up with `status: "error"`. Copy `.env.example` to `functions-v2/.env` and set a model there. `.env` is a config file rather than a secret, so it is separate from `.secret.local`; both are gitignored.
+The tutor also reads its model from an `OPENAI_MODEL` param, which every other function hard-codes instead. It is a `defineString` with **no default**, so if you don't supply one the function sends `model: ""`, OpenAI rejects the request, and the conversation document ends up with `status: "error"`. Copy `.env.example` to `functions-v2/.env.local` and set a model there. It is config rather than a secret, so it is separate from `.secret.local`; both are gitignored by the `*.local` rule.
+
+**Use `.env.local`, not `.env`.** The Firebase CLI reads `.env` at deploy time and applies its values to the deployed functions of whichever project is selected — so a local `OPENAI_MODEL` in `.env` would decide which model production calls. `.env.local` is the one Firebase reserves for emulation and never deploys.
 
 In this approach the functions are running inside of Jest and they connect to the emulated Firestore and Realtime database services.
 

--- a/functions-v2/README.md
+++ b/functions-v2/README.md
@@ -16,6 +16,10 @@ The functions are split into two folders `functions-v1` and `functions-v2`. This
 |_postDocumentComment_|Posts a comment to a document in firestore, adding metadata for the document to firestore if necessary.|
 |_postExemplarComment_|Posts a comment to a document in firestore that is labeled as being from the "exemplar user" (Ivan Idea).|
 |_createFirestoreMetadataDocument_|Checks whether a specific commentable document exists in firestore and creates it if necessary.|
+|_onClassDataDocWritten_|Summarizes a class's collected student and teacher work with an LLM whenever the scheduled task updates its document under `/aicontent`|
+|_generateClassData_|Callable. Rebuilds a class-and-unit data doc on demand, which in turn triggers _onClassDataDocWritten_. The daily scheduled task normally does this; the callable exists so development and testing don't have to wait for it|
+|_getAiContent_|Callable. Generates tile content from an LLM, given a client-supplied prompt plus the current summary of the class's work. Caches the response until the prompt or the summary changes|
+|_chatTutorOnWrite_|Answers the AI chat tutor. Watches each conversation's `messages` subcollection, and on a student message assembles the context, calls OpenAI, and writes the assistant's reply back|
 
 ## Operations
 
@@ -43,7 +47,9 @@ $ npm run test                  # run all tests in `functions` directory
 
 To run `on-analysis-document-imaged.test.ts` you also need to create a `functions-v2/.secret.local` file with `OPENAI_API_KEY=[secret_key]`. You can get the key from 1password.
 
-The chat tutor (`chatTutorOnWrite`) uses its own `OPENAI_TUTOR_API_KEY` secret — a separate key under its own OpenAI project so tutor usage is tracked apart from the comments/analysis functions. To exercise the tutor against the local emulator, add `OPENAI_TUTOR_API_KEY=[secret_key]` to `.secret.local` as well.
+The chat tutor (`chatTutorOnWrite`) uses its own `OPENAI_TUTOR_API_KEY` secret — a separate key under its own OpenAI project so tutor usage is tracked apart from the comments/analysis functions. It does **not** read `OPENAI_API_KEY`, so having that one set is not enough. To exercise the tutor against the local emulator, add `OPENAI_TUTOR_API_KEY=[secret_key]` to `.secret.local` as well.
+
+The tutor also reads its model from an `OPENAI_MODEL` param, which every other function hard-codes instead. It is a `defineString` with **no default**, so if you don't supply one the function sends `model: ""`, OpenAI rejects the request, and the conversation document ends up with `status: "error"`. Copy `.env.example` to `functions-v2/.env` and set a model there. `.env` is a config file rather than a secret, so it is separate from `.secret.local`; both are gitignored.
 
 In this approach the functions are running inside of Jest and they connect to the emulated Firestore and Realtime database services.
 
@@ -56,6 +62,8 @@ In the tests, the function cannot be imported normally. This is because the `fir
 Because the tested functions are not responding to actual changes in the databases, it is necessary for the test to construct an event object that is then passed to the wrapped function. Additionally the database needs to be setup with documents before the test. The test has to make sure the event object is in sync with what is in the database.
 
 `npm run emulator` and `npm run test:emulator` use a project name of `demo-test`. The `demo-` prefix is special and tells the emulator not to allow connections outside of itself. Without this project name being specified the emulator will use the project defined in `.firebaserc`, and will connect to the real version of any service that isn't being emulated.
+
+That isolation is what you want for jest tests and for poking at documents in the emulator UI. It is the one thing you cannot have when a **browser** is driving the functions — see "Driving the functions from a browser" below.
 
 ### Running the functions in the emulator
 
@@ -71,6 +79,32 @@ To persist state between emulator runs, `npm run emulator` loads data from `func
 ```
 firebase emulators:start --project demo-test --import=./emulator-data --export-on-exit=./emulator-data
 ```
+
+### Driving the functions from a browser
+
+Some functions can only really be exercised by the app: `chatTutorOnWrite` answers a message that the chat tutor UI writes, and you want to see the reply arrive in the sidebar.
+
+**`npm run emulator` does not work for this.** Start the emulator on the real project id instead:
+
+```shell
+npm run build
+npx firebase emulators:start --project collaborative-learning-ec215 \
+  --import=./emulator-data --export-on-exit=./emulator-data
+```
+
+Then load CLUE — from a dev server on the usual port — with the emulator params:
+
+```
+?appMode=qa&fakeClass=1&fakeUser=student:1&firestore=emulator&firebase=emulator&auth=emulator
+```
+
+For the chat tutor, add `&chatTutor` — units that don't set `chatTutorEnabled` show the launcher only when that param is present, and only for a student. Under `fakeClass=1` you also have to pick a group in the Join Group dialog before there is a document for the tutor to attach to.
+
+**Why the project id has to match.** The client always initializes Firebase with the production project id; `useEmulator()` redirects the *host* it talks to, not the project it talks about. The functions emulator registers its triggers per project, so under `--project demo-test` the browser's write lands in a namespace where no trigger is watching. Nothing errors — the write succeeds, and the function simply never runs.
+
+That failure is quiet and easy to misread: no console error, no functions log line, no change to the document. For the chat tutor it shows up as a typing indicator that spins forever, which looks exactly like a stale `lib/` from a skipped `npm run build`. If a browser-driven function seems dead, check the project id before you debug anything else.
+
+The trade-off is the one the `demo-test` note above describes: on the real project id, any service you are not emulating will be the real one. Emulate all of them (the command above starts the full suite) and keep `appMode=qa` so nothing you create lands in production data.
 
 ## To deploy firebase functions
 

--- a/functions-v2/README.md
+++ b/functions-v2/README.md
@@ -11,7 +11,7 @@ the `deploy:` scripts target, so `getAiContent` is called as `getAiContent_v2`.
 |Function|Purpose|
 |--------|-------|
 |_onUserDocWritten_|Monitors Firestore user documents for changes and updates the Firestore class documents with the networks of all of the teachers in these classes|
-|_onAnalyzableDocWritten_|Monitors Firestore user metadata for updates to documents that request AI analysis, and puts them into the analysis queue.|
+|_onAnalyzableTestDocWritten_, _onAnalyzableProdDocWritten_|Monitor Firestore user metadata for updates to documents that request AI analysis, and put them into the analysis queue. One each for the test and prod roots.|
 |_onAnalysisDocumentPending_|Monitors the queue for documents to analyze, and sends them to Shutterbug to create a screenshot of the document|
 |_onAnalysisDocumentImaged_|Sends new screenshots to ChatGPT for analysis and creates a comment on the original document|
 |_atMidnight_|Clears old Firebase roots for dev and qa instances|

--- a/functions-v2/README.md
+++ b/functions-v2/README.md
@@ -4,6 +4,10 @@ The functions are split into two folders `functions-v1` and `functions-v2`. This
 
 ## Available Functions
 
+Named below by their implementation name. Five of them are deployed under a `_v2` suffix — see the
+re-exports at the bottom of `src/index.ts` — and the suffixed name is what clients invoke and what
+the `deploy:` scripts target, so `getAiContent` is called as `getAiContent_v2`.
+
 |Function|Purpose|
 |--------|-------|
 |_onUserDocWritten_|Monitors Firestore user documents for changes and updates the Firestore class documents with the networks of all of the teachers in these classes|

--- a/functions-v2/src/chat-tutor.ts
+++ b/functions-v2/src/chat-tutor.ts
@@ -27,6 +27,7 @@ import {getFirestore} from "firebase-admin/firestore";
 
 import {CHAT_GENERIC_PROMPT} from "../../shared/chat-tutor-generic-prompt";
 import {createOpenAIClient} from "./chat/openai";
+import {createOpenAIProvider} from "./chat/openai-provider";
 import {DrainContext, acquireLock, processAndDrain, pickOwnerFields} from "./chat/drain";
 
 // Only the API key is a true secret (defineSecret). OPENAI_MODEL stays a defineString param
@@ -63,9 +64,11 @@ export const chatTutorOnWrite = functionsV1
     const ctx: DrainContext = {
       parentRef,
       messagesCol,
-      openai: createOpenAIClient(openaiKey.value()),
-      model: openaiModel.value(),
-      genericText: CHAT_GENERIC_PROMPT,
+      provider: createOpenAIProvider({
+        openai: createOpenAIClient(openaiKey.value()),
+        model: openaiModel.value(),
+        genericText: CHAT_GENERIC_PROMPT,
+      }),
     };
 
     try {

--- a/functions-v2/src/chat-tutor.ts
+++ b/functions-v2/src/chat-tutor.ts
@@ -19,8 +19,9 @@
 //     ./chat/drain.ts (firebase-admin only, so that logic is emulator-testable without
 //     firebase-functions).
 //
-// This file is deliberately thin: it owns only the trigger registration + params/secret + path
-// parsing, and delegates every Firestore/OpenAI step to ./chat/drain.
+// This file is deliberately thin: it owns the trigger registration, the params/secret, the path
+// parsing, and the choice of which backend answers. The Firestore machinery lives in ./chat/drain
+// and the OpenAI calls in ./chat/openai-provider.
 import * as functionsV1 from "firebase-functions/v1";
 import {defineSecret, defineString} from "firebase-functions/params";
 import {getFirestore} from "firebase-admin/firestore";

--- a/functions-v2/src/chat/drain.ts
+++ b/functions-v2/src/chat/drain.ts
@@ -40,6 +40,35 @@ export interface DrainContext {
 
 export {TurnResult, TutorProvider} from "./provider";
 
+// Parent-doc fields the drain owns; a provider may write anything EXCEPT these.
+//
+// The seam's promise is that Firestore machinery stays here, but a provider returns a plain field
+// map that gets merged into the parent doc, so the promise needs enforcing rather than stating.
+// The lock is the sharp edge: acquireLock proceeds on any status that is not "generating", so a
+// provider writing status:"idle" would release the lock while its own invocation is still
+// draining and let a racing trigger process the same backlog concurrently. The owner stamp is
+// what the client's owner-only read rule keys on, and the cursor decides which messages are
+// already answered.
+//
+// Providers stay free to add their own fields (a session id, an install flag) without touching
+// this file — the rule is only that they cannot touch the drain's.
+const kDrainOwnedParentFields = new Set([
+  "status", "lockedAt", "error",
+  "lastProcessedCreatedAt", "lastProcessedMessageId",
+  "uid", "context_id", "problemPath",
+]);
+
+// Throwing (rather than dropping the offending keys) is deliberate: a provider reaching for these
+// is a bug in that provider, and the catch in ../chat-tutor.ts turns this into status:"error"
+// with the cursor unadvanced, which is loud and recoverable. Silently filtering would leave the
+// provider believing it had persisted something.
+export function assertProviderOwnsFields(parentUpdate: Record<string, unknown>): void {
+  const trespassing = Object.keys(parentUpdate).filter((key) => kDrainOwnedParentFields.has(key));
+  if (trespassing.length > 0) {
+    throw new Error(`provider returned drain-owned parent fields: ${trespassing.join(", ")}`);
+  }
+}
+
 // The owner fields the client's rules require on any doc it reads — copied off the triggering
 // message onto function-written docs (assistant messages, the function-created parent). This is
 // the only channel through which the parent gets its {uid, context_id, problemPath} stamp.
@@ -73,6 +102,7 @@ async function processUnit(ctx: DrainContext, doc: MsgSnap): Promise<UnitResult>
   // turns, so a provider's seq increment can't race across invocations.
   const parent = (await parentRef.get()).data() ?? {};
   const {assistantText, parentUpdate} = await provider.processTurn(parent, data);
+  assertProviderOwnsFields(parentUpdate);
 
   // Stamp owner fields so the client's owner-only onSnapshot can read the reply; write even a
   // null-text assistant doc so the client's "awaiting" indicator clears.

--- a/functions-v2/src/chat/drain.ts
+++ b/functions-v2/src/chat/drain.ts
@@ -1,7 +1,7 @@
 // Chat-tutor drain engine — the lock + drain + per-turn processing logic, separated from the
 // trigger wiring in ../chat-tutor.ts. This module imports firebase-admin (+ the chat helpers),
 // NOT firebase-functions, so the drain/lock logic is testable against the Firestore emulator
-// with a fake OpenAI.
+// with a fake TutorProvider.
 //
 // Uses the modular firebase-admin/firestore imports (not admin.firestore.FieldValue etc.): the
 // functions emulator proxies the firebase-admin module and the namespace statics come through
@@ -11,10 +11,7 @@ import {
   Query, QueryDocumentSnapshot, getFirestore,
 } from "firebase-admin/firestore";
 
-import {
-  createOpenAIClient, createConversation, installDeveloperPrompt, createTutorResponse,
-} from "./openai";
-import {assembleTurnContext} from "./context-assembly";
+import {TutorProvider} from "./provider";
 
 // reclaim a lock whose owner crashed mid-drain, so a conversation can't wedge forever.
 // INVARIANT: STALE_LOCK_MS must exceed the function's configured timeout (default 60s, no
@@ -37,10 +34,11 @@ type MsgCol = CollectionReference;
 export interface DrainContext {
   parentRef: ParentRef;
   messagesCol: MsgCol;
-  openai: ReturnType<typeof createOpenAIClient>;
-  model: string;
-  genericText: string;
+  // which tutor backend answers a turn; the drain itself is vendor-agnostic
+  provider: TutorProvider;
 }
+
+export {TurnResult, TutorProvider} from "./provider";
 
 // The owner fields the client's rules require on any doc it reads — copied off the triggering
 // message onto function-written docs (assistant messages, the function-created parent). This is
@@ -58,60 +56,29 @@ export function pickOwnerFields(data: DocumentData | undefined): Record<string, 
 interface UnitResult {
   // written even for a userText:null reply so the client's "awaiting" indicator clears
   assistant: Record<string, unknown>;
-  // parent-doc fields to persist this turn (conversationId/problemInstalled/seq, once earned)
+  // parent-doc fields the provider earned this turn (conversation/session ids, flags, seq)
   parentUpdate: Record<string, unknown>;
 }
 
-// Process one user message: ensure the conversation + developer items exist, call OpenAI, and
-// RETURN the resulting writes (assistant doc + parent updates). The caller commits them in ONE
-// batch together with the cursor advance, so a crash between the reply and the cursor can't
-// leave a duplicate assistant doc.
+// Process one user message: hand the provider the current parent state + the message, and RETURN
+// the resulting writes (assistant doc + parent updates). The caller commits them in ONE batch
+// together with the cursor advance, so a crash between the reply and the cursor can't leave a
+// duplicate assistant doc.
 async function processUnit(ctx: DrainContext, doc: MsgSnap): Promise<UnitResult> {
-  const {parentRef, openai, model} = ctx;
+  const {parentRef, provider} = ctx;
   const data = doc.data();
   const ownerFields = pickOwnerFields(data);
 
   // Per-conversation state is read fresh each turn (no in-memory state). The lock serializes
-  // turns, so the seq increment below can't race across invocations.
+  // turns, so a provider's seq increment can't race across invocations.
   const parent = (await parentRef.get()).data() ?? {};
-  let conversationId: string | undefined = parent.conversationId;
-  if (!conversationId) {
-    // do NOT persist conversationId yet — only after the install + first response succeed.
-    conversationId = await createConversation(openai);
-  }
-  // "install once" is gated on problemInstalled (not on conversationId existing), so a crash
-  // mid-setup re-writes the developer items next turn instead of running context-blind. An
-  // empty LEFT leaves the flag unset (see context-assembly), keeping the recovery path open.
-  const turn = assembleTurnContext({
-    genericText: ctx.genericText,
-    problemInstalled: !!parent.problemInstalled,
-    parentSeq: parent.seq,
-    message: data,
-  });
-  for (const item of turn.installItems) {
-    await installDeveloperPrompt(openai, conversationId, item);
-  }
-
-  const {userText} = await createTutorResponse(openai, {model, conversationId, input: turn.input});
-
-  // only NOW (developer items written + response succeeded) is conversationId/problemInstalled/
-  // seq earned; the caller persists them (batched with the cursor) so they commit atomically.
-  const parentUpdate: Record<string, unknown> = {};
-  if (!parent.conversationId) {
-    parentUpdate.conversationId = conversationId;
-  }
-  if (turn.markProblemInstalled) {
-    parentUpdate.problemInstalled = true;
-  }
-  if (turn.seq !== undefined) {
-    parentUpdate.seq = turn.seq;
-  }
+  const {assistantText, parentUpdate} = await provider.processTurn(parent, data);
 
   // Stamp owner fields so the client's owner-only onSnapshot can read the reply; write even a
-  // userText:null assistant doc so the client's "awaiting" indicator clears.
+  // null-text assistant doc so the client's "awaiting" indicator clears.
   const assistant = {
     kind: "assistant",
-    userText,
+    userText: assistantText,
     createdAt: FieldValue.serverTimestamp(),
     ...ownerFields,
   };
@@ -186,8 +153,8 @@ export async function processAndDrain(ctx: DrainContext): Promise<void> {
     lastSnap = next;
     // commit the assistant doc + earned parent state + cursor advance in ONE batch: either all
     // land or none, so a crash between the reply and the cursor can't duplicate the assistant
-    // doc (a pre-commit crash re-processes the unit but wrote nothing — only a possible OpenAI
-    // re-bill remains, the documented replay risk).
+    // doc (a pre-commit crash re-processes the unit but wrote nothing — only a possible re-bill
+    // from the provider remains, the documented replay risk).
     const writeBatch = db.batch();
     writeBatch.set(messagesCol.doc(), assistant);
     writeBatch.set(parentRef, {

--- a/functions-v2/src/chat/drain.ts
+++ b/functions-v2/src/chat/drain.ts
@@ -1,7 +1,7 @@
 // Chat-tutor drain engine — the lock + drain + per-turn processing logic, separated from the
-// trigger wiring in ../chat-tutor.ts. This module imports firebase-admin (+ the chat helpers),
-// NOT firebase-functions, so the drain/lock logic is testable against the Firestore emulator
-// with a fake TutorProvider.
+// trigger wiring in ../chat-tutor.ts. This module imports firebase-admin and the TutorProvider
+// type, never firebase-functions, so the drain/lock logic runs against the Firestore emulator
+// with a fake provider and no trigger.
 //
 // Uses the modular firebase-admin/firestore imports (not admin.firestore.FieldValue etc.): the
 // functions emulator proxies the firebase-admin module and the namespace statics come through
@@ -38,45 +38,47 @@ export interface DrainContext {
   provider: TutorProvider;
 }
 
-export {TurnResult, TutorProvider} from "./provider";
+// The owner fields the client's rules require on any doc it reads. One list, because it feeds two
+// places that must not disagree: pickOwnerFields copies them onto function-written docs, and the
+// guard below refuses to let a provider set them. A field added here is protected in both.
+const kOwnerFields = ["uid", "context_id", "problemPath"] as const;
 
 // Parent-doc fields the drain owns; a provider may write anything EXCEPT these.
 //
-// The seam's promise is that Firestore machinery stays here, but a provider returns a plain field
-// map that gets merged into the parent doc, so the promise needs enforcing rather than stating.
-// The lock is the sharp edge: acquireLock proceeds on any status that is not "generating", so a
-// provider writing status:"idle" would release the lock while its own invocation is still
-// draining and let a racing trigger process the same backlog concurrently. The owner stamp is
-// what the client's owner-only read rule keys on, and the cursor decides which messages are
-// already answered.
+// A provider returns a plain field map that gets merged into the parent doc, so the boundary needs
+// enforcing rather than stating. The lock is the sharp edge: acquireLock proceeds on any status
+// that is not "generating", so a provider writing status:"idle" would release the lock while its
+// own invocation is still draining and let a racing trigger process the same backlog concurrently.
+// The owner stamp is what the client's owner-only read rule keys on, and the cursor decides which
+// messages are already answered.
 //
 // Providers stay free to add their own fields (a session id, an install flag) without touching
 // this file — the rule is only that they cannot touch the drain's.
-const kDrainOwnedParentFields = new Set([
+const kDrainOwnedParentFields = new Set<string>([
   "status", "lockedAt", "error",
   "lastProcessedCreatedAt", "lastProcessedMessageId",
-  "uid", "context_id", "problemPath",
+  ...kOwnerFields,
 ]);
 
 // Throwing (rather than dropping the offending keys) is deliberate: a provider reaching for these
 // is a bug in that provider, and the catch in ../chat-tutor.ts turns this into status:"error"
 // with the cursor unadvanced, which is loud and recoverable. Silently filtering would leave the
-// provider believing it had persisted something.
-export function assertProviderOwnsFields(parentUpdate: Record<string, unknown>): void {
+// provider believing it had persisted something. The message names the offending fields so a
+// production log says which provider reached where.
+function assertProviderOwnsFields(parentUpdate: Record<string, unknown>): void {
   const trespassing = Object.keys(parentUpdate).filter((key) => kDrainOwnedParentFields.has(key));
   if (trespassing.length > 0) {
     throw new Error(`provider returned drain-owned parent fields: ${trespassing.join(", ")}`);
   }
 }
 
-// The owner fields the client's rules require on any doc it reads — copied off the triggering
-// message onto function-written docs (assistant messages, the function-created parent). This is
-// the only channel through which the parent gets its {uid, context_id, problemPath} stamp.
+// Copied off the triggering message onto function-written docs (assistant messages, the
+// function-created parent). This is the only channel through which the parent gets its stamp.
 export function pickOwnerFields(data: DocumentData | undefined): Record<string, unknown> {
   const out: Record<string, unknown> = {};
-  if (data?.uid !== undefined) out.uid = data.uid;
-  if (data?.context_id !== undefined) out.context_id = data.context_id;
-  if (data?.problemPath !== undefined) out.problemPath = data.problemPath;
+  for (const field of kOwnerFields) {
+    if (data?.[field] !== undefined) out[field] = data[field];
+  }
   return out;
 }
 

--- a/functions-v2/src/chat/openai-provider.ts
+++ b/functions-v2/src/chat/openai-provider.ts
@@ -1,8 +1,7 @@
 // The OpenAI tutor backend, behind the TutorProvider seam.
 //
-// This is the code that used to be the body of drain.ts's processUnit; it is unchanged in
-// behavior, only relocated so the drain engine no longer names a vendor. Conversation state
-// lives on OpenAI and its id is carried on the parent doc.
+// Conversation state lives on OpenAI; its id is carried on the parent doc, and the drain persists
+// that id only once this returns, so a turn that fails part-way leaves nothing recorded.
 import {DocumentData} from "firebase-admin/firestore";
 
 import {assembleTurnContext} from "./context-assembly";

--- a/functions-v2/src/chat/openai-provider.ts
+++ b/functions-v2/src/chat/openai-provider.ts
@@ -1,0 +1,59 @@
+// The OpenAI tutor backend, behind the TutorProvider seam.
+//
+// This is the code that used to be the body of drain.ts's processUnit; it is unchanged in
+// behavior, only relocated so the drain engine no longer names a vendor. Conversation state
+// lives on OpenAI and its id is carried on the parent doc.
+import {DocumentData} from "firebase-admin/firestore";
+
+import {assembleTurnContext} from "./context-assembly";
+import {createConversation, createOpenAIClient, createTutorResponse, installDeveloperPrompt} from "./openai";
+import {TurnResult, TutorProvider} from "./provider";
+
+export function createOpenAIProvider(args: {
+  openai: ReturnType<typeof createOpenAIClient>;
+  model: string;
+  genericText: string;
+}): TutorProvider {
+  const {openai, model, genericText} = args;
+
+  return {
+    async processTurn(parent: DocumentData, message: DocumentData): Promise<TurnResult> {
+      let conversationId: string | undefined = parent.conversationId;
+      if (!conversationId) {
+        // do NOT report conversationId yet — only after the install + first response succeed.
+        conversationId = await createConversation(openai);
+      }
+
+      // "install once" is gated on problemInstalled (not on conversationId existing), so a crash
+      // mid-setup re-writes the developer items next turn instead of running context-blind. An
+      // empty LEFT leaves the flag unset (see context-assembly), keeping the recovery path open.
+      const turn = assembleTurnContext({
+        genericText,
+        problemInstalled: !!parent.problemInstalled,
+        parentSeq: parent.seq,
+        message,
+      });
+      for (const item of turn.installItems) {
+        await installDeveloperPrompt(openai, conversationId, item);
+      }
+
+      const {userText} = await createTutorResponse(openai, {model, conversationId, input: turn.input});
+
+      // only NOW (developer items written + response succeeded) is conversationId/
+      // problemInstalled/seq earned; the drain persists them batched with the cursor so they
+      // commit atomically.
+      const parentUpdate: Record<string, unknown> = {};
+      if (!parent.conversationId) {
+        parentUpdate.conversationId = conversationId;
+      }
+      if (turn.markProblemInstalled) {
+        parentUpdate.problemInstalled = true;
+      }
+      if (turn.seq !== undefined) {
+        parentUpdate.seq = turn.seq;
+      }
+
+      return {assistantText: userText, parentUpdate};
+    },
+  };
+}

--- a/functions-v2/src/chat/provider.ts
+++ b/functions-v2/src/chat/provider.ts
@@ -1,0 +1,21 @@
+// The contract between the drain engine and a tutor backend.
+//
+// Everything Firestore-shaped — the lock, the drain cursor, the atomic batch commit, the owner
+// fields — stays in drain.ts. A provider sees only the parent doc's current state plus the
+// triggering message, and returns what to persist. That split is what lets a second backend sit
+// alongside the OpenAI path without touching the machinery the CLUE-566 spec calls out as hard
+// to get right.
+import {DocumentData} from "firebase-admin/firestore";
+
+export interface TurnResult {
+  // The reply to write as an assistant doc. A null text still writes a doc, or the client's
+  // "awaiting reply" indicator spins forever.
+  assistantText: string | null;
+  // Parent-doc fields this turn earned (conversation/session ids, install flags, seq). The
+  // drain commits them in the same batch as the cursor, so they land atomically or not at all.
+  parentUpdate: Record<string, unknown>;
+}
+
+export interface TutorProvider {
+  processTurn(parent: DocumentData, message: DocumentData): Promise<TurnResult>;
+}

--- a/functions-v2/src/chat/provider.ts
+++ b/functions-v2/src/chat/provider.ts
@@ -1,10 +1,10 @@
 // The contract between the drain engine and a tutor backend.
 //
-// Everything Firestore-shaped — the lock, the drain cursor, the atomic batch commit, the owner
-// fields — stays in drain.ts. A provider sees only the parent doc's current state plus the
-// triggering message, and returns what to persist. That split is what lets a second backend sit
-// alongside the OpenAI path without touching the machinery the CLUE-566 spec calls out as hard
-// to get right.
+// Everything Firestore-shaped — the lock, the drain cursor, the batch commit, the owner fields —
+// stays in drain.ts, which refuses a parentUpdate that reaches for any of them. A provider sees
+// only the parent doc's current state plus the triggering message, and returns what to persist.
+// That split is what lets a second backend sit alongside the OpenAI path without touching the
+// lock and cursor machinery.
 import {DocumentData} from "firebase-admin/firestore";
 
 export interface TurnResult {

--- a/functions-v2/test/chat-drain-emulator.test.ts
+++ b/functions-v2/test/chat-drain-emulator.test.ts
@@ -1,0 +1,150 @@
+// Drain-engine tests against the Firestore emulator with a fake TutorProvider.
+//
+// These cover the machinery the CLUE-566 spec calls out as hard to get right — the drain cursor
+// and the atomic assistant-doc + parent-state + cursor commit — which had no automated coverage
+// because the only way to reach it was through the real trigger and the real OpenAI client. The
+// provider seam is what makes it reachable: the drain no longer knows which backend answered.
+//
+// Requires a FIRESTORE-ONLY emulator (npm run test:emulator). A full stack with functions loaded
+// fires the real chatTutorOnWrite trigger on these writes and corrupts state mid-run.
+import {clearFirestoreData} from "firebase-functions-test/lib/providers/firestore";
+import {DocumentData, FieldValue, getFirestore} from "firebase-admin/firestore";
+
+import {initialize, projectConfig} from "./initialize";
+import {DrainContext, TurnResult, TutorProvider, processAndDrain} from "../src/chat/drain";
+
+const {cleanup} = initialize();
+
+const kConversation = "demo/test-demo/chatTutor/conv1";
+
+// A provider that records what the drain handed it and replies with a canned script, so a test
+// can assert on both directions of the seam.
+function fakeProvider(script: TurnResult[]): TutorProvider & {calls: {parent: DocumentData, message: DocumentData}[]} {
+  const calls: {parent: DocumentData, message: DocumentData}[] = [];
+  return {
+    calls,
+    processTurn: async (parent, message) => {
+      calls.push({parent, message});
+      return script[calls.length - 1] ?? script[script.length - 1];
+    },
+  };
+}
+
+function makeCtx(provider: TutorProvider): DrainContext {
+  const parentRef = getFirestore().doc(kConversation);
+  return {parentRef, messagesCol: parentRef.collection("messages"), provider};
+}
+
+async function queueUserMessage(text: string) {
+  await getFirestore().doc(kConversation).collection("messages").add({
+    kind: "user",
+    text,
+    uid: "student-1",
+    context_id: "class-hash-1",
+    problemPath: "sas/1/1",
+    createdAt: FieldValue.serverTimestamp(),
+  });
+}
+
+async function readMessages() {
+  const snap = await getFirestore().doc(kConversation).collection("messages")
+    .orderBy("createdAt").get();
+  return snap.docs;
+}
+
+describe("processAndDrain", () => {
+  beforeEach(async () => {
+    await clearFirestoreData(projectConfig);
+  });
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  it("commits the provider's reply, the parent state it earned, and the cursor together", async () => {
+    await queueUserMessage("how do I start?");
+    const provider = fakeProvider([
+      {assistantText: "What do you notice about the sensor value?", parentUpdate: {conversationId: "conv_abc"}},
+    ]);
+
+    await processAndDrain(makeCtx(provider));
+
+    const docs = await readMessages();
+    const assistants = docs.filter((d) => d.get("kind") === "assistant");
+    expect(assistants).toHaveLength(1);
+    expect(assistants[0].get("userText")).toBe("What do you notice about the sensor value?");
+    // owner fields are copied off the triggering message, or the client's owner-filtered
+    // onSnapshot cannot read the reply at all
+    expect(assistants[0].get("uid")).toBe("student-1");
+    expect(assistants[0].get("context_id")).toBe("class-hash-1");
+
+    const parent = (await getFirestore().doc(kConversation).get()).data();
+    expect(parent?.conversationId).toBe("conv_abc");
+    expect(parent?.status).toBe("idle");
+    expect(parent?.lastProcessedMessageId).toBe(docs.find((d) => d.get("kind") === "user")?.id);
+  });
+
+  it("writes an assistant doc even when the provider declines to reply", async () => {
+    await queueUserMessage("thanks!");
+    const provider = fakeProvider([{assistantText: null, parentUpdate: {}}]);
+
+    await processAndDrain(makeCtx(provider));
+
+    // a silent reply must still land, or the client's typing indicator spins forever
+    const assistants = (await readMessages()).filter((d) => d.get("kind") === "assistant");
+    expect(assistants).toHaveLength(1);
+    expect(assistants[0].get("userText")).toBeNull();
+  });
+
+  it("hands the provider the parent state earned by earlier turns", async () => {
+    await getFirestore().doc(kConversation).set({conversationId: "conv_abc", problemInstalled: true, seq: 4});
+    await queueUserMessage("and now?");
+    const provider = fakeProvider([{assistantText: "Say more.", parentUpdate: {seq: 5}}]);
+
+    await processAndDrain(makeCtx(provider));
+
+    expect(provider.calls).toHaveLength(1);
+    expect(provider.calls[0].parent.conversationId).toBe("conv_abc");
+    expect(provider.calls[0].parent.problemInstalled).toBe(true);
+    expect(provider.calls[0].parent.seq).toBe(4);
+    expect(provider.calls[0].message.text).toBe("and now?");
+  });
+
+  it("drains a backlog in order, one provider turn per queued message", async () => {
+    await queueUserMessage("first");
+    await queueUserMessage("second");
+    await queueUserMessage("third");
+    const provider = fakeProvider([
+      {assistantText: "r1", parentUpdate: {}},
+      {assistantText: "r2", parentUpdate: {}},
+      {assistantText: "r3", parentUpdate: {}},
+    ]);
+
+    await processAndDrain(makeCtx(provider));
+
+    expect(provider.calls.map((c) => c.message.text)).toEqual(["first", "second", "third"]);
+    // each turn sees the cursor state the previous one committed
+    const parent = (await getFirestore().doc(kConversation).get()).data();
+    expect(parent?.status).toBe("idle");
+    const assistants = (await readMessages()).filter((d) => d.get("kind") === "assistant");
+    expect(assistants.map((d) => d.get("userText"))).toEqual(["r1", "r2", "r3"]);
+  });
+
+  it("leaves the cursor unadvanced and writes nothing when the provider throws", async () => {
+    await queueUserMessage("this turn fails");
+    const provider: TutorProvider = {
+      processTurn: async () => {
+        throw new Error("provider exploded");
+      },
+    };
+
+    await expect(processAndDrain(makeCtx(provider))).rejects.toThrow("provider exploded");
+
+    // the whole point of the single-batch commit: a failed turn leaves no partial state, so the
+    // next trigger re-processes the same message rather than skipping it
+    const assistants = (await readMessages()).filter((d) => d.get("kind") === "assistant");
+    expect(assistants).toHaveLength(0);
+    const parent = (await getFirestore().doc(kConversation).get()).data();
+    expect(parent?.lastProcessedMessageId).toBeUndefined();
+  });
+});

--- a/functions-v2/test/chat-drain-emulator.test.ts
+++ b/functions-v2/test/chat-drain-emulator.test.ts
@@ -130,6 +130,24 @@ describe("processAndDrain", () => {
     expect(assistants.map((d) => d.get("userText"))).toEqual(["r1", "r2", "r3"]);
   });
 
+  it("commits nothing when the parent write fails after the provider already succeeded", async () => {
+    await queueUserMessage("the turn works, the write does not");
+    // an undefined field the Firestore SDK rejects, so the parent write fails while the assistant
+    // doc and cursor in the SAME batch are already staged. Written sequentially the assistant doc
+    // would survive; batched, nothing does — which is what makes this test about atomicity rather
+    // than about failure handling.
+    const provider = fakeProvider([
+      {assistantText: "a reply that must not survive", parentUpdate: {bad: undefined as unknown as string}},
+    ]);
+
+    await expect(processAndDrain(makeCtx(provider))).rejects.toThrow();
+
+    const assistants = (await readMessages()).filter((d) => d.get("kind") === "assistant");
+    expect(assistants).toHaveLength(0);
+    const parent = (await getFirestore().doc(kConversation).get()).data();
+    expect(parent?.lastProcessedMessageId).toBeUndefined();
+  });
+
   it("leaves the cursor unadvanced and writes nothing when the provider throws", async () => {
     await queueUserMessage("this turn fails");
     const provider: TutorProvider = {

--- a/functions-v2/test/chat-drain-emulator.test.ts
+++ b/functions-v2/test/chat-drain-emulator.test.ts
@@ -1,31 +1,32 @@
-// Drain-engine tests against the Firestore emulator with a fake TutorProvider.
-//
-// These cover the machinery the CLUE-566 spec calls out as hard to get right — the drain cursor
-// and the atomic assistant-doc + parent-state + cursor commit — which had no automated coverage
-// because the only way to reach it was through the real trigger and the real OpenAI client. The
-// provider seam is what makes it reachable: the drain no longer knows which backend answered.
+// Drain-engine tests: the lock, the cursor, and the batch commit, run against the Firestore
+// emulator with a fake TutorProvider so no backend is involved.
 //
 // Requires a FIRESTORE-ONLY emulator (npm run test:emulator). A full stack with functions loaded
 // fires the real chatTutorOnWrite trigger on these writes and corrupts state mid-run.
 import {clearFirestoreData} from "firebase-functions-test/lib/providers/firestore";
-import {DocumentData, FieldValue, getFirestore} from "firebase-admin/firestore";
+import {DocumentData, FieldValue, Timestamp, getFirestore} from "firebase-admin/firestore";
 
 import {initialize, projectConfig} from "./initialize";
-import {DrainContext, TurnResult, TutorProvider, processAndDrain} from "../src/chat/drain";
+import {DrainContext, acquireLock, processAndDrain} from "../src/chat/drain";
+import {TurnResult, TutorProvider} from "../src/chat/provider";
 
 const {cleanup} = initialize();
 
 const kConversation = "demo/test-demo/chatTutor/conv1";
 
 // A provider that records what the drain handed it and replies with a canned script, so a test
-// can assert on both directions of the seam.
+// can assert on both directions of the seam. Running off the end of the script throws rather
+// than replaying the last reply, so an unexpected extra turn shows up as a failure here instead
+// of as a plausible-looking duplicate answer.
 function fakeProvider(script: TurnResult[]): TutorProvider & {calls: {parent: DocumentData, message: DocumentData}[]} {
   const calls: {parent: DocumentData, message: DocumentData}[] = [];
   return {
     calls,
     processTurn: async (parent, message) => {
       calls.push({parent, message});
-      return script[calls.length - 1] ?? script[script.length - 1];
+      const reply = script[calls.length - 1];
+      if (!reply) throw new Error(`fakeProvider called ${calls.length} times, script has ${script.length}`);
+      return reply;
     },
   };
 }
@@ -52,15 +53,16 @@ async function readMessages() {
   return snap.docs;
 }
 
+// file-scoped: cleanup() deletes the Firebase app, so it must not run between describe blocks
+beforeEach(async () => {
+  await clearFirestoreData(projectConfig);
+});
+
+afterAll(async () => {
+  await cleanup();
+});
+
 describe("processAndDrain", () => {
-  beforeEach(async () => {
-    await clearFirestoreData(projectConfig);
-  });
-
-  afterAll(async () => {
-    await cleanup();
-  });
-
   it("commits the provider's reply, the parent state it earned, and the cursor together", async () => {
     await queueUserMessage("how do I start?");
     const provider = fakeProvider([
@@ -122,12 +124,31 @@ describe("processAndDrain", () => {
 
     await processAndDrain(makeCtx(provider));
 
+    // the provider call order is the authoritative statement about ordering; the assistant docs
+    // share a serverTimestamp() and are read back by createdAt alone, so their relative order is
+    // not something this test can pin
     expect(provider.calls.map((c) => c.message.text)).toEqual(["first", "second", "third"]);
-    // each turn sees the cursor state the previous one committed
     const parent = (await getFirestore().doc(kConversation).get()).data();
     expect(parent?.status).toBe("idle");
     const assistants = (await readMessages()).filter((d) => d.get("kind") === "assistant");
-    expect(assistants.map((d) => d.get("userText"))).toEqual(["r1", "r2", "r3"]);
+    expect(assistants.map((d) => d.get("userText")).sort()).toEqual(["r1", "r2", "r3"]);
+  });
+
+  it("resumes at the persisted cursor instead of re-answering the backlog", async () => {
+    await queueUserMessage("first");
+    await processAndDrain(makeCtx(fakeProvider([{assistantText: "r1", parentUpdate: {}}])));
+
+    await queueUserMessage("second");
+    // a fresh provider whose script holds exactly one reply: if the drain re-read from the top it
+    // would ask for a second turn and the script would throw. This is the behavior that stops a
+    // re-trigger from re-answering — and re-billing — the whole backlog.
+    const resumed = fakeProvider([{assistantText: "r2", parentUpdate: {}}]);
+    await processAndDrain(makeCtx(resumed));
+
+    expect(resumed.calls).toHaveLength(1);
+    expect(resumed.calls[0].message.text).toBe("second");
+    const assistants = (await readMessages()).filter((d) => d.get("kind") === "assistant");
+    expect(assistants).toHaveLength(2);
   });
 
   it("refuses a provider that tries to release the drain's lock", async () => {
@@ -137,30 +158,33 @@ describe("processAndDrain", () => {
     // concurrent drain of the same backlog.
     const provider = fakeProvider([{assistantText: "reply", parentUpdate: {status: "idle"}}]);
 
-    await expect(processAndDrain(makeCtx(provider))).rejects.toThrow(/drain-owned/);
+    await expect(processAndDrain(makeCtx(provider))).rejects.toThrow(/drain-owned parent fields: status/);
 
     const assistants = (await readMessages()).filter((d) => d.get("kind") === "assistant");
     expect(assistants).toHaveLength(0);
   });
 
   it("refuses a provider that tries to restamp the owner fields", async () => {
+    // seed the owner stamp so the assertion below has something to defend: the owner stamp is
+    // what the client's owner-only read rule keys on, and letting a provider set it would
+    // re-point a conversation at another user.
+    await getFirestore().doc(kConversation).set({uid: "student-1"});
     await queueUserMessage("a provider reaching further");
-    // the owner stamp is what the client's owner-only read rule keys on; letting a provider set
-    // it would re-point a conversation at another user.
     const provider = fakeProvider([{assistantText: "reply", parentUpdate: {uid: "someone-else"}}]);
 
-    await expect(processAndDrain(makeCtx(provider))).rejects.toThrow(/drain-owned/);
+    await expect(processAndDrain(makeCtx(provider))).rejects.toThrow(/drain-owned parent fields: uid/);
 
     const parent = (await getFirestore().doc(kConversation).get()).data();
-    expect(parent?.uid).not.toBe("someone-else");
+    expect(parent?.uid).toBe("student-1");
   });
 
   it("commits nothing when the parent write fails after the provider already succeeded", async () => {
     await queueUserMessage("the turn works, the write does not");
-    // an undefined field the Firestore SDK rejects, so the parent write fails while the assistant
-    // doc and cursor in the SAME batch are already staged. Written sequentially the assistant doc
-    // would survive; batched, nothing does — which is what makes this test about atomicity rather
-    // than about failure handling.
+    // an undefined field the SDK rejects. WriteBatch.set() validates synchronously, so this
+    // throws while the batch is being assembled and commit() is never reached — nothing the
+    // drain staged reaches Firestore. What that pins is that the assistant doc is staged rather
+    // than written eagerly: the same provider against a drain that wrote sequentially would
+    // leave the reply behind.
     const provider = fakeProvider([
       {assistantText: "a reply that must not survive", parentUpdate: {bad: undefined as unknown as string}},
     ]);
@@ -189,5 +213,49 @@ describe("processAndDrain", () => {
     expect(assistants).toHaveLength(0);
     const parent = (await getFirestore().doc(kConversation).get()).data();
     expect(parent?.lastProcessedMessageId).toBeUndefined();
+  });
+});
+
+describe("acquireLock", () => {
+  const ownerFields = {uid: "student-1", context_id: "class-hash-1", problemPath: "sas/1/1"};
+  const parentRef = () => getFirestore().doc(kConversation);
+
+  it("admits the first caller and turns the next one away", async () => {
+    expect(await acquireLock(parentRef(), ownerFields)).toBe(true);
+
+    // single-in-flight: while the first invocation is still draining, a second trigger for the
+    // same conversation must back off rather than drain the same backlog alongside it
+    expect(await acquireLock(parentRef(), ownerFields)).toBe(false);
+  });
+
+  it("stamps the owner fields when it creates the parent, so the client can read status", async () => {
+    await acquireLock(parentRef(), ownerFields);
+
+    const parent = (await parentRef().get()).data();
+    expect(parent?.status).toBe("generating");
+    expect(parent?.uid).toBe("student-1");
+    expect(parent?.context_id).toBe("class-hash-1");
+  });
+
+  it("reclaims a lock whose owner crashed mid-drain", async () => {
+    // STALE_LOCK_MS is 5 minutes; a lock older than that belongs to an invocation that died
+    // without releasing it, and refusing to reclaim would wedge the conversation permanently
+    await parentRef().set({
+      status: "generating",
+      lockedAt: Timestamp.fromMillis(Date.now() - 6 * 60 * 1000),
+      ...ownerFields,
+    });
+
+    expect(await acquireLock(parentRef(), ownerFields)).toBe(true);
+  });
+
+  it("does not reclaim a lock that is merely recent", async () => {
+    await parentRef().set({
+      status: "generating",
+      lockedAt: Timestamp.fromMillis(Date.now() - 30 * 1000),
+      ...ownerFields,
+    });
+
+    expect(await acquireLock(parentRef(), ownerFields)).toBe(false);
   });
 });

--- a/functions-v2/test/chat-drain-emulator.test.ts
+++ b/functions-v2/test/chat-drain-emulator.test.ts
@@ -130,6 +130,31 @@ describe("processAndDrain", () => {
     expect(assistants.map((d) => d.get("userText"))).toEqual(["r1", "r2", "r3"]);
   });
 
+  it("refuses a provider that tries to release the drain's lock", async () => {
+    await queueUserMessage("a provider overreaching");
+    // status is drain-owned: acquireLock proceeds on anything that is not "generating", so a
+    // provider writing status:"idle" mid-drain would let a racing trigger start a second
+    // concurrent drain of the same backlog.
+    const provider = fakeProvider([{assistantText: "reply", parentUpdate: {status: "idle"}}]);
+
+    await expect(processAndDrain(makeCtx(provider))).rejects.toThrow(/drain-owned/);
+
+    const assistants = (await readMessages()).filter((d) => d.get("kind") === "assistant");
+    expect(assistants).toHaveLength(0);
+  });
+
+  it("refuses a provider that tries to restamp the owner fields", async () => {
+    await queueUserMessage("a provider reaching further");
+    // the owner stamp is what the client's owner-only read rule keys on; letting a provider set
+    // it would re-point a conversation at another user.
+    const provider = fakeProvider([{assistantText: "reply", parentUpdate: {uid: "someone-else"}}]);
+
+    await expect(processAndDrain(makeCtx(provider))).rejects.toThrow(/drain-owned/);
+
+    const parent = (await getFirestore().doc(kConversation).get()).data();
+    expect(parent?.uid).not.toBe("someone-else");
+  });
+
   it("commits nothing when the parent write fails after the provider already succeeded", async () => {
     await queueUserMessage("the turn works, the write does not");
     // an undefined field the Firestore SDK rejects, so the parent write fails while the assistant

--- a/functions-v2/test/chat-openai-provider.test.ts
+++ b/functions-v2/test/chat-openai-provider.test.ts
@@ -1,12 +1,10 @@
-// Tests for the OpenAI tutor backend behind the TutorProvider seam.
+// Tests for the OpenAI tutor backend behind the TutorProvider seam: conversation creation,
+// install-once, the rule that parent state is earned only after a successful response, and the
+// conversation id and model actually reaching the OpenAI call.
 //
-// The drain suite injects a fake provider, which is what makes the drain testable — but it also
-// means nothing there exercises this adapter. These cover the boundary the refactor moved:
-// conversation creation, install-once, and the rule that parent state is earned only after a
-// successful response.
-//
-// The OpenAI module is mocked because the alternative is billing a real API call; every assertion
-// that can be made against the returned TurnResult is made there rather than against the mocks.
+// The OpenAI module is mocked because the alternative is billing a real API call. Assertions
+// prefer the returned TurnResult; the mocks are inspected only where the behavior is a call the
+// provider is supposed to make.
 import {createOpenAIProvider} from "../src/chat/openai-provider";
 import * as openai from "../src/chat/openai";
 
@@ -57,6 +55,12 @@ describe("createOpenAIProvider", () => {
     // an already-persisted conversationId is not re-reported
     expect(result.parentUpdate.conversationId).toBeUndefined();
     expect(result.parentUpdate.problemInstalled).toBeUndefined();
+    // the parent's conversation and the configured model are what reach OpenAI — the two pieces
+    // of plumbing the seam carries that the TurnResult cannot show
+    expect(createTutorResponse).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({conversationId: "conv_existing", model: "test-model"})
+    );
   });
 
   it("leaves problemInstalled unset when LEFT is empty, keeping the recovery path open", async () => {

--- a/functions-v2/test/chat-openai-provider.test.ts
+++ b/functions-v2/test/chat-openai-provider.test.ts
@@ -1,0 +1,99 @@
+// Tests for the OpenAI tutor backend behind the TutorProvider seam.
+//
+// The drain suite injects a fake provider, which is what makes the drain testable — but it also
+// means nothing there exercises this adapter. These cover the boundary the refactor moved:
+// conversation creation, install-once, and the rule that parent state is earned only after a
+// successful response.
+//
+// The OpenAI module is mocked because the alternative is billing a real API call; every assertion
+// that can be made against the returned TurnResult is made there rather than against the mocks.
+import {createOpenAIProvider} from "../src/chat/openai-provider";
+import * as openai from "../src/chat/openai";
+
+jest.mock("../src/chat/openai");
+
+const createConversation = openai.createConversation as jest.MockedFunction<typeof openai.createConversation>;
+const installDeveloperPrompt =
+  openai.installDeveloperPrompt as jest.MockedFunction<typeof openai.installDeveloperPrompt>;
+const createTutorResponse = openai.createTutorResponse as jest.MockedFunction<typeof openai.createTutorResponse>;
+
+const kGeneric = "GENERIC TUTOR PROMPT";
+const kLeft = JSON.stringify({sections: [{type: "introduction", title: "1.1", content: "{}"}]});
+
+function provider() {
+  return createOpenAIProvider({openai: {} as never, model: "test-model", genericText: kGeneric});
+}
+
+// the prompt text each installDeveloperPrompt call carried, in order
+function installedItems() {
+  return installDeveloperPrompt.mock.calls.map((call) => call[2]);
+}
+
+describe("createOpenAIProvider", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    createConversation.mockResolvedValue("conv_new");
+    createTutorResponse.mockResolvedValue({userText: "What do you notice about the sensor?"});
+  });
+
+  it("creates a conversation and installs the prompt and problem on a first turn", async () => {
+    const result = await provider().processTurn({}, {text: "how do I start?", leftContext: kLeft});
+
+    expect(result.assistantText).toBe("What do you notice about the sensor?");
+    expect(result.parentUpdate.conversationId).toBe("conv_new");
+    expect(result.parentUpdate.problemInstalled).toBe(true);
+    expect(installedItems()).toHaveLength(2);
+    expect(installedItems()[0]).toBe(kGeneric);
+    expect(installedItems()[1]).toContain(kLeft);
+  });
+
+  it("reuses the parent's conversation and skips the install once the problem is flagged", async () => {
+    const parent = {conversationId: "conv_existing", problemInstalled: true};
+
+    const result = await provider().processTurn(parent, {text: "and now?", leftContext: kLeft});
+
+    expect(createConversation).not.toHaveBeenCalled();
+    expect(installedItems()).toHaveLength(0);
+    // an already-persisted conversationId is not re-reported
+    expect(result.parentUpdate.conversationId).toBeUndefined();
+    expect(result.parentUpdate.problemInstalled).toBeUndefined();
+  });
+
+  it("leaves problemInstalled unset when LEFT is empty, keeping the recovery path open", async () => {
+    const result = await provider().processTurn({}, {text: "hi", leftContext: JSON.stringify({sections: []})});
+
+    // the generic prompt still installs; the problem does not, so a later turn re-attaches LEFT
+    expect(installedItems()).toEqual([kGeneric]);
+    expect(result.parentUpdate.problemInstalled).toBeUndefined();
+    expect(result.parentUpdate.conversationId).toBe("conv_new");
+  });
+
+  it("increments the parent's seq when a workspace refresh rides the turn", async () => {
+    const result = await provider().processTurn(
+      {conversationId: "conv_existing", problemInstalled: true, seq: 4},
+      {text: "look at this", rightContext: "# workspace"}
+    );
+
+    expect(result.parentUpdate.seq).toBe(5);
+  });
+
+  it("earns no parent state when the response fails", async () => {
+    createTutorResponse.mockRejectedValue(new Error("openai 500"));
+
+    await expect(provider().processTurn({}, {text: "hi", leftContext: kLeft}))
+      .rejects.toThrow("openai 500");
+
+    // the conversation was created, but the caller gets nothing to persist — so the next turn
+    // re-creates rather than recording a conversation whose first response never landed
+    expect(createConversation).toHaveBeenCalled();
+  });
+
+  it("earns no parent state when the prompt install fails", async () => {
+    installDeveloperPrompt.mockRejectedValue(new Error("install failed"));
+
+    await expect(provider().processTurn({}, {text: "hi", leftContext: kLeft}))
+      .rejects.toThrow("install failed");
+
+    expect(createTutorResponse).not.toHaveBeenCalled();
+  });
+});

--- a/specs/CLUE-566-ai-chat-tutor.md
+++ b/specs/CLUE-566-ai-chat-tutor.md
@@ -416,10 +416,14 @@ ran against the requirements, and three against the implementation plan. The sig
 **Process / testing**
 - Parent conversation doc is created server-side by `acquireLock`; the client writes only message
   docs; the client parent-create rule is defensive (D-1).
-- Trigger/drain behavior is manual/observational for the spike — the rules harness can't run
-  triggers and the functions harness bypasses rules; automated coverage is the rules suite, the
-  pure `decideContext`/context-assembly unit tests, and the promoted focus-trap contract test
+- Trigger behavior is manual/observational for the spike — the rules harness can't run triggers
+  and the functions harness bypasses rules; automated coverage is the rules suite, the pure
+  `decideContext`/context-assembly unit tests, and the promoted focus-trap contract test
   (D-3/QA-1..5). A formal DoD checklist was declined by the project owner (PM finding, IC-6).
+  *(Superseded for the drain: extracting the provider seam made the lock, the cursor and the
+  batch commit reachable without the trigger or a real backend, and they are now covered by
+  `functions-v2/test/chat-drain-emulator.test.ts` against a firestore-only emulator with a fake
+  provider. The trigger wiring itself remains observational.)*
 - PII-to-OpenAI elevated to the headline risk: test accounts only; real-student piloting gated on
   the FERPA/PII + retention review.
 
@@ -427,7 +431,8 @@ ran against the requirements, and three against the implementation plan. The sig
 
 - Jest: client suites (chat-tutor modules, app-config, authoring page), `functions-v2`
   context-assembly suite, and the `firebase-test` chat rules suite (28 cases; firestore-only
-  emulator, serial jest).
+  emulator, serial jest). Later joined by the `functions-v2` drain and OpenAI-provider suites,
+  which cover the lock, the drain cursor and the batch commit directly.
 - Live emulator validation of the chat round-trip, lock behavior, and error path; browser
   (Playwright) validation of the authoring flow, draft preview, prompt append/replace, and
   fresh-conversation-on-edit (2026-07-09).


### PR DESCRIPTION
## Test the machinery the tutor's reliability rests on

**Before:** `functions-v2/src/chat/drain.ts` owns the per-conversation lock, the drain cursor, and the atomic commit that keeps a crashed turn from duplicating or losing a reply. None of it had a single automated test. The only way in was the real Firestore trigger driving the real OpenAI client, which is why the CLUE-566 spec recorded the lock and drain as observational rather than tested — a line this PR makes false, and amends.

**After:** thirteen tests exercise that machinery against the Firestore emulator with a fake backend — the atomic reply-plus-state-plus-cursor commit, a declined reply, parent state reaching the backend, backlog ordering, that a failed turn leaves nothing behind, that a failed *write* leaves nothing behind either, and that a provider reaching for the lock or the owner stamp is refused.

What made them possible is a seam. `processUnit` reached OpenAI directly, so any test of the drain had to bring OpenAI with it. Now the drain hands a `TutorProvider` the parent doc's current state plus the triggering message, and gets back the reply text and whatever parent fields the turn earned. Everything Firestore-shaped stays in `drain.ts` — enforced, not just intended: a `parentUpdate` carrying a drain-owned field is rejected rather than merged.

## Why now

ForeverLearning is a candidate second backend for the chat tutor (CLUE-578), and this is the half of that spike that doesn't depend on them. It is also the half worth keeping if the spike goes nowhere: the coverage above is about the tutor we already ship.

Adding a `ForeverLearningProvider` later is one new file plus one line in `chat-tutor.ts`. Nothing in the lock, drain, cursor, or batch commit has to move again.

## Behavior is unchanged

`conversationId` is still withheld until the developer-item install and the response both succeed. `problemInstalled` is still gated on the flag rather than on a conversation existing, so a crash mid-setup re-installs instead of running context-blind. A null reply still writes an assistant doc so the client stops waiting on it. The OpenAI code changed file, not behavior.

## One decision worth a look

`TurnResult.assistantText` is a single value, not a list. A list only helps if ForeverLearning's session-init greeting and its first real answer become two assistant docs — and two docs committed in one batch share a `serverTimestamp()`, so their order would fall to random doc ids. Merging them into one doc sidesteps that entirely and is the current plan. If the FL work proves otherwise, widening this is small.

## Two documentation commits rescued from `ai-highlights`

**Both have already been reviewed — only the middle commit needs your attention.** `ffd6720a0` and `f9ca5d475` are verbatim cherry-picks (`-x`) of 9fd87ff and c07184075, both reviewed and approved as part of #2972. They are unchanged here, and today they live only on the `ai-highlights` spike branch. They are kept as two commits rather than squashed so they stay identical to what was reviewed there — which is also why the second one reads as fixing the first.

The first documents that `npm run emulator`'s `--project demo-test` cannot work when a browser drives the functions, and the tutor's two quietly-failing config requirements — it reads `OPENAI_TUTOR_API_KEY`, not the `OPENAI_API_KEY` the 1Password pointer names, and `OPENAI_MODEL` is a `defineString` with no default. It adds `.env.example` and backfills four functions the Available Functions table had fallen behind on.

The second corrects where that local config goes: `.env.local`, not `.env`. The Firebase CLI reads `.env` at deploy time and applies its values to the deployed functions of whichever project is selected, so a developer's local `OPENAI_MODEL` in `.env` would decide which model production calls. `.env.local` is the file Firebase reserves for emulation and never deploys.

`ai-highlights` is open-ended pending stakeholder testing. Instructions everyone needs shouldn't wait on that decision, or vanish if it goes the other way. Once this merges, master can be merged into `ai-highlights`, so that branch carries only its own changes when its time comes.

## Not addressed here: what the deployed tutor model actually is

This PR changes no deploy-time configuration, deliberately. But the port comparison surfaced a gap worth naming, and CLUE-659 tracks it.

`OPENAI_MODEL` is a `defineString` resolved at deploy time, and nothing in this repo records its value for staging or production. report-service — where this backend came from — commits `functions/.env.report-service-dev` and `functions/.env.report-service-pro`, both carrying `OPENAI_MODEL=gpt-5.5`, and its `chat/openai.ts` records that the tutor was verified end to end against that model. CLUE committed no equivalent files, so the deployed value is whatever the last deploy happened to supply, and it cannot be read from source.

That gap already produced a concrete ambiguity. CLUE's analysis functions hardcode `gpt-4o-mini` (`get-ai-content.ts:19`, `on-class-data-doc-written.ts:14`), while the tutor's model is the unrecorded param — so a report that "production is using gpt-4o-mini" is automatically true of the analysis functions, and says nothing about the tutor either way.

**Resolved in review, and it was not academic.** The tutor was deployed against `gpt-5.5` to match report-service, and no move away from it was intended. The functions were then released with `OPENAI_MODEL=gpt-4o-mini`, so production is currently running a tutor model change that nobody meant to make. Nothing in this PR causes or fixes that — it is named here because the same missing convention is what let it happen quietly. CLUE-659 covers committing the per-project files, which would have made a change like that arrive as a reviewable diff rather than something reconstructed afterwards.

## Testing

`npm test` in `functions-v2` is 114 passed across 18 suites, run the way CI runs it:

```
npx firebase emulators:exec --only firestore,database --project demo-test "npm test"
```

`OPENAI_API_KEY=dummy` is required, as in the workflow; without it `on-analysis-document-imaged.test.ts` fails locally for reasons unrelated to this branch.

Nineteen of those tests are new: nine against the drain and four against acquireLock, both with a fake provider, and six against the OpenAI adapter with the OpenAI module mocked. Each was checked against deliberately broken code rather than trusted for passing —

- corrupting the assistant doc's `kind` fails three drain tests
- blanking the parent state before the provider sees it fails another
- replacing the single batch with two sequential `set()` calls fails the atomicity test, and nothing else in the suite
- emptying the prompt-install loop fails three provider tests
- always reporting `conversationId` fails the one that pins it
- removing the drain-owned-field guard fails the two tests that pin the provider boundary
- ignoring the persisted cursor on resume fails the test that stops a re-trigger re-answering the backlog
- making the lock never refuse fails two of the acquireLock tests; widening the stale window fails a third
- forwarding a wrong conversation id to OpenAI fails the provider test that pins the plumbing

Three review rounds shaped the last three commits. Two Copilot passes at Balanced effort came first: one found that the adapter the refactor moved had no tests of its own and that the original atomicity assertions would have been satisfied by three sequential writes; the other found that `parentUpdate` let a provider write drain-owned fields — releasing the lock mid-drain, among other things — so the seam's boundary is now enforced rather than merely stated.

Doug's review then found the three that mattered most, each a behavior no test could fail on: the persisted-cursor resume (stub it and every drain test stayed green, while a re-trigger would re-answer and re-bill a whole backlog), `acquireLock` having no test at all despite this description claiming the lock was covered, and an owner-field assertion that was true by construction. Comments not acted on are answered in their threads.
