### PR TITLE
feat: only accept valid comment rating values (CLUE-645)

### DIFF
--- a/firebase-test/src/comment-ratings-rules.test.ts
+++ b/firebase-test/src/comment-ratings-rules.test.ts
@@ -1,5 +1,6 @@
 import { assertFails, assertSucceeds } from "@firebase/rules-unit-testing";
 import firebase from "firebase";
+import { kRatingValues } from "../../shared/shared";
 import {
   adminWriteDoc, cPath, cProblem, cSection, cUnit, initFirestore, mockTimestamp, network1, noNetwork,
   prepareEachTest, student2Id, studentAuth, studentId, teacher2Auth, teacher2Id, teacher2Name,
@@ -47,7 +48,7 @@ function testRatingRules(realmName: string, realm: IRatingRealm) {
       db = initFirestore(raterAuth);
     });
 
-    it.each(["yes", "no", "notSure"])("a user can rate a comment '%s'", async (value) => {
+    it.each([...kRatingValues])("a user can rate a comment '%s'", async (value) => {
       await seedComment();
       await expectRatingUpdateToSucceed(db, commentPath, { [`ratings.${raterId}`]: value });
     });

--- a/firebase-test/src/comment-ratings-rules.test.ts
+++ b/firebase-test/src/comment-ratings-rules.test.ts
@@ -1,9 +1,10 @@
 import { assertFails, assertSucceeds } from "@firebase/rules-unit-testing";
 import firebase from "firebase";
 import {
-  adminWriteDoc, cPath, cProblem, cSection, cUnit, initFirestore, mockTimestamp, network1, noNetwork,
-  prepareEachTest, student2Id, studentAuth, studentId, teacher2Auth, teacher2Id, teacher2Name,
-  teacherId, teacherName, tearDownTests, thisClass
+  adminWriteDoc, cPath, cProblem, cSection, cUnit, expectWriteToFail, expectWriteToSucceed,
+  initFirestore, mockTimestamp, network1, noNetwork, prepareEachTest, student2Id, studentAuth,
+  studentId, studentName, teacher2Auth, teacher2Id, teacher2Name, teacherAuth, teacherId,
+  teacherName, tearDownTests, thisClass
 } from "./setup-rules-tests";
 
 // The client rates a comment by updating a single dotted key, and toggles a rating off by deleting
@@ -23,17 +24,28 @@ interface IRatingRealm {
   commentPath: string;
   // writes the parent document and the comment, starting from the given ratings
   seedComment: (ratings?: Record<string, any>) => Promise<void>;
-  // auth of the user doing the rating. Never the comment's author: an author can update their own
-  // comment through the other branch of isValidCommentUpdateRequest, which doesn't check ratings.
+  // auth of a user rating someone else's comment
   raterAuth: any;
   // the rater's platform user id, which is the key their rating is stored under
   raterId: string;
   // some other user's id, used to check that a rater can't write another user's rating
   otherUserId: string;
+  // auth of the user who wrote the comment. They reach these rules through a second path, since
+  // isValidCommentUpdateRequest also lets an author edit their own comment.
+  authorAuth: any;
+  // the author's platform user id
+  authorId: string;
+  // writes the parent document alone, for tests that create the comment themselves
+  seedParent: () => Promise<void>;
+  // path of a comment that doesn't exist yet, which the rater creates
+  newCommentPath: string;
+  // a comment the rater can validly create, plus whatever fields the test is probing
+  newComment: (extraFields?: Record<string, any>) => Record<string, any>;
 }
 
 function testRatingRules(realmName: string, realm: IRatingRealm) {
-  const { commentPath, seedComment, raterAuth, raterId, otherUserId } = realm;
+  const { commentPath, seedComment, raterAuth, raterId, otherUserId, authorAuth, authorId,
+    seedParent, newCommentPath, newComment } = realm;
 
   describe(realmName, () => {
     let db: firebase.firestore.Firestore;
@@ -109,6 +121,71 @@ function testRatingRules(realmName: string, realm: IRatingRealm) {
       await expectRatingUpdateToFail(db, commentPath,
         { [`ratings.${raterId}`]: "yes", content: "A different comment!" });
     });
+
+    // An author can edit their own comment, so their writes can satisfy isValidCommentUpdateRequest
+    // without going through the rating rule. Ratings are read-only on that path, which leaves the
+    // rating rule as the only way anyone changes them.
+    describe("written by the comment's author", () => {
+      beforeEach(() => {
+        db = initFirestore(authorAuth);
+      });
+
+      it("the author can rate their own comment", async () => {
+        await seedComment();
+        await expectRatingUpdateToSucceed(db, commentPath, { [`ratings.${authorId}`]: "yes" });
+      });
+
+      it("rejects a rating value outside the allowed set", async () => {
+        await seedComment();
+        await expectRatingUpdateToFail(db, commentPath, { [`ratings.${authorId}`]: "bogus" });
+      });
+
+      it("rejects writing another user's rating", async () => {
+        await seedComment();
+        await expectRatingUpdateToFail(db, commentPath, { [`ratings.${raterId}`]: "yes" });
+      });
+
+      it("rejects replacing the whole ratings map, dropping another user's rating", async () => {
+        await seedComment({ [raterId]: "yes" });
+        await expectRatingUpdateToFail(db, commentPath, { ratings: { [authorId]: "yes" } });
+      });
+
+      it("the author can still edit their own comment", async () => {
+        await seedComment({ [raterId]: "yes" });
+        await expectRatingUpdateToSucceed(db, commentPath, { content: "A different comment!" });
+      });
+
+      it("rejects an edit that carries a rating change with it", async () => {
+        await seedComment();
+        await expectRatingUpdateToFail(db, commentPath,
+          { [`ratings.${authorId}`]: "yes", content: "A different comment!" });
+      });
+
+      it("rejects the author adding agreeWithAi to their own comment", async () => {
+        await seedComment();
+        await expectRatingUpdateToFail(db, commentPath, { agreeWithAi: { version: 1, value: "yes" } });
+      });
+    });
+
+    // `ratings` and `agreeWithAi` are also forbidden at creation, so a comment can't be born with
+    // entries that never passed the rules above. Nothing legitimate creates comments this way: the
+    // app posts them through the postDocumentComment_v2 callable, which runs as admin.
+    describe("creating a comment", () => {
+      it("a user can create an ordinary comment", async () => {
+        await seedParent();
+        await expectWriteToSucceed(db, newCommentPath, newComment());
+      });
+
+      it("rejects a create that carries a ratings map", async () => {
+        await seedParent();
+        await expectWriteToFail(db, newCommentPath, newComment({ ratings: { [raterId]: "yes" } }));
+      });
+
+      it("rejects a create that carries agreeWithAi", async () => {
+        await seedParent();
+        await expectWriteToFail(db, newCommentPath, newComment({ agreeWithAi: { version: 1, value: "yes" } }));
+      });
+    });
   });
 }
 
@@ -120,44 +197,66 @@ describe("Firestore security rules for comment ratings", () => {
 
   // A student in the class rates a teacher's comment on a document in that class.
   const kDocumentDocPath = "authed/myPortal/documents/myDocument";
+  const seedDocument = async () => {
+    await adminWriteDoc(kDocumentDocPath, {
+      context_id: thisClass, network: noNetwork, uid: teacherId, type: "problemDocument",
+      key: "my-document", createdAt: mockTimestamp()
+    });
+  };
   testRatingRules("document comment ratings", {
     commentPath: `${kDocumentDocPath}/comments/myComment`,
     raterAuth: studentAuth,
     raterId: studentId,
     otherUserId: student2Id,
+    authorAuth: teacherAuth,
+    authorId: teacherId,
+    seedParent: seedDocument,
     seedComment: async (ratings?: Record<string, any>) => {
-      await adminWriteDoc(kDocumentDocPath, {
-        context_id: thisClass, network: noNetwork, uid: teacherId, type: "problemDocument",
-        key: "my-document", createdAt: mockTimestamp()
-      });
+      await seedDocument();
       await adminWriteDoc(`${kDocumentDocPath}/comments/myComment`, {
         uid: teacherId, name: teacherName, network: noNetwork, content: "A comment!",
         createdAt: mockTimestamp(), ...(ratings ? { ratings } : {})
       });
-    }
+    },
+    newCommentPath: `${kDocumentDocPath}/comments/aNewComment`,
+    newComment: (extraFields?: Record<string, any>) => ({
+      uid: studentId, name: studentName, network: noNetwork, content: "A new comment!",
+      createdAt: mockTimestamp(), ...extraFields
+    })
   });
 
   // A teacher in the document's network rates another teacher's comment on a curriculum document.
   // Only teachers with access to the curriculum document can rate its comments.
   const kCurriculumDocPath = "authed/myPortal/curriculum/myCurriculum";
+  const seedCurriculum = async () => {
+    await adminWriteDoc(kCurriculumDocPath, {
+      uid: teacherId, unit: cUnit, problem: cProblem, section: cSection, path: cPath,
+      network: network1
+    });
+    // teacher 2 reaches the document through the network it belongs to
+    await adminWriteDoc(`authed/myPortal/users/${teacher2Id}`, {
+      uid: teacher2Id, name: teacher2Name, type: "teacher", networks: [network1]
+    });
+  };
   testRatingRules("curriculum comment ratings", {
     commentPath: `${kCurriculumDocPath}/comments/myComment`,
     raterAuth: teacher2Auth,
     raterId: teacher2Id,
     otherUserId: teacherId,
+    authorAuth: teacherAuth,
+    authorId: teacherId,
+    seedParent: seedCurriculum,
     seedComment: async (ratings?: Record<string, any>) => {
-      await adminWriteDoc(kCurriculumDocPath, {
-        uid: teacherId, unit: cUnit, problem: cProblem, section: cSection, path: cPath,
-        network: network1
-      });
-      // teacher 2 reaches the document through the network it belongs to
-      await adminWriteDoc(`authed/myPortal/users/${teacher2Id}`, {
-        uid: teacher2Id, name: teacher2Name, type: "teacher", networks: [network1]
-      });
+      await seedCurriculum();
       await adminWriteDoc(`${kCurriculumDocPath}/comments/myComment`, {
         uid: teacherId, name: teacherName, network: network1, content: "A comment!",
         createdAt: mockTimestamp(), ...(ratings ? { ratings } : {})
       });
-    }
+    },
+    newCommentPath: `${kCurriculumDocPath}/comments/aNewComment`,
+    newComment: (extraFields?: Record<string, any>) => ({
+      uid: teacher2Id, name: teacher2Name, network: network1, content: "A new comment!",
+      createdAt: mockTimestamp(), ...extraFields
+    })
   });
 });

--- a/firebase-test/src/comment-ratings-rules.test.ts
+++ b/firebase-test/src/comment-ratings-rules.test.ts
@@ -7,20 +7,21 @@ import {
   teacherAuth, teacherId, teacherName, tearDownTests, thisClass
 } from "./setup-rules-tests";
 
-// The client rates a comment by updating a single dotted key, and toggles a rating off by deleting
-// that key (src/hooks/use-update-comment-rating.ts), so these tests write the same way rather than
-// through the set-with-merge helpers in setup-rules-tests.
-const expectRatingUpdateToSucceed =
+// A comment update, whatever it carries. Most of these tests write a rating, and the client rates by
+// updating a single dotted key and toggles off by deleting that key
+// (src/hooks/use-update-comment-rating.ts), so these tests write the same way rather than through the
+// set-with-merge helpers in setup-rules-tests. A few tests update other fields through these helpers
+// as well — an edit to the comment's own text, alone or alongside a rating.
+const expectCommentUpdateToSucceed =
   async (db: firebase.firestore.Firestore, docPath: string, update: Record<string, any>) => {
     expect(await assertSucceeds(db.doc(docPath).update(update))).toBeUndefined();
   };
-const expectRatingUpdateToFail =
+const expectCommentUpdateToFail =
   async (db: firebase.firestore.Firestore, docPath: string, update: Record<string, any>) => {
     expect(await assertFails(db.doc(docPath).update(update))).toBeDefined();
   };
 
 interface IRatingRealm {
-  // path of the comment being rated
   commentPath: string;
   // writes the parent document and the comment, starting from the given ratings
   seedComment: (ratings?: Record<string, any>) => Promise<void>;
@@ -33,7 +34,6 @@ interface IRatingRealm {
   // auth of the user who wrote the comment. They reach these rules through a second path, since
   // isValidCommentUpdateRequest also lets an author edit their own comment.
   authorAuth: any;
-  // the author's platform user id
   authorId: string;
 }
 
@@ -50,68 +50,68 @@ function testRatingRules(realmName: string, realm: IRatingRealm) {
 
     it.each([...kRatingValues])("a user can rate a comment '%s'", async (value) => {
       await seedComment();
-      await expectRatingUpdateToSucceed(db, commentPath, { [`ratings.${raterId}`]: value });
+      await expectCommentUpdateToSucceed(db, commentPath, { [`ratings.${raterId}`]: value });
     });
 
     it("a user can change their own rating to another allowed value", async () => {
       await seedComment({ [raterId]: "yes" });
-      await expectRatingUpdateToSucceed(db, commentPath, { [`ratings.${raterId}`]: "no" });
+      await expectCommentUpdateToSucceed(db, commentPath, { [`ratings.${raterId}`]: "no" });
     });
 
     it("a user can toggle their own rating off by deleting their key", async () => {
       await seedComment({ [raterId]: "yes" });
-      await expectRatingUpdateToSucceed(db, commentPath,
+      await expectCommentUpdateToSucceed(db, commentPath,
         { [`ratings.${raterId}`]: firebase.firestore.FieldValue.delete() });
     });
 
     it("a user can toggle their own rating off while another user's rating remains", async () => {
       await seedComment({ [raterId]: "yes", [otherUserId]: "no" });
-      await expectRatingUpdateToSucceed(db, commentPath,
+      await expectCommentUpdateToSucceed(db, commentPath,
         { [`ratings.${raterId}`]: firebase.firestore.FieldValue.delete() });
     });
 
     it("rejects a rating value outside the allowed set", async () => {
       await seedComment();
-      await expectRatingUpdateToFail(db, commentPath, { [`ratings.${raterId}`]: "maybe" });
+      await expectCommentUpdateToFail(db, commentPath, { [`ratings.${raterId}`]: "maybe" });
     });
 
     it("rejects an empty rating value", async () => {
       await seedComment();
-      await expectRatingUpdateToFail(db, commentPath, { [`ratings.${raterId}`]: "" });
+      await expectCommentUpdateToFail(db, commentPath, { [`ratings.${raterId}`]: "" });
     });
 
     it("rejects a rating value that isn't a string", async () => {
       await seedComment();
-      await expectRatingUpdateToFail(db, commentPath, { [`ratings.${raterId}`]: 1 });
-      await expectRatingUpdateToFail(db, commentPath, { [`ratings.${raterId}`]: true });
-      await expectRatingUpdateToFail(db, commentPath, { [`ratings.${raterId}`]: { value: "yes" } });
-      await expectRatingUpdateToFail(db, commentPath, { [`ratings.${raterId}`]: ["yes"] });
+      await expectCommentUpdateToFail(db, commentPath, { [`ratings.${raterId}`]: 1 });
+      await expectCommentUpdateToFail(db, commentPath, { [`ratings.${raterId}`]: true });
+      await expectCommentUpdateToFail(db, commentPath, { [`ratings.${raterId}`]: { value: "yes" } });
+      await expectCommentUpdateToFail(db, commentPath, { [`ratings.${raterId}`]: ["yes"] });
     });
 
     it("rejects changing an existing rating of one's own to a disallowed value", async () => {
       await seedComment({ [raterId]: "yes" });
-      await expectRatingUpdateToFail(db, commentPath, { [`ratings.${raterId}`]: "definitely" });
+      await expectCommentUpdateToFail(db, commentPath, { [`ratings.${raterId}`]: "definitely" });
     });
 
     it("rejects replacing the whole ratings map", async () => {
       await seedComment({ [otherUserId]: "no" });
-      await expectRatingUpdateToFail(db, commentPath, { ratings: { [raterId]: "yes" } });
+      await expectCommentUpdateToFail(db, commentPath, { ratings: { [raterId]: "yes" } });
     });
 
     it("rejects writing another user's rating", async () => {
       await seedComment();
-      await expectRatingUpdateToFail(db, commentPath, { [`ratings.${otherUserId}`]: "yes" });
+      await expectCommentUpdateToFail(db, commentPath, { [`ratings.${otherUserId}`]: "yes" });
     });
 
     it("rejects deleting another user's rating", async () => {
       await seedComment({ [otherUserId]: "yes" });
-      await expectRatingUpdateToFail(db, commentPath,
+      await expectCommentUpdateToFail(db, commentPath,
         { [`ratings.${otherUserId}`]: firebase.firestore.FieldValue.delete() });
     });
 
     it("rejects a valid rating that also changes another field", async () => {
       await seedComment();
-      await expectRatingUpdateToFail(db, commentPath,
+      await expectCommentUpdateToFail(db, commentPath,
         { [`ratings.${raterId}`]: "yes", content: "A different comment!" });
     });
 
@@ -125,32 +125,32 @@ function testRatingRules(realmName: string, realm: IRatingRealm) {
 
       it("the author can rate their own comment", async () => {
         await seedComment();
-        await expectRatingUpdateToSucceed(db, commentPath, { [`ratings.${authorId}`]: "yes" });
+        await expectCommentUpdateToSucceed(db, commentPath, { [`ratings.${authorId}`]: "yes" });
       });
 
       it("rejects a rating value outside the allowed set", async () => {
         await seedComment();
-        await expectRatingUpdateToFail(db, commentPath, { [`ratings.${authorId}`]: "bogus" });
+        await expectCommentUpdateToFail(db, commentPath, { [`ratings.${authorId}`]: "bogus" });
       });
 
       it("rejects writing another user's rating", async () => {
         await seedComment();
-        await expectRatingUpdateToFail(db, commentPath, { [`ratings.${raterId}`]: "yes" });
+        await expectCommentUpdateToFail(db, commentPath, { [`ratings.${raterId}`]: "yes" });
       });
 
       it("rejects replacing the whole ratings map, dropping another user's rating", async () => {
         await seedComment({ [raterId]: "yes" });
-        await expectRatingUpdateToFail(db, commentPath, { ratings: { [authorId]: "yes" } });
+        await expectCommentUpdateToFail(db, commentPath, { ratings: { [authorId]: "yes" } });
       });
 
       it("the author can still edit their own comment", async () => {
         await seedComment({ [raterId]: "yes" });
-        await expectRatingUpdateToSucceed(db, commentPath, { content: "A different comment!" });
+        await expectCommentUpdateToSucceed(db, commentPath, { content: "A different comment!" });
       });
 
       it("rejects an edit that carries a rating change with it", async () => {
         await seedComment();
-        await expectRatingUpdateToFail(db, commentPath,
+        await expectCommentUpdateToFail(db, commentPath,
           { [`ratings.${authorId}`]: "yes", content: "A different comment!" });
       });
     });

--- a/firebase-test/src/comment-ratings-rules.test.ts
+++ b/firebase-test/src/comment-ratings-rules.test.ts
@@ -1,0 +1,163 @@
+import { assertFails, assertSucceeds } from "@firebase/rules-unit-testing";
+import firebase from "firebase";
+import {
+  adminWriteDoc, cPath, cProblem, cSection, cUnit, initFirestore, mockTimestamp, network1, noNetwork,
+  prepareEachTest, student2Id, studentAuth, studentId, teacher2Auth, teacher2Id, teacher2Name,
+  teacherId, teacherName, tearDownTests, thisClass
+} from "./setup-rules-tests";
+
+// The client rates a comment by updating a single dotted key, and toggles a rating off by deleting
+// that key (src/hooks/use-update-comment-rating.ts), so these tests write the same way rather than
+// through the set-with-merge helpers in setup-rules-tests.
+const expectRatingUpdateToSucceed =
+  async (db: firebase.firestore.Firestore, docPath: string, update: Record<string, any>) => {
+    expect(await assertSucceeds(db.doc(docPath).update(update))).toBeUndefined();
+  };
+const expectRatingUpdateToFail =
+  async (db: firebase.firestore.Firestore, docPath: string, update: Record<string, any>) => {
+    expect(await assertFails(db.doc(docPath).update(update))).toBeDefined();
+  };
+
+interface IRatingRealm {
+  // path of the comment being rated
+  commentPath: string;
+  // writes the parent document and the comment, starting from the given ratings
+  seedComment: (ratings?: Record<string, any>) => Promise<void>;
+  // auth of the user doing the rating. Never the comment's author: an author can update their own
+  // comment through the other branch of isValidCommentUpdateRequest, which doesn't check ratings.
+  raterAuth: any;
+  // the rater's platform user id, which is the key their rating is stored under
+  raterId: string;
+  // some other user's id, used to check that a rater can't write another user's rating
+  otherUserId: string;
+}
+
+function testRatingRules(realmName: string, realm: IRatingRealm) {
+  const { commentPath, seedComment, raterAuth, raterId, otherUserId } = realm;
+
+  describe(realmName, () => {
+    let db: firebase.firestore.Firestore;
+
+    beforeEach(async () => {
+      await prepareEachTest();
+      db = initFirestore(raterAuth);
+    });
+
+    it.each(["yes", "no", "notSure"])("a user can rate a comment '%s'", async (value) => {
+      await seedComment();
+      await expectRatingUpdateToSucceed(db, commentPath, { [`ratings.${raterId}`]: value });
+    });
+
+    it("a user can change their own rating to another allowed value", async () => {
+      await seedComment({ [raterId]: "yes" });
+      await expectRatingUpdateToSucceed(db, commentPath, { [`ratings.${raterId}`]: "no" });
+    });
+
+    it("a user can toggle their own rating off by deleting their key", async () => {
+      await seedComment({ [raterId]: "yes" });
+      await expectRatingUpdateToSucceed(db, commentPath,
+        { [`ratings.${raterId}`]: firebase.firestore.FieldValue.delete() });
+    });
+
+    it("a user can toggle their own rating off while another user's rating remains", async () => {
+      await seedComment({ [raterId]: "yes", [otherUserId]: "no" });
+      await expectRatingUpdateToSucceed(db, commentPath,
+        { [`ratings.${raterId}`]: firebase.firestore.FieldValue.delete() });
+    });
+
+    it("rejects a rating value outside the allowed set", async () => {
+      await seedComment();
+      await expectRatingUpdateToFail(db, commentPath, { [`ratings.${raterId}`]: "maybe" });
+    });
+
+    it("rejects an empty rating value", async () => {
+      await seedComment();
+      await expectRatingUpdateToFail(db, commentPath, { [`ratings.${raterId}`]: "" });
+    });
+
+    it("rejects a rating value that isn't a string", async () => {
+      await seedComment();
+      await expectRatingUpdateToFail(db, commentPath, { [`ratings.${raterId}`]: 1 });
+      await expectRatingUpdateToFail(db, commentPath, { [`ratings.${raterId}`]: true });
+      await expectRatingUpdateToFail(db, commentPath, { [`ratings.${raterId}`]: { value: "yes" } });
+      await expectRatingUpdateToFail(db, commentPath, { [`ratings.${raterId}`]: ["yes"] });
+    });
+
+    it("rejects changing an existing rating of one's own to a disallowed value", async () => {
+      await seedComment({ [raterId]: "yes" });
+      await expectRatingUpdateToFail(db, commentPath, { [`ratings.${raterId}`]: "definitely" });
+    });
+
+    it("rejects replacing the whole ratings map", async () => {
+      await seedComment({ [otherUserId]: "no" });
+      await expectRatingUpdateToFail(db, commentPath, { ratings: { [raterId]: "yes" } });
+    });
+
+    it("rejects writing another user's rating", async () => {
+      await seedComment();
+      await expectRatingUpdateToFail(db, commentPath, { [`ratings.${otherUserId}`]: "yes" });
+    });
+
+    it("rejects deleting another user's rating", async () => {
+      await seedComment({ [otherUserId]: "yes" });
+      await expectRatingUpdateToFail(db, commentPath,
+        { [`ratings.${otherUserId}`]: firebase.firestore.FieldValue.delete() });
+    });
+
+    it("rejects a valid rating that also changes another field", async () => {
+      await seedComment();
+      await expectRatingUpdateToFail(db, commentPath,
+        { [`ratings.${raterId}`]: "yes", content: "A different comment!" });
+    });
+  });
+}
+
+describe("Firestore security rules for comment ratings", () => {
+
+  afterAll(async () => {
+    await tearDownTests();
+  });
+
+  // A student in the class rates a teacher's comment on a document in that class.
+  const kDocumentDocPath = "authed/myPortal/documents/myDocument";
+  testRatingRules("document comment ratings", {
+    commentPath: `${kDocumentDocPath}/comments/myComment`,
+    raterAuth: studentAuth,
+    raterId: studentId,
+    otherUserId: student2Id,
+    seedComment: async (ratings?: Record<string, any>) => {
+      await adminWriteDoc(kDocumentDocPath, {
+        context_id: thisClass, network: noNetwork, uid: teacherId, type: "problemDocument",
+        key: "my-document", createdAt: mockTimestamp()
+      });
+      await adminWriteDoc(`${kDocumentDocPath}/comments/myComment`, {
+        uid: teacherId, name: teacherName, network: noNetwork, content: "A comment!",
+        createdAt: mockTimestamp(), ...(ratings ? { ratings } : {})
+      });
+    }
+  });
+
+  // A teacher in the document's network rates another teacher's comment on a curriculum document.
+  // Only teachers with access to the curriculum document can rate its comments.
+  const kCurriculumDocPath = "authed/myPortal/curriculum/myCurriculum";
+  testRatingRules("curriculum comment ratings", {
+    commentPath: `${kCurriculumDocPath}/comments/myComment`,
+    raterAuth: teacher2Auth,
+    raterId: teacher2Id,
+    otherUserId: teacherId,
+    seedComment: async (ratings?: Record<string, any>) => {
+      await adminWriteDoc(kCurriculumDocPath, {
+        uid: teacherId, unit: cUnit, problem: cProblem, section: cSection, path: cPath,
+        network: network1
+      });
+      // teacher 2 reaches the document through the network it belongs to
+      await adminWriteDoc(`authed/myPortal/users/${teacher2Id}`, {
+        uid: teacher2Id, name: teacher2Name, type: "teacher", networks: [network1]
+      });
+      await adminWriteDoc(`${kCurriculumDocPath}/comments/myComment`, {
+        uid: teacherId, name: teacherName, network: network1, content: "A comment!",
+        createdAt: mockTimestamp(), ...(ratings ? { ratings } : {})
+      });
+    }
+  });
+});

--- a/firebase-test/src/comment-ratings-rules.test.ts
+++ b/firebase-test/src/comment-ratings-rules.test.ts
@@ -1,10 +1,9 @@
 import { assertFails, assertSucceeds } from "@firebase/rules-unit-testing";
 import firebase from "firebase";
 import {
-  adminWriteDoc, cPath, cProblem, cSection, cUnit, expectWriteToFail, expectWriteToSucceed,
-  initFirestore, mockTimestamp, network1, noNetwork, prepareEachTest, student2Id, studentAuth,
-  studentId, studentName, teacher2Auth, teacher2Id, teacher2Name, teacherAuth, teacherId,
-  teacherName, tearDownTests, thisClass
+  adminWriteDoc, cPath, cProblem, cSection, cUnit, initFirestore, mockTimestamp, network1, noNetwork,
+  prepareEachTest, student2Id, studentAuth, studentId, teacher2Auth, teacher2Id, teacher2Name,
+  teacherAuth, teacherId, teacherName, tearDownTests, thisClass
 } from "./setup-rules-tests";
 
 // The client rates a comment by updating a single dotted key, and toggles a rating off by deleting
@@ -35,17 +34,10 @@ interface IRatingRealm {
   authorAuth: any;
   // the author's platform user id
   authorId: string;
-  // writes the parent document alone, for tests that create the comment themselves
-  seedParent: () => Promise<void>;
-  // path of a comment that doesn't exist yet, which the rater creates
-  newCommentPath: string;
-  // a comment the rater can validly create, plus whatever fields the test is probing
-  newComment: (extraFields?: Record<string, any>) => Record<string, any>;
 }
 
 function testRatingRules(realmName: string, realm: IRatingRealm) {
-  const { commentPath, seedComment, raterAuth, raterId, otherUserId, authorAuth, authorId,
-    seedParent, newCommentPath, newComment } = realm;
+  const { commentPath, seedComment, raterAuth, raterId, otherUserId, authorAuth, authorId } = realm;
 
   describe(realmName, () => {
     let db: firebase.firestore.Firestore;
@@ -160,31 +152,6 @@ function testRatingRules(realmName: string, realm: IRatingRealm) {
         await expectRatingUpdateToFail(db, commentPath,
           { [`ratings.${authorId}`]: "yes", content: "A different comment!" });
       });
-
-      it("rejects the author adding agreeWithAi to their own comment", async () => {
-        await seedComment();
-        await expectRatingUpdateToFail(db, commentPath, { agreeWithAi: { version: 1, value: "yes" } });
-      });
-    });
-
-    // `ratings` and `agreeWithAi` are also forbidden at creation, so a comment can't be born with
-    // entries that never passed the rules above. Nothing legitimate creates comments this way: the
-    // app posts them through the postDocumentComment_v2 callable, which runs as admin.
-    describe("creating a comment", () => {
-      it("a user can create an ordinary comment", async () => {
-        await seedParent();
-        await expectWriteToSucceed(db, newCommentPath, newComment());
-      });
-
-      it("rejects a create that carries a ratings map", async () => {
-        await seedParent();
-        await expectWriteToFail(db, newCommentPath, newComment({ ratings: { [raterId]: "yes" } }));
-      });
-
-      it("rejects a create that carries agreeWithAi", async () => {
-        await seedParent();
-        await expectWriteToFail(db, newCommentPath, newComment({ agreeWithAi: { version: 1, value: "yes" } }));
-      });
     });
   });
 }
@@ -197,12 +164,6 @@ describe("Firestore security rules for comment ratings", () => {
 
   // A student in the class rates a teacher's comment on a document in that class.
   const kDocumentDocPath = "authed/myPortal/documents/myDocument";
-  const seedDocument = async () => {
-    await adminWriteDoc(kDocumentDocPath, {
-      context_id: thisClass, network: noNetwork, uid: teacherId, type: "problemDocument",
-      key: "my-document", createdAt: mockTimestamp()
-    });
-  };
   testRatingRules("document comment ratings", {
     commentPath: `${kDocumentDocPath}/comments/myComment`,
     raterAuth: studentAuth,
@@ -210,34 +171,21 @@ describe("Firestore security rules for comment ratings", () => {
     otherUserId: student2Id,
     authorAuth: teacherAuth,
     authorId: teacherId,
-    seedParent: seedDocument,
     seedComment: async (ratings?: Record<string, any>) => {
-      await seedDocument();
+      await adminWriteDoc(kDocumentDocPath, {
+        context_id: thisClass, network: noNetwork, uid: teacherId, type: "problemDocument",
+        key: "my-document", createdAt: mockTimestamp()
+      });
       await adminWriteDoc(`${kDocumentDocPath}/comments/myComment`, {
         uid: teacherId, name: teacherName, network: noNetwork, content: "A comment!",
         createdAt: mockTimestamp(), ...(ratings ? { ratings } : {})
       });
-    },
-    newCommentPath: `${kDocumentDocPath}/comments/aNewComment`,
-    newComment: (extraFields?: Record<string, any>) => ({
-      uid: studentId, name: studentName, network: noNetwork, content: "A new comment!",
-      createdAt: mockTimestamp(), ...extraFields
-    })
+    }
   });
 
   // A teacher in the document's network rates another teacher's comment on a curriculum document.
   // Only teachers with access to the curriculum document can rate its comments.
   const kCurriculumDocPath = "authed/myPortal/curriculum/myCurriculum";
-  const seedCurriculum = async () => {
-    await adminWriteDoc(kCurriculumDocPath, {
-      uid: teacherId, unit: cUnit, problem: cProblem, section: cSection, path: cPath,
-      network: network1
-    });
-    // teacher 2 reaches the document through the network it belongs to
-    await adminWriteDoc(`authed/myPortal/users/${teacher2Id}`, {
-      uid: teacher2Id, name: teacher2Name, type: "teacher", networks: [network1]
-    });
-  };
   testRatingRules("curriculum comment ratings", {
     commentPath: `${kCurriculumDocPath}/comments/myComment`,
     raterAuth: teacher2Auth,
@@ -245,18 +193,19 @@ describe("Firestore security rules for comment ratings", () => {
     otherUserId: teacherId,
     authorAuth: teacherAuth,
     authorId: teacherId,
-    seedParent: seedCurriculum,
     seedComment: async (ratings?: Record<string, any>) => {
-      await seedCurriculum();
+      await adminWriteDoc(kCurriculumDocPath, {
+        uid: teacherId, unit: cUnit, problem: cProblem, section: cSection, path: cPath,
+        network: network1
+      });
+      // teacher 2 reaches the document through the network it belongs to
+      await adminWriteDoc(`authed/myPortal/users/${teacher2Id}`, {
+        uid: teacher2Id, name: teacher2Name, type: "teacher", networks: [network1]
+      });
       await adminWriteDoc(`${kCurriculumDocPath}/comments/myComment`, {
         uid: teacherId, name: teacherName, network: network1, content: "A comment!",
         createdAt: mockTimestamp(), ...(ratings ? { ratings } : {})
       });
-    },
-    newCommentPath: `${kCurriculumDocPath}/comments/aNewComment`,
-    newComment: (extraFields?: Record<string, any>) => ({
-      uid: teacher2Id, name: teacher2Name, network: network1, content: "A new comment!",
-      createdAt: mockTimestamp(), ...extraFields
-    })
+    }
   });
 });

--- a/firestore.rules
+++ b/firestore.rules
@@ -418,21 +418,15 @@ service cloud.firestore {
           return userIsRequestUser() &&
                   // comments network must match network of parent document
                   (request.resource.data.network == getCurriculumNetwork()) &&
-                  request.resource.data.keys().hasAll(["name", "createdAt", "content", "network"]) &&
-                  // a comment can't be created carrying either frozen field
-                  !('ratings' in request.resource.data) &&
-                  !('agreeWithAi' in request.resource.data);
+                  request.resource.data.keys().hasAll(["name", "createdAt", "content", "network"]);
         }
 
-        // Two of these fields can change, and are listed here so that an edit to the comment can't
-        // carry a change to them. `ratings` changes only through isValidRatingUpdate, which limits a
+        // `ratings` can change, and is listed here so that an edit to the comment can't carry a
+        // rating change with it. Ratings change only through isValidRatingUpdate, which limits a
         // write to the requester's own key and to the values the UI offers — including when the
-        // requester wrote the comment. `agreeWithAi` is a legacy field with no legitimate
-        // rules-governed writer (the app posts comments through the postDocumentComment_v2 admin
-        // callable, which bypasses these rules); it stays frozen until the CLUE-645 cutover removes
-        // the function that consumes it.
+        // requester wrote the comment.
         function preservesReadOnlyCommentFields() {
-          let readOnlyFieldsSet = ["uid", "network", "createdAt", "tileId", "ratings", "agreeWithAi"].toSet();
+          let readOnlyFieldsSet = ["uid", "network", "createdAt", "tileId", "ratings"].toSet();
           let affectedFieldsSet = request.resource.data.diff(resource.data).affectedKeys();
           return !affectedFieldsSet.hasAny(readOnlyFieldsSet);
         }
@@ -605,21 +599,15 @@ service cloud.firestore {
           return userIsRequestUser() &&
                   // comment's network must match network of parent document
                   (request.resource.data.network == getDocumentNetwork()) &&
-                  request.resource.data.keys().hasAll(["name", "createdAt", "content"]) &&
-                  // a comment can't be created carrying either frozen field
-                  !('ratings' in request.resource.data) &&
-                  !('agreeWithAi' in request.resource.data);
+                  request.resource.data.keys().hasAll(["name", "createdAt", "content"]);
         }
 
-        // Two of these fields can change, and are listed here so that an edit to the comment can't
-        // carry a change to them. `ratings` changes only through isValidRatingUpdate, which limits a
+        // `ratings` can change, and is listed here so that an edit to the comment can't carry a
+        // rating change with it. Ratings change only through isValidRatingUpdate, which limits a
         // write to the requester's own key and to the values the UI offers — including when the
-        // requester wrote the comment. `agreeWithAi` is a legacy field with no legitimate
-        // rules-governed writer (the app posts comments through the postDocumentComment_v2 admin
-        // callable, which bypasses these rules); it stays frozen until the CLUE-645 cutover removes
-        // the function that consumes it.
+        // requester wrote the comment.
         function preservesReadOnlyCommentFields() {
-          let readOnlyFieldsSet = ["uid", "network", "createdAt", "tileId", "ratings", "agreeWithAi"].toSet();
+          let readOnlyFieldsSet = ["uid", "network", "createdAt", "tileId", "ratings"].toSet();
           let affectedFieldsSet = request.resource.data.diff(resource.data).affectedKeys();
           return !affectedFieldsSet.hasAny(readOnlyFieldsSet);
         }

--- a/firestore.rules
+++ b/firestore.rules
@@ -421,10 +421,8 @@ service cloud.firestore {
                   request.resource.data.keys().hasAll(["name", "createdAt", "content", "network"]);
         }
 
-        // `ratings` can change, and is listed here so that an edit to the comment can't carry a
-        // rating change with it. Ratings change only through isValidRatingUpdate, which limits a
-        // write to the requester's own key and to the values the UI offers — including when the
-        // requester wrote the comment.
+        // `ratings` is listed here so a comment edit can't carry a rating change: isValidRatingUpdate
+        // is the only path that changes it, authors included.
         function preservesReadOnlyCommentFields() {
           let readOnlyFieldsSet = ["uid", "network", "createdAt", "tileId", "ratings"].toSet();
           let affectedFieldsSet = request.resource.data.diff(resource.data).affectedKeys();
@@ -437,7 +435,6 @@ service cloud.firestore {
           let existingRatings = resource.data.get('ratings', {});
           let newRatings = request.resource.data.get('ratings', {});
           // The user's own key missing from the new map is the toggle-off case, which is allowed.
-          // When the key is present, its value must be one of the values the UI offers.
           return affectedFields.hasOnly(['ratings'])
             && newRatings.diff(existingRatings).affectedKeys().hasOnly([userId])
             && (!(userId in newRatings) || newRatings[userId] in ['yes', 'no', 'notSure']);
@@ -602,10 +599,8 @@ service cloud.firestore {
                   request.resource.data.keys().hasAll(["name", "createdAt", "content"]);
         }
 
-        // `ratings` can change, and is listed here so that an edit to the comment can't carry a
-        // rating change with it. Ratings change only through isValidRatingUpdate, which limits a
-        // write to the requester's own key and to the values the UI offers — including when the
-        // requester wrote the comment.
+        // `ratings` is listed here so a comment edit can't carry a rating change: isValidRatingUpdate
+        // is the only path that changes it, authors included.
         function preservesReadOnlyCommentFields() {
           let readOnlyFieldsSet = ["uid", "network", "createdAt", "tileId", "ratings"].toSet();
           let affectedFieldsSet = request.resource.data.diff(resource.data).affectedKeys();
@@ -618,7 +613,6 @@ service cloud.firestore {
           let existingRatings = resource.data.get('ratings', {});
           let newRatings = request.resource.data.get('ratings', {});
           // The user's own key missing from the new map is the toggle-off case, which is allowed.
-          // When the key is present, its value must be one of the values the UI offers.
           return affectedFields.hasOnly(['ratings'])
             && newRatings.diff(existingRatings).affectedKeys().hasOnly([userId])
             && (!(userId in newRatings) || newRatings[userId] in ['yes', 'no', 'notSure']);

--- a/firestore.rules
+++ b/firestore.rules
@@ -432,8 +432,11 @@ service cloud.firestore {
           let userId = string(request.auth.token.platform_user_id);
           let existingRatings = resource.data.get('ratings', {});
           let newRatings = request.resource.data.get('ratings', {});
+          // The user's own key missing from the new map is the toggle-off case, which is allowed.
+          // When the key is present, its value must be one of the values the UI offers.
           return affectedFields.hasOnly(['ratings'])
-            && newRatings.diff(existingRatings).affectedKeys().hasOnly([userId]);
+            && newRatings.diff(existingRatings).affectedKeys().hasOnly([userId])
+            && (!(userId in newRatings) || newRatings[userId] in ['yes', 'no', 'notSure']);
         }
 
         function isValidCommentUpdateRequest() {
@@ -606,8 +609,11 @@ service cloud.firestore {
           let userId = string(request.auth.token.platform_user_id);
           let existingRatings = resource.data.get('ratings', {});
           let newRatings = request.resource.data.get('ratings', {});
+          // The user's own key missing from the new map is the toggle-off case, which is allowed.
+          // When the key is present, its value must be one of the values the UI offers.
           return affectedFields.hasOnly(['ratings'])
-            && newRatings.diff(existingRatings).affectedKeys().hasOnly([userId]);
+            && newRatings.diff(existingRatings).affectedKeys().hasOnly([userId])
+            && (!(userId in newRatings) || newRatings[userId] in ['yes', 'no', 'notSure']);
         }
 
         function isValidCommentUpdateRequest() {

--- a/firestore.rules
+++ b/firestore.rules
@@ -418,11 +418,21 @@ service cloud.firestore {
           return userIsRequestUser() &&
                   // comments network must match network of parent document
                   (request.resource.data.network == getCurriculumNetwork()) &&
-                  request.resource.data.keys().hasAll(["name", "createdAt", "content", "network"]);
+                  request.resource.data.keys().hasAll(["name", "createdAt", "content", "network"]) &&
+                  // a comment can't be created carrying either frozen field
+                  !('ratings' in request.resource.data) &&
+                  !('agreeWithAi' in request.resource.data);
         }
 
+        // Two of these fields can change, and are listed here so that an edit to the comment can't
+        // carry a change to them. `ratings` changes only through isValidRatingUpdate, which limits a
+        // write to the requester's own key and to the values the UI offers — including when the
+        // requester wrote the comment. `agreeWithAi` is a legacy field with no legitimate
+        // rules-governed writer (the app posts comments through the postDocumentComment_v2 admin
+        // callable, which bypasses these rules); it stays frozen until the CLUE-645 cutover removes
+        // the function that consumes it.
         function preservesReadOnlyCommentFields() {
-          let readOnlyFieldsSet = ["uid", "network", "createdAt", "tileId"].toSet();
+          let readOnlyFieldsSet = ["uid", "network", "createdAt", "tileId", "ratings", "agreeWithAi"].toSet();
           let affectedFieldsSet = request.resource.data.diff(resource.data).affectedKeys();
           return !affectedFieldsSet.hasAny(readOnlyFieldsSet);
         }
@@ -595,11 +605,21 @@ service cloud.firestore {
           return userIsRequestUser() &&
                   // comment's network must match network of parent document
                   (request.resource.data.network == getDocumentNetwork()) &&
-                  request.resource.data.keys().hasAll(["name", "createdAt", "content"]);
+                  request.resource.data.keys().hasAll(["name", "createdAt", "content"]) &&
+                  // a comment can't be created carrying either frozen field
+                  !('ratings' in request.resource.data) &&
+                  !('agreeWithAi' in request.resource.data);
         }
 
+        // Two of these fields can change, and are listed here so that an edit to the comment can't
+        // carry a change to them. `ratings` changes only through isValidRatingUpdate, which limits a
+        // write to the requester's own key and to the values the UI offers — including when the
+        // requester wrote the comment. `agreeWithAi` is a legacy field with no legitimate
+        // rules-governed writer (the app posts comments through the postDocumentComment_v2 admin
+        // callable, which bypasses these rules); it stays frozen until the CLUE-645 cutover removes
+        // the function that consumes it.
         function preservesReadOnlyCommentFields() {
-          let readOnlyFieldsSet = ["uid", "network", "createdAt", "tileId"].toSet();
+          let readOnlyFieldsSet = ["uid", "network", "createdAt", "tileId", "ratings", "agreeWithAi"].toSet();
           let affectedFieldsSet = request.resource.data.diff(resource.data).affectedKeys();
           return !affectedFieldsSet.hasAny(readOnlyFieldsSet);
         }

--- a/shared/shared.ts
+++ b/shared/shared.ts
@@ -233,13 +233,16 @@ export interface IPublishSupportParams extends IFirebaseFunctionBaseParams {
 }
 export type IPublishSupportUnionParams = IPublishSupportParams | IFirebaseFunctionWarmUpParams;
 
+export const kRatingValues = ["yes", "no", "notSure"] as const;
+
+export type RatingValue = typeof kRatingValues[number];
+
 export interface IAgreeWithAi {
   version: 1;
-  value: "yes" | "no" | "notSure";
+  value: RatingValue;
 }
 
 export type AgreementValue = IAgreeWithAi["value"]
-export type RatingValue = "yes" | "no" | "notSure";
 export interface IClientCommentParams {
   tileId?: string;    // empty for document comments
   content: string;    // plain text for now; potentially html if we need rich text

--- a/src/components/chat/comment-card.tsx
+++ b/src/components/chat/comment-card.tsx
@@ -12,7 +12,7 @@ import { logDocumentViewEvent } from "../../models/document/log-document-event";
 import { DocumentModelType } from "../../models/document/document";
 import ChatAvatar from "./chat-avatar";
 import WaitingMessage from "./waiting-message";
-import { isSectionPath, escapeKey, RatingValue } from "../../../shared/shared";
+import { isSectionPath, escapeKey, kRatingValues, RatingValue } from "../../../shared/shared";
 import { useCommentsCollectionPath } from "../../hooks/document-comment-hooks";
 import { useUpdateCommentRating } from "../../hooks/use-update-comment-rating";
 import { logCommentEvent } from "../../models/tiles/log/log-comment-event";
@@ -27,7 +27,7 @@ import "./comment-card.scss";
 import "../themes.scss";
 
 function countRatings(ratings: Record<string, RatingValue> | undefined): Record<RatingValue, number> {
-  const counts: Record<RatingValue, number> = { yes: 0, no: 0, notSure: 0 };
+  const counts = Object.fromEntries(kRatingValues.map(value => [value, 0])) as Record<RatingValue, number>;
   if (ratings) {
     Object.values(ratings).forEach(v => { counts[v]++; });
   }
@@ -187,11 +187,14 @@ export const CommentCard: React.FC<IProps> = observer(({ activeNavTab, user, pos
       : `documents/${focusDocument}/comments`)
     : "";
 
-  const ratingButtons: { value: RatingValue; label: string; icon: JSX.Element; testId: string }[] = [
-    { value: "yes", label: "Yes", icon: <YesIcon />, testId: "rating-yes-button" },
-    { value: "no", label: "No", icon: <NoIcon />, testId: "rating-no-button" },
-    { value: "notSure", label: "Not Sure", icon: <NotSureIcon />, testId: "rating-not-sure-button" },
-  ];
+  const ratingButtonProps: Record<RatingValue, { label: string; icon: JSX.Element; testId: string }> = {
+    yes: { label: "Yes", icon: <YesIcon />, testId: "rating-yes-button" },
+    no: { label: "No", icon: <NoIcon />, testId: "rating-no-button" },
+    notSure: { label: "Not Sure", icon: <NotSureIcon />, testId: "rating-not-sure-button" },
+  };
+  // Keyed by rating value, so a value added to kRatingValues doesn't compile here until it has a
+  // label and an icon. The order shown follows kRatingValues.
+  const ratingButtons = kRatingValues.map(value => ({ value, ...ratingButtonProps[value] }));
 
   const renderRatingButtons = (comment: WithId<CommentDocument>) => {
     if (!showCommentRating) return null;

--- a/src/components/chat/comment-rating-rules.test.ts
+++ b/src/components/chat/comment-rating-rules.test.ts
@@ -1,0 +1,33 @@
+import * as fs from "fs";
+import * as path from "path";
+import { kRatingValues } from "../../../shared/shared";
+
+// firestore.rules can't import kRatingValues, so the rating enum is spelled out twice there —
+// once in the document comment block, once in the curriculum one. Adding a value to the shared
+// list and missing either block is a silent break: every write of the new value fails with
+// permission-denied while the whole Jest suite stays green.
+//
+// The file is read from disk rather than imported because it isn't JavaScript. That makes this a
+// textual check: it verifies the two enums agree with the shared list, not that the surrounding
+// rule logic is correct — the emulator suite in firebase-test/ covers that.
+const rulesPath = path.join(__dirname, "../../../firestore.rules");
+
+// Matches the enum pin in both blocks: `newRatings[userId] in ['yes', 'no', 'notSure']`.
+const ratingEnumRegex = /newRatings\[userId\] in \[([^\]]*)\]/g;
+
+function parseRatingEnums(): string[][] {
+  const rules = fs.readFileSync(rulesPath, "utf8");
+  return [...rules.matchAll(ratingEnumRegex)]
+    .map(match => match[1].split(",").map(entry => entry.trim().replace(/^['"]|['"]$/g, "")));
+}
+
+describe("firestore.rules comment rating enum", () => {
+  // One assertion over the whole match set, not a loop over it. A loop passes vacuously if the
+  // pins are ever reworded out of the regex's reach, and pairing it with a separate count
+  // assertion guards that only by convention. Comparing the match set against both expected
+  // lists at once fails on a missing pin, an extra pin, content drift, and an empty match set
+  // alike.
+  it("pins exactly the shared vocabulary in both comment blocks", () => {
+    expect(parseRatingEnums()).toEqual([[...kRatingValues], [...kRatingValues]]);
+  });
+});


### PR DESCRIPTION
This is a small, preliminary step for the upcoming changes for [CLUE-645](https://concord-consortium.atlassian.net/browse/CLUE-645) that can be done independently from them.

Most of this is `firestore.rules`. It also moves the three rating values into a single shared list, which touches `shared/shared.ts` and the comment UI, and adds a Jest test that keeps the rules in step with that list. No functions changes, no index changes.

## Why

When a user rates a comment, the rating is stored in a `ratings` map on that comment, under the user's own id. The rules checked which key in that map a write touched, but never what it stored there, so the value could be any text at all.

Today that text does not go far: the only thing that reads it is the count shown beside the comment. The upcoming CLUE-645 work changes that. It copies rating values into the document summaries that are sent to the AI when it evaluates a similar document, so from then on an unchecked value becomes part of what the AI reads. A signed-in student or teacher can write a rating by hand: open the browser's developer console, paste in a few lines, and store any text at all as their own rating. They can only act as themselves (they cannot rate on someone else's behalf, or change anyone else's comment) but nothing checks what they store.

I don't think this is likely to happen. It takes deliberate effort and some curiosity about developer tools, and nothing suggests anyone has tried. The reason to do it now is that the fix is two small conditions in the rules with no cost at runtime, and it is simpler to have them in place before rating values start being read than to add them afterwards, once unchecked values could already be sitting in the database.

## What changed

Both sets of comment rules are updated the same way, the ones for comments on student documents and the ones for comments on curriculum documents.

1. A rating value must now be `yes`, `no`, or `notSure`. Removing your own rating still works: when your key is not in the new map there is no value to check, and the rule allows that case explicitly.

2. `ratings` is now listed as read-only in `preservesReadOnlyCommentFields()`. Updating a comment is allowed in two situations: the person who wrote the comment is editing it, or someone is writing a valid rating. The first of those never looked at rating values, so the person who wrote a comment could still put anything into the `ratings` map on it, including entries under other people's ids. Listing the field as read-only there means every write to `ratings` has to go through the rating rule instead. Rating your own comment still works, because that write is handled by the rating rule rather than the edit rule.

Separately, the three values now live in one place. `kRatingValues` in `shared/shared.ts` is the source, and `RatingValue` and `IAgreeWithAi["value"]` derive from it, as do the comment UI and the emulator tests. `firestore.rules` can't import it, so the values are still written out in both rules blocks; `src/components/chat/comment-rating-rules.test.ts` reads the file and fails if either block drifts from the shared list, or if an enum check is removed. This follows the pattern already used for the chat tutor providers.

The rating buttons in `comment-card.tsx` are now keyed by rating value and mapped over the shared list, so adding a fourth value stops that file compiling until the value has a label and an icon.

## One behavior change worth knowing about

A single write that both edits a comment and changes a rating is now refused. Nothing in the app does that: rating a comment is always its own separate write, in `src/hooks/use-update-comment-rating.ts`.

## What this does not cover

Comments are created by a server function that runs with full access, so these rules do not apply to it. A caller could still send extra fields to that function and have them stored. We looked at closing that and decided against it for now, to keep this change small.

Comments also carry an older field, `agreeWithAi`, and that is the value which reaches the AI's input today: the function that builds document summaries copies it in without checking it. Nothing in the app writes that field any more, and the upcoming work removes the function that reads it, so this change leaves it alone. This PR does not close that path.

The defense that holds no matter who wrote the value is the planned read-side check, which ignores any rating value outside the three allowed ones when building the AI's input. That is also the only thing that covers the `demo` and `dev` areas of the database, where the rules allow any signed-in user to write anything, and the only thing that helps with values already stored.

## Tests

New file: `firebase-test/src/comment-ratings-rules.test.ts`. It runs the same 20 cases against both kinds of comment, 40 tests in total.

Rating someone else's comment: each allowed value works; changing your own rating works; removing your own rating works, both on its own and when another person's rating is present. Refused: a value outside the three, an empty string, a number, a boolean, a map, an array, another person's key, replacing the whole map, and a rating sent together with another field.

Rating your own comment: rating it works, and editing its text still works. Refused: an invalid value, another person's key, replacing the map in a way that drops someone else's rating, and an edit that carries a rating change with it.

The tests write the same way the app does: a single `ratings.<user id>` key, and a field delete to remove a rating. Test data is written with the rules turned off, so a comment can be set up in any shape the tests need.

## A note on CI

The 40 tests in `firebase-test/` don't run in CI: the root Jest project ignores that directory, and no workflow starts a Firestore emulator for it. `origin/ci-firebase-rules-tests` changes that, and this PR doesn't wait on it.

I ran them locally against the emulator. The whole `firebase-test` suite passes: 478 passed, 2 skipped, across 11 files. I also ran the new tests against the old rules, by restoring `firestore.rules` from `master`: 16 of the 40 fail, which is every test that expects a write to be refused because of this change, and every test that expects a write to succeed still passes.

`src/components/chat/comment-rating-rules.test.ts` does run in CI, so the shared list and the two rules blocks can't drift apart unnoticed. It doesn't check rule behavior, though — the `readOnlyFieldsSet` change has no CI coverage until the emulator suite runs there.

[CLUE-645]: https://concord-consortium.atlassian.net/browse/CLUE-645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
