### PR TITLE
CLUE-622: Fix flaky test--Keep Copy to Workspace disabled until the workspace document loads

### DIFF
--- a/cypress/e2e/functional/document_tests/tiles_copy_test_spec.js
+++ b/cypress/e2e/functional/document_tests/tiles_copy_test_spec.js
@@ -327,7 +327,9 @@ context('Test copy tiles from one document to other document', function () {
     // For Copy to Workspace, if tiles are coming from a Problem tab,
     // they are copied below the section header for that tab in the Workspace
     cy.log('Copy to Workspace should place tiles below the section header for that tab.');
-    canvas.getCopyToWorkspaceButton().should('not.have.attr', 'disabled');
+    // Toolbar buttons report their disabled state via aria-disabled, so that is what has to be
+    // asserted here; a bare `disabled` attribute is never rendered and would always be absent.
+    canvas.getCopyToWorkspaceButton().should('not.have.attr', 'aria-disabled');
     canvas.getCopyToWorkspaceButton().click();
 
     // Confirm the Initial Challenge section header

--- a/src/components/toolbar.test.tsx
+++ b/src/components/toolbar.test.tsx
@@ -1,10 +1,14 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "mobx-react";
+import { getSnapshot } from "mobx-state-tree";
 import React from "react";
 import { ModalProvider } from "react-modal-hook";
+import { Logger } from "../lib/logger";
+import { SectionModel } from "../models/curriculum/section";
 import { createDocumentModel } from "../models/document/document";
 import { DocumentContentModel } from "../models/document/document-content";
+import { ProblemDocument } from "../models/document/document-types";
 import { ToolbarModel, IToolbarModelSnapshot } from "../models/stores/problem-configuration";
 import { specStores } from "../models/stores/spec-stores";
 import { ToolbarComponent } from "./toolbar";
@@ -158,6 +162,84 @@ describe("ToolbarComponent", () => {
       fireEvent.keyDown(toolbar, { key: "End" });
       fireEvent.keyDown(toolbar, { key: "ArrowDown" });
       expect(window.document.activeElement).toBe(lastButton);
+    });
+  });
+
+  // A section toolbar has no document of its own, and the primary workspace document it copies
+  // into is not available for a window after load. Buttons must report that accurately: a click
+  // on a button whose action cannot run is discarded without feedback.
+  describe("section toolbar button state without a primary document", () => {
+
+    const selectedTileId = "selected-tile";
+
+    const copyConfig: IToolbarModelSnapshot = [
+      { id: "copyToWorkspace", title: "Copy to Workspace", iconId: "icon-copy-to-workspace-tool",
+        isDefault: false, isTileTool: false },
+      { id: "copyToDocument", title: "Copy to Document", iconId: "icon-copy-to-document-tool",
+        isDefault: false, isTileTool: false },
+      { id: "edit", title: "Edit", iconId: "icon-edit-tool", isDefault: false, isTileTool: false }
+    ];
+
+    // "none": no primary document key at all, as on first load.
+    // "keyOnly": a key has been chosen but the document has not finished loading into the store.
+    // "loaded": the document is available and can actually be copied into.
+    type PrimaryState = "none" | "keyOnly" | "loaded";
+
+    const renderSectionToolbar = (primary: PrimaryState) => {
+      const testStores = specStores();
+      const sectionContent = DocumentContentModel.create({
+        tileMap: { [selectedTileId]: { id: selectedTileId, content: { type: "Unknown" } } }
+      });
+      const section = SectionModel.create({
+        type: "introduction",
+        content: getSnapshot(sectionContent)
+      });
+      testStores.ui.selectAllTiles([selectedTileId]);
+
+      if (primary !== "none") {
+        const primaryDocument = createDocumentModel({
+          type: ProblemDocument, uid: "1", key: "primary-doc", createdAt: 1, content: {}
+        });
+        if (primary === "loaded") {
+          testStores.documents.add(primaryDocument);
+        }
+        // setPrimaryDocument logs a document event, which needs logger context to resolve the user
+        Logger.initializeLogger(testStores);
+        testStores.persistentUI.problemWorkspace.setPrimaryDocument(primaryDocument);
+      }
+
+      render(
+        <ModalProvider>
+          <Provider stores={testStores}>
+            <ToolbarComponent toolbarModel={ToolbarModel.create(copyConfig)} section={section} />
+          </Provider>
+        </ModalProvider>
+      );
+    };
+
+    it("disables Copy to Workspace while there is no primary document key", () => {
+      renderSectionToolbar("none");
+      expect(screen.getByTestId("tool-copytoworkspace")).toHaveAttribute("aria-disabled", "true");
+    });
+
+    it("disables Copy to Workspace while the primary document has not finished loading", () => {
+      renderSectionToolbar("keyOnly");
+      expect(screen.getByTestId("tool-copytoworkspace")).toHaveAttribute("aria-disabled", "true");
+    });
+
+    it("enables Copy to Workspace once the primary document is loaded", () => {
+      renderSectionToolbar("loaded");
+      expect(screen.getByTestId("tool-copytoworkspace")).not.toHaveAttribute("aria-disabled");
+    });
+
+    it("leaves Copy to Document enabled, since it does not copy to the primary document", () => {
+      renderSectionToolbar("none");
+      expect(screen.getByTestId("tool-copytodocument")).not.toHaveAttribute("aria-disabled");
+    });
+
+    it("does not treat a section as the primary document when neither has a key", () => {
+      renderSectionToolbar("none");
+      expect(screen.getByTestId("tool-edit")).not.toHaveAttribute("aria-disabled");
     });
   });
 

--- a/src/components/toolbar.test.tsx
+++ b/src/components/toolbar.test.tsx
@@ -172,6 +172,11 @@ describe("ToolbarComponent", () => {
 
     const selectedTileId = "selected-tile";
 
+    // This config is synthetic: production section toolbars filter Edit out, since
+    // problem-panel passes myResourcesToolbar({}) and leaves showEdit undefined. Edit is
+    // included anyway because it is the only button that reaches the primary-document guard on
+    // its own, so it is what pins the requirement for a primary document key. Copy to Workspace
+    // cannot pin it: the guard for a loaded primary document disables that button first.
     const copyConfig: IToolbarModelSnapshot = [
       { id: "copyToWorkspace", title: "Copy to Workspace", iconId: "icon-copy-to-workspace-tool",
         isDefault: false, isTileTool: false },

--- a/src/components/toolbar.tsx
+++ b/src/components/toolbar.tsx
@@ -150,9 +150,20 @@ export const ToolbarComponent = observer(function ToolbarComponent(props: IProps
       return true;
     }
 
-    // don't allow the following tools when the document is the primary document
+    // don't allow the following tools when the document is the primary document.
+    // Require a primary document key: this toolbar also serves sections, which have no document,
+    // and an undefined key must not be read as a match with an undefined document key.
     const disallowedPrimaryDocumentTools = ["edit", "copyToWorkspace"];
-    if (disallowedPrimaryDocumentTools.includes(toolButton.id) && document?.key === primaryDocumentKey) {
+    if (disallowedPrimaryDocumentTools.includes(toolButton.id) &&
+        !!primaryDocumentKey && document?.key === primaryDocumentKey) {
+      return true;
+    }
+
+    // Copying to the workspace needs a loaded primary document to copy into. Until one is
+    // available the action can do nothing, so keep the button disabled rather than letting it
+    // accept clicks that are silently discarded.
+    if (toolButton.id === "copyToWorkspace" &&
+        !stores.documents.getDocument(primaryDocumentKey ?? "")?.content) {
       return true;
     }
 


### PR DESCRIPTION
## What this fixes

**Copy to Workspace could silently do nothing.** With tiles selected in a Problems tab, clicking the button before the workspace document finished loading copied nothing — no error, no feedback, the click simply discarded. The window is short, so people rarely notice: they click again and it works. The Cypress regression suite clicks the instant the button looks actionable and hit the window often enough that the resulting failure was written off as flake.

After this change the button reports its true state. It stays disabled while there is nothing to copy into, and becomes enabled as soon as there is — so the click either works or is visibly unavailable.

## Three defects, stacked

Each one hid the next, which is why this took a while to pin down:

1. `persistentUI.problemWorkspace.primaryDocumentKey` is undefined for a window after load — no workspace document is registered to copy into yet.
2. `isButtonDisabled` compared `document?.key === primaryDocumentKey`. A **section** toolbar has no document of its own, so while the key was also undefined this was `undefined === undefined`, and Copy to Workspace flipped to disabled. `ToolbarButtonComponent.handleClick` returns early when disabled, so the click was dropped silently.
3. With that corrected the click reached `handleCopyToWorkspace`, which guards on `primaryDocument?.content` and returned without copying — silently again.

## Why the test could not see it

The spec guarded the click with:

```js
canvas.getCopyToWorkspaceButton().should('not.have.attr', 'disabled');
```

Toolbar buttons report their state via `aria-disabled` and never render a bare `disabled` attribute, so this assertion passed instantly regardless of the button's real state. Cypress never waited, and clicked straight into the window.

This check has been vacuous since it was added in April 2025 — the element was a `<div>` then, with no `disabled` attribute either. It is **not** fallout from the later accessibility work that made these buttons real `<button>` elements.

## Changes

- `src/components/toolbar.tsx` — require a primary document key before treating a document as the primary document, and keep Copy to Workspace disabled until a loaded primary document exists.
- `cypress/e2e/functional/document_tests/tiles_copy_test_spec.js` — assert `aria-disabled`, so Cypress waits for the button to become actionable.
- `src/components/toolbar.test.tsx` — unit tests pinning button state across three cases: no primary key, key set but not yet loaded, and loaded.

## Verification

| Check | Result |
|---|---|
| Cypress spec loop, `retries=0` | 4 of 6 runs failed before; 7 of 7 passed after |
| Full jest suite | 3978 passed, 0 failures |
| `npm run check:types`, eslint | clean |

Both production changes are pinned: reverting the fix makes two of the new unit tests fail. The failure signature `Found '22', expected '32'` was confirmed to be exactly the no-copy state by removing the click entirely and getting the same count.

## For the reviewer

This makes Copy to Workspace **correctly** disabled during a window on load where it previously appeared enabled. That is the intended behavior, but it is a visible change to button state, so it deserves an eye.

Jira: CLUE-622

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01462X5PX8pREGYLLy9fSr6m
