### PR TITLE
fix: use the modular FieldValue so the functions work in the emulator

### DIFF
--- a/functions-v2/src/on-analysis-document-imaged.ts
+++ b/functions-v2/src/on-analysis-document-imaged.ts
@@ -1,6 +1,8 @@
 import {FirestoreEvent, onDocumentCreated, QueryDocumentSnapshot} from "firebase-functions/v2/firestore";
 import * as logger from "firebase-functions/logger";
 import * as admin from "firebase-admin";
+// Modular import: admin.firestore.FieldValue is undefined in the functions emulator.
+import {FieldValue} from "firebase-admin/firestore";
 import {getAnalysisQueueFirestorePath} from "./utils";
 import {categorizeSummary, categorizeUrl} from "../lib/src/ai-categorize-document";
 import {defineSecret} from "firebase-functions/params";
@@ -89,7 +91,7 @@ export const onAnalysisDocumentImaged =
       await firestore.collection(commentsPath).add({
         tags,
         content: message,
-        createdAt: admin.firestore.FieldValue.serverTimestamp(),
+        createdAt: FieldValue.serverTimestamp(),
         name: kAnalyzerUserParams.fullName,
         uid: kAnalyzerUserParams.id,
       });
@@ -98,7 +100,7 @@ export const onAnalysisDocumentImaged =
       await firestore.collection(getAnalysisQueueFirestorePath("done")).add({
         ...queueDoc,
         documentId: event.params.docId,
-        completedAt: admin.firestore.FieldValue.serverTimestamp(),
+        completedAt: FieldValue.serverTimestamp(),
         promptTokens,
         completionTokens,
         fullResponse,

--- a/functions-v2/src/on-analysis-document-pending.ts
+++ b/functions-v2/src/on-analysis-document-pending.ts
@@ -2,6 +2,8 @@ import {FirestoreEvent, onDocumentCreated, QueryDocumentSnapshot} from "firebase
 import {getAnalysisQueueFirestorePath, isKnownEvaluator} from "./utils";
 import {getDatabase} from "firebase-admin/database";
 import * as admin from "firebase-admin";
+// Modular import: admin.firestore.FieldValue is undefined in the functions emulator.
+import {FieldValue} from "firebase-admin/firestore";
 import * as logger from "firebase-functions/logger";
 import {type AnalysisQueueDocument} from "./on-analyzable-doc-written";
 import {documentSummarizer} from "../../shared/ai-summarizer/ai-summarizer";
@@ -168,7 +170,7 @@ export const onAnalysisDocumentPending =
       }
       nextQueueDoc = {
         ...nextQueueDoc,
-        docImaged: admin.firestore.FieldValue.serverTimestamp(),
+        docImaged: FieldValue.serverTimestamp(),
         docImageUrl: (responseJSON as { url: string }).url,
       };
     } else {

--- a/functions-v2/src/on-class-data-doc-written.ts
+++ b/functions-v2/src/on-class-data-doc-written.ts
@@ -1,6 +1,7 @@
 import {onDocumentWritten} from "firebase-functions/v2/firestore";
 import * as logger from "firebase-functions/logger";
-import * as admin from "firebase-admin";
+// Modular import: admin.firestore.FieldValue is undefined in the functions emulator.
+import {FieldValue} from "firebase-admin/firestore";
 import {defineSecret} from "firebase-functions/params";
 import {MarkdownTextSplitter} from "@langchain/textsplitters";
 import {ChatOpenAI} from "@langchain/openai";
@@ -148,7 +149,7 @@ export const onClassDataDocWritten = onDocumentWritten(
         studentSummary: summary,
         teacherSummary: teacherSummary.summary,
         summaryTokenCount: studentSummary.tokenCount + teacherSummary.tokenCount,
-        summaryCreatedAt: admin.firestore.FieldValue.serverTimestamp(),
+        summaryCreatedAt: FieldValue.serverTimestamp(),
       });
 
       logger.info("Summarized the class work into the data doc", event.subject);

--- a/functions-v2/src/post-document-comment.ts
+++ b/functions-v2/src/post-document-comment.ts
@@ -1,4 +1,6 @@
 import * as admin from "firebase-admin";
+// Modular import: admin.firestore.FieldValue is undefined in the functions emulator.
+import {FieldValue} from "firebase-admin/firestore";
 import {CallableRequest, onCall, HttpsError} from "firebase-functions/v2/https";
 import {
   IPostDocumentCommentUnionParams, isCurriculumMetadata, isDocumentMetadata, isWarmUpParams,
@@ -46,7 +48,7 @@ export const postDocumentComment = onCall(async (request: CallableRequest<IPostD
     uid,
     name: userContext.name,
     network: userContext.network,
-    createdAt: admin.firestore.FieldValue.serverTimestamp(),
+    createdAt: FieldValue.serverTimestamp(),
   });
   return {version, id: result.id};
 });

--- a/functions-v2/src/post-exemplar-comment.ts
+++ b/functions-v2/src/post-exemplar-comment.ts
@@ -1,4 +1,6 @@
 import * as admin from "firebase-admin";
+// Modular import: admin.firestore.FieldValue is undefined in the functions emulator.
+import {FieldValue} from "firebase-admin/firestore";
 import {CallableRequest, onCall, HttpsError} from "firebase-functions/v2/https";
 import {
   IPostDocumentCommentUnionParams, isCurriculumMetadata, isDocumentMetadata, isWarmUpParams,
@@ -50,7 +52,7 @@ export const postExemplarComment = onCall(async (request: CallableRequest<IPostD
     ...comment,
     uid: kExemplarUserParams.id,
     name: kExemplarUserParams.fullName,
-    createdAt: admin.firestore.FieldValue.serverTimestamp(),
+    createdAt: FieldValue.serverTimestamp(),
   });
   return {version, id: result.id};
 });


### PR DESCRIPTION
## The problem

Running the AI analysis pipeline against the Firebase emulators fails as soon as a function reaches a `serverTimestamp()` call:

```
TypeError: Cannot read properties of undefined (reading 'serverTimestamp')
⚠  Your function was killed because it raised an unhandled error.
```

The emulator stops the function, nothing is recorded, and for the queue functions the entry is left in place. Those triggers have no retry configured, so the document is never processed again.

## Why it happens

The functions emulator replaces the `firebase-admin` module with a proxy. When code reads `admin.firestore`, the proxy returns `Proxied.getOriginal(target, "firestore")`, which is:

```js
return value.bind(target);
```

A bound function is a new function object, and it does not carry the original's own properties. So the statics on `admin.firestore` — `FieldValue` and the rest — are undefined inside the emulator. Checked directly:

```
original .FieldValue: function
bound    .FieldValue: undefined
```

It works normally in a plain node process and in deployed functions, which is why this went unnoticed until someone tried to run the pipeline locally.

## The change

Import `FieldValue` from `firebase-admin/firestore` instead of reaching for it through the `admin.firestore` namespace. That avoids the proxy and behaves the same in both places.

**`src/chat/drain.ts` already used the modular imports and explains why. This brings the rest of the directory in line with it.**

All six call sites, in five files:

| File | Field |
|---|---|
| `on-analysis-document-pending.ts` | `docImaged` |
| `on-analysis-document-imaged.ts` | the comment's `createdAt` |
| `on-analysis-document-imaged.ts` | the `done` record's `completedAt` |
| `post-document-comment.ts` | `createdAt` |
| `post-exemplar-comment.ts` | `createdAt` |
| `on-class-data-doc-written.ts` | `summaryCreatedAt` |

`admin.firestore.FieldValue` was the only namespace static used anywhere in `functions-v2/src` — no `Timestamp`, no `FieldPath`, no `admin.database.ServerValue` — so this covers all of it rather than part of it. `on-class-data-doc-written.ts` no longer imports `firebase-admin` at all, since that was its only use of it.

## Testing

The existing suite passes, unchanged at 122 tests, along with typecheck and lint.

**No test covers this change, and that is deliberate.** The tests in `functions-v2` call the functions directly rather than through the emulator's runtime, so `firebase-admin` is never proxied and they cannot tell the two forms apart. They confirm the change breaks nothing; they cannot confirm it fixes anything.

A check that read the source files and failed on the old form was written and then dropped. It could not tell a runtime call from a type annotation such as `admin.firestore.Firestore`, which TypeScript erases at compile time and which is perfectly safe.

## What was verified by hand

All against the emulators, with the change applied.

The full AI analysis pipeline ran end to end through the CLUE user interface — a text-only document, a drawing-only document, an empty document, and the mock evaluator — each producing a comment in the panel. Before the change, every one of those runs stopped at the first `serverTimestamp()` call.

Posting a comment from the comments panel exercised `post-document-comment`. Calling the `postExemplarComment` endpoint directly exercised `post-exemplar-comment`. Both wrote a real `createdAt` timestamp.

`on-class-data-doc-written` was not run, because triggering it makes a paid OpenAI call. Its change is identical to the other five.