### PR TITLE
fix: harness catch up with drawing summary changes (CLUE-371)

### DIFF
--- a/scripts/ai-harness/README.md
+++ b/scripts/ai-harness/README.md
@@ -183,7 +183,7 @@ A production corpus arrives in three steps, and the third one is not optional:
 `represent` writes an envelope per (document, variant):
 
 ```json
-{ "schemaVersion": 1, "docId": "…", "variantId": "default", "variantVersion": 1,
+{ "schemaVersion": 1, "docId": "…", "variantId": "default", "variantVersion": 2,
   "sourceContentSha256": "…", "generatedAt": "…", "markdown": "…" }
 ```
 
@@ -191,9 +191,11 @@ Staleness is decided by the envelope, not by the file existing: a representation
 `sourceContentSha256` and `variantVersion` both still match. Each variant in `src/represent-text.ts`
 exports a `variantVersion` that is bumped whenever its output would change for the same input.
 
-Every text variant is at version 2, which is the summarizer as CLUE-646 left it: each tile carries a
-"This tile's id is …" line, and a Drawing tile is summarized as a table of its objects. Version 1 is
-the summarizer before that change, which is what the recorded runs further down this file used.
+Every text variant is at version 2 and carries CLUE-646's "This tile's id is …" line. The three that
+use production's Drawing handler — `default`, `minimal` and `no-dataset-tables` — also summarize a
+Drawing tile as a table of its objects; `drawing-text` replaces that handler with its own prototype
+serializer and so does not. Version 1 is the summarizer before those changes, which is what the
+recorded runs further down this file used.
 
 | Variant | What it sends |
 |---|---|
@@ -1020,7 +1022,9 @@ Milestone 1 (against
    derives that requirement from the handler tier (`full` or `partial`), but two fixtures have no
    place to put a marker the handler would emit: the placeholder handler returns an empty string, and
    the empty document is intentionally contentless. The flag defaults to the tier rule and is set
-   explicitly (with a `notes` line) where it cannot hold.
+   explicitly (with a `notes` line) where it cannot hold. The `drawing` fixture was a third such case
+   while its handler was a stub; that exemption is gone, because the handler now emits a table of the
+   drawing's objects and the fixture's marker is one of those object ids.
 7. **`historical` gained an optional `contentSha256`.** The spec fixes the historical record's shape
    without a hash of the input it ran against, which makes the "never compare unless the content hash
    matches" rule unenforceable. `historicalIsComparable` requires that field, so a record without it

--- a/scripts/ai-harness/README.md
+++ b/scripts/ai-harness/README.md
@@ -191,16 +191,22 @@ Staleness is decided by the envelope, not by the file existing: a representation
 `sourceContentSha256` and `variantVersion` both still match. Each variant in `src/represent-text.ts`
 exports a `variantVersion` that is bumped whenever its output would change for the same input.
 
+Every text variant is at version 2, which is the summarizer as CLUE-646 left it: each tile carries a
+"This tile's id is …" line, and a Drawing tile is summarized as a table of its objects. Version 1 is
+the summarizer before that change, which is what the recorded runs further down this file used.
+
 | Variant | What it sends |
 |---|---|
 | `default` | `documentSummarizer(content, {})` — what production produces. |
 | `minimal` | No boilerplate, headers or row/column structure: the text content and nothing else. |
 | `no-dataset-tables` | `default`, with each data set's *case data* left out. The heading, attributes table, formulas and case count stay, so the shape of the data is still described. A large table can be most of a document's summary, and whether a model needs the rows to categorize a design is worth measuring rather than assuming. |
-| `drawing-text` | `default`, with drawings **described** instead of merely mentioned: each object's type, position and size, and any text object's own text. The default handler says "This tile contains a drawing" and stops, so a text run otherwise learns nothing about what was drawn — including text a student typed *inside* a drawing, which no other text variant carries. |
+| `drawing-text` | `default`, with drawings described by the harness's own prototype serializer: each object's type, position and size, and any text object's own text. Written when the production handler said "This tile contains a drawing" and stopped. Production's `default` now emits a table of the drawing's objects instead (CLUE-646), so this is the earlier prototype, kept so the runs recorded with it stay comparable. |
 
 `drawing-text` is a measurement prototype, not a good description: it reports geometry and does not
 interpret it, because interpreting the picture is what the model is being measured on. Beating it is
-the point, and a new variant is how someone shows they have.
+the point, and a new variant is how someone shows they have. It is no longer the only text variant
+that carries what a student drew — `default` describes a drawing too, in a different shape — but it
+is what the recorded runs below were produced with.
 
 **A text run reaches it only on a document that carries student text elsewhere**, which today means
 the geometry half is barely exercised. Skip-empty asks the classifier whether any tile holds

--- a/scripts/ai-harness/README.md
+++ b/scripts/ai-harness/README.md
@@ -200,7 +200,7 @@ recorded runs further down this file used.
 | Variant | What it sends |
 |---|---|
 | `default` | `documentSummarizer(content, {})` — what production produces. |
-| `minimal` | No boilerplate, headers or row/column structure: the text content and nothing else. |
+| `minimal` | No boilerplate explanations, and no row or column structure: the section and tile summaries and nothing else. Each tile is summarized by the handler `default` uses, so a Drawing tile still arrives as the whole object table — `drawingToTable` does not read the `minimal` option, which is a gap in the summarizer rather than a choice this variant makes. |
 | `no-dataset-tables` | `default`, with each data set's *case data* left out. The heading, attributes table, formulas and case count stay, so the shape of the data is still described. A large table can be most of a document's summary, and whether a model needs the rows to categorize a design is worth measuring rather than assuming. |
 | `drawing-text` | `default`, with drawings described by the harness's own prototype serializer: each object's type, position and size, and any text object's own text. Written when the production handler said "This tile contains a drawing" and stopped. Production's `default` now emits a table of the drawing's objects instead (CLUE-646), so this is the earlier prototype, kept so the runs recorded with it stay comparable. |
 

--- a/scripts/ai-harness/examples/synthetic-corpus/documents/drawing.json
+++ b/scripts/ai-harness/examples/synthetic-corpus/documents/drawing.json
@@ -21,6 +21,7 @@
         "fixtureMarker": "drawing-fixture-marker",
         "objects": [
           {
+            "id": "drawing-rect-1",
             "type": "rectangle",
             "x": 10,
             "y": 10,
@@ -32,6 +33,7 @@
             "strokeDashArray": "solid"
           },
           {
+            "id": "drawing-ellipse-1",
             "type": "ellipse",
             "x": 160,
             "y": 40,

--- a/scripts/ai-harness/examples/synthetic-corpus/documents/mixed.json
+++ b/scripts/ai-harness/examples/synthetic-corpus/documents/mixed.json
@@ -38,6 +38,7 @@
         "type": "Drawing",
         "objects": [
           {
+            "id": "mixed-rect-1",
             "type": "rectangle",
             "x": 5,
             "y": 5,
@@ -49,6 +50,7 @@
             "strokeDashArray": "solid"
           },
           {
+            "id": "mixed-text-1",
             "type": "text",
             "x": 12,
             "y": 60,

--- a/scripts/ai-harness/examples/synthetic-corpus/expectations.json
+++ b/scripts/ai-harness/examples/synthetic-corpus/expectations.json
@@ -107,7 +107,7 @@
         "requiresVisualRepresentation": true
       },
       "handlerTier": "full",
-      "notes": "No text objects, so the instance-level check keeps containsStudentText false. The production handler now emits a table of the drawing's objects, so the marker the default summary must carry is one of those object ids — the first column of that table — rather than a string in the tile's own content."
+      "notes": "No text objects, so the instance-level check keeps containsStudentText false. The production handler now emits a table of the drawing's objects, so the marker the default summary must carry is one of those object ids — the first column of that table. This is the one fixture whose distinctiveString is therefore not its tile's fixtureMarker, which no summarizer emits."
     },
     "empty": {
       "expectDistinctiveInDefaultSummary": false,

--- a/scripts/ai-harness/examples/synthetic-corpus/expectations.json
+++ b/scripts/ai-harness/examples/synthetic-corpus/expectations.json
@@ -94,10 +94,10 @@
       "handlerTier": "fallback"
     },
     "drawing": {
-      "expectDistinctiveInDefaultSummary": false,
+      "expectDistinctiveInDefaultSummary": true,
       "defaultSummaryMustSucceed": true,
       "minimalSummaryMustSucceed": true,
-      "distinctiveString": "drawing-fixture-marker",
+      "distinctiveString": "drawing-rect-1",
       "computedModality": "visual-only",
       "tileTypes": [
         "Drawing"
@@ -107,7 +107,7 @@
         "requiresVisualRepresentation": true
       },
       "handlerTier": "full",
-      "notes": "No text objects, so the instance-level check keeps containsStudentText false. The production handler describes the drawing as a table of its objects, one row each; the objects carry ids so that table's first column has something to print."
+      "notes": "No text objects, so the instance-level check keeps containsStudentText false. The production handler now emits a table of the drawing's objects, so the marker the default summary must carry is one of those object ids — the first column of that table — rather than a string in the tile's own content."
     },
     "empty": {
       "expectDistinctiveInDefaultSummary": false,

--- a/scripts/ai-harness/examples/synthetic-corpus/expectations.json
+++ b/scripts/ai-harness/examples/synthetic-corpus/expectations.json
@@ -106,8 +106,8 @@
         "containsStudentText": false,
         "requiresVisualRepresentation": true
       },
-      "handlerTier": "stub",
-      "notes": "No text objects, so the instance-level check keeps containsStudentText false. The stub handler emits one sentence — that weak summary is the measurement, not a failure."
+      "handlerTier": "full",
+      "notes": "No text objects, so the instance-level check keeps containsStudentText false. The production handler describes the drawing as a table of its objects, one row each; the objects carry ids so that table's first column has something to print."
     },
     "empty": {
       "expectDistinctiveInDefaultSummary": false,
@@ -230,7 +230,7 @@
         "requiresVisualRepresentation": true
       },
       "handlerTier": "full",
-      "notes": "handlerTier describes the Text tile that carries the marker. The Drawing tile is stub tier, and its text object is what the drawing instance-level check looks for."
+      "notes": "handlerTier describes the Text tile that carries the marker. The Drawing tile is full tier as well: the production handler describes it as a table of its objects, and those objects carry ids so that table's first column has something to print. Its text object is what the drawing instance-level check looks for."
     },
     "numberline": {
       "expectDistinctiveInDefaultSummary": false,

--- a/scripts/ai-harness/src/represent-text.ts
+++ b/scripts/ai-harness/src/represent-text.ts
@@ -39,12 +39,12 @@ export interface TextVariant {
 export const textVariants: Record<string, TextVariant> = {
   default: {
     id: "default",
-    variantVersion: 1,
+    variantVersion: 2,
     render: (content) => documentSummarizer(content, {})
   },
   minimal: {
     id: "minimal",
-    variantVersion: 1,
+    variantVersion: 2,
     render: (content) => documentSummarizer(content, { minimal: true })
   },
   /**
@@ -59,23 +59,24 @@ export const textVariants: Record<string, TextVariant> = {
    */
   "no-dataset-tables": {
     id: "no-dataset-tables",
-    variantVersion: 1,
+    variantVersion: 2,
     render: (content) => documentSummarizer(content, { dataSetTables: "schema-only" })
   },
   /**
-   * `default` with drawings described rather than merely mentioned.
+   * `default` with drawings described by the harness's own prototype serializer.
    *
-   * The default handler says "This tile contains a drawing" and stops, so a text-only run is told
-   * nothing about what the student drew — which is most of what a visual document *is*, and a large
-   * part of why an image run might beat a text one. This variant swaps in a pure serializer that
+   * Written when the production handler said "This tile contains a drawing" and stopped, so a
+   * text-only run was told nothing about what the student drew. It swaps in a pure serializer that
    * lists each object's type, position and size, and any text objects' text.
    *
-   * A measurement prototype, deliberately unambitious: it describes geometry and does not interpret
-   * it. Beating it is the point, and a variant is how someone would show that they had.
+   * CLUE has since given the production handler an object table of its own, so `default` now
+   * describes a drawing too and this is no longer the only text variant that carries what was
+   * drawn. It is kept as the earlier prototype: runs recorded with it are still comparable, and
+   * `experiments/vibe-mixed-vs-baselines.json` names its run.
    */
   "drawing-text": {
     id: "drawing-text",
-    variantVersion: 1,
+    variantVersion: 2,
     // Ahead of the defaults, which is how `documentSummarizerWithDrawings` composes: the first
     // handler that answers wins, so this one takes the Drawing tiles and the rest are untouched.
     render: (content) => documentSummarizer(content, {

--- a/scripts/ai-harness/src/represent-text.ts
+++ b/scripts/ai-harness/src/represent-text.ts
@@ -72,7 +72,7 @@ export const textVariants: Record<string, TextVariant> = {
    * CLUE has since given the production handler an object table of its own, so `default` now
    * describes a drawing too and this is no longer the only text variant that carries what was
    * drawn. It is kept as the earlier prototype: runs recorded with it are still comparable, and
-   * `experiments/vibe-mixed-vs-baselines.json` names its run.
+   * `experiments/mixed-vs-baselines.json` names its `text-drawing-text` run.
    */
   "drawing-text": {
     id: "drawing-text",

--- a/scripts/ai-harness/test/fixtures.test.ts
+++ b/scripts/ai-harness/test/fixtures.test.ts
@@ -42,6 +42,16 @@ describe("the committed synthetic corpus", () => {
       .toEqual(expect.arrayContaining(["text-only", "visual-only", "mixed", "empty"]));
   });
 
+  it("gives every drawing object an id, so the object table has one to print", () => {
+    // The production summary of a Drawing tile is a table whose first column is each object's id.
+    // A fixture object without one makes that column read "undefined", which is a gap in the
+    // fixture rather than in the summarizer — real CLUE documents always store ids.
+    for (const docId of ["drawing", "mixed"]) {
+      const summary = textVariants.default.render(readDocument(docId));
+      expect({ docId, summary }).toEqual({ docId, summary: expect.not.stringContaining("undefined") });
+    }
+  });
+
   it("stands in for the Unknown registration with a type this build does not register", () => {
     const unknownFixture = expectations.documents.unknown;
     expect(unknownFixture).toBeDefined();
@@ -128,28 +138,30 @@ describe("the no-dataset-tables variant", () => {
 });
 
 describe("the drawing-text variant", () => {
+  // `drawing-text` is the prototype description of a drawing, written when production's summary of a
+  // Drawing tile was the one sentence "This tile contains a drawing." That default sentence has been
+  // replaced with a table of the drawing's objects, so `default` now describes a drawing too. The
+  // variant is kept as the earlier prototype, so recorded runs that used it can still be compared
+  // against — not as an improvement over `default`. These tests therefore say what the variant
+  // emits and nothing about what `default` does or does not say.
   const load = (docId: string) => JSON.parse(fs.readFileSync(
     path.join(harnessRoot, "examples", "synthetic-corpus", "documents", `${docId}.json`), "utf8"));
 
-  it("describes what the student drew, where `default` only says a drawing is there", () => {
+  it("describes a drawing's objects in words", () => {
     const summary = textVariants["drawing-text"].render(load("drawing"));
-    expect(textVariants.default.render(load("drawing"))).toContain("This tile contains a drawing.");
     // The fixture is a rectangle and an ellipse; the variant says so, with their geometry.
     expect(summary).toContain("2 objects (1 rectangle, 1 ellipse)");
     expect(summary).toContain("- rectangle at (10, 10), 120×60");
     expect(summary).toContain("- ellipse at (160, 40), radii 30×20");
   });
 
-  it("carries a drawing's text objects, which the default summary loses entirely", () => {
-    // The `mixed` fixture has a Drawing holding a text object. A text-only run against `default`
-    // never sees those words at all.
-    const summary = textVariants["drawing-text"].render(load("mixed"));
-    const fallback = textVariants.default.render(load("mixed"));
-    const drawnText = JSON.parse(fs.readFileSync(
-      path.join(harnessRoot, "examples", "synthetic-corpus", "documents", "mixed.json"), "utf8"))
-      .tileMap["mixed-drawing-tile"].content.objects.find((object: any) => object.type === "text").text;
+  it("carries a drawing's text objects", () => {
+    // The `mixed` fixture has a Drawing holding a text object.
+    const content = load("mixed");
+    const summary = textVariants["drawing-text"].render(content);
+    const drawnText = content.tileMap["mixed-drawing-tile"].content.objects
+      .find((object: any) => object.type === "text").text;
     expect(summary).toContain(drawnText);
-    expect(fallback).not.toContain(drawnText);
   });
 
   it("leaves every other tile type exactly as `default` renders it", () => {

--- a/scripts/ai-harness/test/fixtures.test.ts
+++ b/scripts/ai-harness/test/fixtures.test.ts
@@ -18,6 +18,26 @@ function readDocument(docId: string): unknown {
   return JSON.parse(fs.readFileSync(path.join(documentsDir, `${docId}.json`), "utf8"));
 }
 
+/**
+ * The `id` of every object in every Drawing tile of a document, a group's members included.
+ *
+ * One entry per object rather than per id: an object that has no id has to show up here as a gap,
+ * since that is the thing the test below exists to catch.
+ */
+function drawingObjectIds(content: unknown): (string | undefined)[] {
+  const ids: (string | undefined)[] = [];
+  const walk = (objects: any[]) => objects.forEach((object) => {
+    ids.push(object?.id);
+    if (Array.isArray(object?.objects)) walk(object.objects);
+  });
+  for (const tile of Object.values<any>((content as any)?.tileMap ?? {})) {
+    if (tile?.content?.type === "Drawing" && Array.isArray(tile.content.objects)) {
+      walk(tile.content.objects);
+    }
+  }
+  return ids;
+}
+
 describe("the committed synthetic corpus", () => {
   it("has one document per file and one expectation per document", () => {
     const files = fs.readdirSync(documentsDir).filter((name) => name.endsWith(".json"))
@@ -46,9 +66,24 @@ describe("the committed synthetic corpus", () => {
     // The production summary of a Drawing tile is a table whose first column is each object's id.
     // A fixture object without one makes that column read "undefined", which is a gap in the
     // fixture rather than in the summarizer — real CLUE documents always store ids.
-    for (const docId of ["drawing", "mixed"]) {
-      const summary = textVariants.default.render(readDocument(docId));
-      expect({ docId, summary }).toEqual({ docId, summary: expect.not.stringContaining("undefined") });
+    //
+    // The documents are found rather than listed, so a third Drawing fixture added without ids
+    // fails here instead of sitting outside the check.
+    const withDrawings = docIds.filter((docId) =>
+      expectations.documents[docId].tileTypes.includes("Drawing"));
+    expect(withDrawings).not.toEqual([]);
+    for (const docId of withDrawings) {
+      const content = readDocument(docId);
+      const summary = textVariants.default.render(content);
+      const ids = drawingObjectIds(content);
+      expect({ docId, objects: ids.length }).not.toEqual({ docId, objects: 0 });
+      // Two separate ways to fail: an object with no id, and an id the summary never prints.
+      // Asking only that "undefined" is absent would pass just as well if the column disappeared.
+      expect({
+        docId,
+        withoutId: ids.filter((id) => !id).length,
+        missing: ids.filter((id) => id && !summary.includes(id))
+      }).toEqual({ docId, withoutId: 0, missing: [] });
     }
   });
 

--- a/scripts/ai-harness/test/smoke.test.ts
+++ b/scripts/ai-harness/test/smoke.test.ts
@@ -73,7 +73,7 @@ describe("end-to-end smoke run against the synthetic corpus", () => {
     await main(["represent", "--corpus", "smoke-corpus", "--variants", "default,minimal"], deps);
     const envelope = readRepresentation(representationPath(paths, "default", "text"));
     expect(envelope.variantId).toBe("default");
-    expect(envelope.variantVersion).toBe(1);
+    expect(envelope.variantVersion).toBe(2);
     expect(envelope.markdown).toContain("text-fixture-marker");
     expect(readRepresentation(representationPath(paths, "minimal", "text")).markdown).toContain("text-fixture-marker");
   });


### PR DESCRIPTION
[CLUE-371](https://concord-consortium.atlassian.net/browse/CLUE-371)

Two branches merged into `master` within a day of each other: `CLUE-371` brought the AI evaluation harness in `scripts/ai-harness/`, including a text variant called `drawing-text` that describes a Drawing tile's objects in words, and `CLUE-646` changed the production summarizer so that every tile gets a "This tile's id is …" line and Drawing tiles get a table of their objects instead of the single sentence "This tile contains a drawing." Neither branch was wrong, but together they left two harness tests failing, because both tests were written to show that `drawing-text` beat `default` — one asserted that `default` says only that a drawing is there, the other that `default` loses a drawing's text entirely, and neither is true any
more. This PR fixes those two tests, gives the synthetic drawing fixtures object ids, and bumps the text variants' versions.

## Changes

- **`test/fixtures.test.ts`** — the two `drawing-text` tests now assert what the variant emits and say nothing about `default`. A new test checks that the `default` summary of the `drawing` and `mixed` fixtures contains no `undefined`.
- **`examples/synthetic-corpus/documents/drawing.json`, `mixed.json`** — every object in a Drawing tile now has an `id`. Without one, the new object table printed `undefined` in its first column for every row. Real CLUE documents always store these ids.
- **`examples/synthetic-corpus/expectations.json`** — the `drawing` fixture's `handlerTier` moves from `stub` to `full`, and the notes on both `drawing` and `mixed` no longer describe the Drawing handler as a stub that emits one sentence.
- **`src/represent-text.ts`** — `default`, `minimal`, `no-dataset-tables` and `drawing-text` all move from `variantVersion` 1 to 2. Every one of them passes tiles through the production summarizer, so the new id line changed all four; cached representations from before this change are now correctly treated as stale.
- **`README.md`** — the `drawing-text` row in the text-variants table is reworded, and the `variantVersion` section says what version 2 means.

## Notes

- The `drawing-text` variant is kept rather than retired: an existing experiment names its `text-drawing-text` run, and the recorded results stand behind it. It is now documented as the earlier prototype, kept so those runs stay comparable, rather than as an improvement over `default`.
- The Drawing entry in the capability registry still records the old fidelity. That file will be moved to `shared/` on a different, work-in-progress branch, so it is updated there rather than here, to avoid a conflict on that branch's rebase.
- The `dataflow` fixture's `default` summary still contains the string `undefined`, from the Dataflow summarizer printing `formulaWithValues` as `unset_num1 + unset_num2 = undefined`. That is in `shared/ai-summarizer/` and is not touched here, which is why the new no-`undefined` assertion covers the drawing fixtures rather than the whole corpus.



[CLUE-371]: https://concord-consortium.atlassian.net/browse/CLUE-371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ