### PR TITLE
feat: persist document summaries so ratings can be recorded (CLUE-645)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,8 +32,9 @@ npm run lint:fix               # ESLint with auto-fix
 npm run check:types            # TypeScript type checking
 
 # Firebase
-npm run deploy:firestore:rules # Deploy Firestore security rules
-npm run deploy:database:rules  # Deploy realtime database rules
+npm run deploy:firestore:rules   # Deploy Firestore security rules
+npm run deploy:firestore:indexes # Deploy Firestore indexes (see functions-v2/README.md first)
+npm run deploy:database:rules    # Deploy realtime database rules
 ```
 
 ## Architecture

--- a/docs/plans/CLUE-645-ratings-to-summaries-design.md
+++ b/docs/plans/CLUE-645-ratings-to-summaries-design.md
@@ -312,7 +312,11 @@ the moment Track C starts populating it, so Track C must close it, not discover 
    require an exact composite index, so the deploy has to include it or the lookup returns an error
    rather than degrading. Deploy the index **before** the function that queries it.
 4. Existing records predate both fields and will not match a scoped query. Acceptable — the corpus
-   is one demo record, and re-analysis rewrites it with the fields present.
+   is one demo record, and re-analysis rewrites it with the fields present. That holds only for a
+   record already at the id the shared helper derives: `onDocumentSummarized` keyed by the metadata
+   document id, which differs from `key` on older documents, so such a record is never found again
+   and is stranded rather than refreshed. Consistent with Resolved Decision 3 (no backfill), and
+   the one production record is not one of them.
 
 ## Read Side
 

--- a/docs/plans/CLUE-645-ratings-to-summaries-design.md
+++ b/docs/plans/CLUE-645-ratings-to-summaries-design.md
@@ -452,3 +452,29 @@ covers the read side and is extended.
 | `firestore.indexes.json` | Track C: `root` and `space` added to the `summaries` composite index (realm scoping) |
 
 No client files change.
+
+## Deviations (Track C, 2026-09-01)
+
+Where this document and the code disagree, prefer the code. The full reconciliation list is in the
+implementation plan under DEVIATIONS; recorded here are the three that change something this
+document states.
+
+1. **`summaryEmbedding` is a `VectorValue`, not a `FieldValue`** (Data Model). `FieldValue.vector()`
+   is what produces a vector; `VectorValue` is what a vector is, and what a read gives back. The
+   type had never had a writer, so nothing had caught it.
+2. **The categorize function is `categorizeRepresentations`** (Pipeline change 1), and hoisting the
+   embedding out of `findRelatedSummaries` also hoisted the metadata read, because the summary write
+   needs the same fields the lookup does and reading them twice would be two reads of one document.
+3. **A failed summary write does not fail the run** — it is logged, and Ada's comment is posted
+   anyway. Pipeline change 3 fixes the *order* of the two writes but says nothing about what happens
+   when the first one fails. The evaluation succeeded and the student is owed its feedback; a
+   missing record costs only ratings of that comment, which `onCommentRated` already logs and skips,
+   and the next analysis writes the record again.
+
+Unchanged by reconciliation, and worth restating because it is the one thing here that has to
+happen in a particular order outside the code: **the `summaries` composite index carrying `root`
+and `space` must be deployed and built before the functions deploy.** Note the failure mode is
+quiet, not loud: a missing index fails the query with `FAILED_PRECONDITION`, which
+`categorizeRepresentations` catches and continues past, so the wrong order costs agreement counts
+in prompts without anything appearing to break. The measured procedure is in the implementation
+plan under "Deploying Track C".

--- a/docs/plans/CLUE-645-ratings-to-summaries-design.md
+++ b/docs/plans/CLUE-645-ratings-to-summaries-design.md
@@ -448,10 +448,13 @@ covers the read side and is extended.
 | Shared summary-id helper (new, alongside path helpers) | Canonical `summaryId` derivation for both writers |
 | `functions-v2/test/…` | New `onCommentRated` suite; pipeline-write and read-side test updates |
 | `firebase-test/src/…` | Rules tests for the value enum |
-
 | `firestore.indexes.json` | Track C: `root` and `space` added to the `summaries` composite index (realm scoping) |
 
-No client files change.
+Client files do change, though client behavior does not. Track A moved the rating values into
+`shared/shared.ts` and had `comment-card.tsx` derive its buttons from them; Track C removes the
+retired `agreeWithAi` parameter from `chat-panel.tsx` and `document-comment-hooks.ts`. The
+stored-comment schema keeps `agreeWithAi`, which `onCommentRated` reads when a legacy comment is
+deleted.
 
 ## Deviations (Track C, 2026-09-01)
 

--- a/docs/plans/CLUE-645-ratings-to-summaries-implementation.md
+++ b/docs/plans/CLUE-645-ratings-to-summaries-implementation.md
@@ -7,10 +7,11 @@ record the departure (see DEVIATIONS at the end).
 **Verified against:** `master` at `c08e75c28` (2026-08-27), post-harness-merge. File and symbol
 references below were re-checked on that commit.
 
-**Status (2026-09-01).** Track A shipped in PR #2990. Track B — tasks 3 to 6 — is merged, and its
-functions are deployed to production, where `onCommentRated` runs but finds no summaries to record
-against. Track C's tasks 7 to 9 are implemented on `CLUE-645-track-c`, which is what makes the
-collection exist; task 11 is the only one here that describes work still to do.
+**Status (2026-09-02).** Track A (tasks 1 and 2) shipped in PR #2990 and Track B (tasks 3 to 6) in
+PR #2991. Both are merged and deployed to production, where `onCommentRated` runs on every rating
+but finds no summary to record it against. Track C — tasks 7 to 11 — is implemented on
+`CLUE-645-persist-document-summaries`, and is what makes those summaries exist. Every task in this
+plan is now written; what remains is the deployment.
 
 **The one thing in Track C with no equivalent in code is the index deploy.** The realm-scoped
 lookup needs `root` and `space` in the `summaries` composite index, so `firestore.indexes.json` must
@@ -509,8 +510,10 @@ the first record the staging pipeline writes is what would settle it.
    delivery; the summary document itself is never created or deleted by the rating trigger.
 5. Re-analysis of a rated document refreshes its summary and preserves its agreements; first
    analysis initializes empty agreements and zero counts.
-6. No client files changed; `summaries` remains admin-only. Track B changes no indexes; Track C adds
-   `root` and `space` to the `summaries` composite index (see 9).
+6. No client *behavior* changes, and `summaries` remains admin-only. Client files do change: Track A
+   in `shared/shared.ts` and `comment-card.tsx`, Task 11 in `chat-panel.tsx` and
+   `document-comment-hooks.ts`. Track B changes no indexes; Track C adds `root` and `space` to the
+   `summaries` composite index (see 9).
 7. A rating on a document with no summary produces an info log and nothing else.
 8. The deployed `onDocumentSummarized` trigger is deleted in the same cutover that deploys
    `onCommentRated`; the `package.json` deploy script is updated to match.

--- a/docs/plans/CLUE-645-ratings-to-summaries-implementation.md
+++ b/docs/plans/CLUE-645-ratings-to-summaries-implementation.md
@@ -305,7 +305,7 @@ merge stays trivial. Task 3's import switch touches the same import hunk.
    `investigation`, `problem`, `unit`, `key`, `numAiAgreements`, vector). A vector query needs an
    exact composite index: without it the lookup errors rather than degrading, so **deploy the index
    before the function**. Records that predate the fields stop matching; that is one demo record, and
-   re-analysis rewrites it.
+   re-analysis rewrites it — see the caveat under Task 8 for the legacy ids it cannot reach.
 
 **Verify:** existing categorize tests plus an explicit `getEmbeddings → undefined` case, and a test
 that a summary in another realm is not returned.
@@ -327,7 +327,10 @@ that a summary in another realm is not returned.
      `numAgreements: 0`.
    - *Update:* only `key`, `root`, `space`, context fields, `summary`, `summaryEmbedding`,
      `analyzedAt`, `adaCommentId`; never touch `aiAgreements` or either count. `root`/`space` are
-     written on this path too, so a record that predates them gains them on the next analysis.
+     written on this path too, so a record that predates them gains them on the next analysis —
+     but only one already at the id `getSummaryPath` derives. The retired trigger keyed records by
+     the metadata document id, which differs from `key` on older documents; a record at one of
+     those ids is never found, and re-analysis writes a fresh record beside it.
    `root`/`space`/`key` and the context fields come from Task 7's widened return
    (`documentMetadata`) — the imaged handler has no metadata of its own under the CLUE-371
    contract, and never derives any of this from the queue `docId`. No `documentMetadata` (read

--- a/docs/plans/CLUE-645-ratings-to-summaries-implementation.md
+++ b/docs/plans/CLUE-645-ratings-to-summaries-implementation.md
@@ -421,6 +421,11 @@ Written 2026-09-02, from a read-only probe run against both staging and producti
 (`functions-v2/probe-vector-query.ts`, untracked; its header carries the findings). Everything here
 was measured, not assumed — inspection alone had the index field order wrong.
 
+The durable half of this — deploy indexes before the functions that query them, and why the wrong
+order fails quietly — now lives in `functions-v2/README.md` under "To deploy firebase functions",
+where the next person deploying anything will find it. What follows is the rest: what this
+particular deploy will encounter.
+
 **The order is index first, functions second.** Not because the wrong order breaks loudly, but
 because it does not: a query whose index is missing fails with `FAILED_PRECONDITION`, and
 `categorizeRepresentations` catches that and continues without related summaries. So deploying the
@@ -617,47 +622,30 @@ departure and reason here (and in the design doc when it changes a decision).
 ### Track C reconciliation (Tasks 7 to 9, as implemented)
 
 Tasks 7 to 9 were drafted against `CLUE-371-production-mixed-mode-implementation.md` before that
-work merged, so they describe what the pipeline was expected to look like. The reconciliation pass
-this track opens with found the following. Task 7's central claim held: the merged
-`categorizeRepresentations` did return `{completion, messageShape}` and did leave the imaged handler
-with nothing Task 8 needed.
+work merged, so they describe what the pipeline was expected to look like. Task 7's central claim
+held: the merged `categorizeRepresentations` did return `{completion, messageShape}` and did leave
+the imaged handler with nothing Task 8 needed.
 
-- **The function is `categorizeRepresentations`**, not `categorizeDocumentRepresentations`.
-- **Hoisting `getEmbeddings` forced two more entries into `CategorizeDeps`.** Until this change no
-  test reached OpenAI or Firestore from this module, because both calls sat *inside* the injected
-  `findRelatedSummaries`. Moving them to the entry point would have had the existing integration
-  tests issue real embedding calls, so `readDocumentMetadata` and `getEmbeddings` are injected too.
-- **The metadata read became `readDocumentMetadata`, which returns `undefined` rather than
-  throwing.** A missing document used to throw into the lookup's catch, which was fine when the
-  only consumer was enrichment. The summary write needs to tell "no metadata" apart from "the
-  lookup failed", so the three unusable cases — not a document path, no such document, incomplete
-  context — are one answer, given once.
+Departures the code now states for itself, listed only so this plan is not mistaken for the current
+design: the function is `categorizeRepresentations`, not `categorizeDocumentRepresentations`; the
+metadata read became `readDocumentMetadata`, which reports why it found nothing rather than
+throwing; hoisting it and `getEmbeddings` out of the lookup put both into `CategorizeDeps`, and
+exported them and `findRelatedSummaries` so the realm filter could be tested against a real
+Firestore; `offeringId` is normalized to `""`; `Summary.summaryEmbedding` was typed `FieldValue` and
+is now `VectorValue`; `adaCommentId` is written once rather than written-then-updated; and Task 9's
+realm case lives in Task 7's test file with the other realm tests.
+
+Three have no home in the code, and are why this section is worth keeping.
+
 - **The summary-write gate is "the request carried a summary", not `queueDoc.sendSummary`.** Same
   condition: `representationsOf` has already folded `sendSummary` into `summary !== null`, and the
   handler never sees the raw field. One source, and it is the same one that decides whether related
   summaries are looked up, which is what keeps a document from receiving agreement counts it can
   never contribute to.
-- **`offeringId` is normalized to `""`.** It is optional on a metadata document, required on
-  `Summary`, and absent from the context guard, so it can genuinely be missing — and `undefined`
-  cannot be written to Firestore.
-- **`Summary.summaryEmbedding` was typed `FieldValue` and is now `VectorValue`.** `FieldValue.vector()`
-  returns the latter. The type had never had a writer, so nothing had caught it; Task 8 is the first.
-- **`adaCommentId` is written once, not written-then-updated.** `collection.doc()` generates an id
-  locally without writing anything, so the summary can name the comment *and* still be written
-  first. Task 8 step 2 offered this as the alternative; it is strictly better than the two-write
-  version, which would leave a window where the record named no comment.
 - **A summary write that fails is logged and the run continues to the comment.** Neither doc
   settled this. The evaluation succeeded and the student is owed its feedback; a missing record
   costs only ratings of that comment, which `onCommentRated` already logs and skips, and the next
-  analysis writes the record again. This matches how the surrounding code already treats this
-  collection ("enrichment, their absence costs the evaluation nothing").
-- **Task 9's last case is covered in Task 7's test file, not Task 8's.** "A record in another realm
-  is not returned by the lookup" is a fact about `findRelatedSummaries`, so it lives with the other
-  realm tests in `functions-v2/test/related-summaries-emulator.test.ts`.
-- **`findRelatedSummaries` and `readDocumentMetadata` are exported.** They were module-local,
-  reachable only through the injection seam. The realm filter is the kind of thing that has to be
-  checked against a real Firestore rather than against a recording of the calls it made, and the
-  emulator supports `findNearest`.
+  analysis writes the record again.
 - **What the realm tests do not prove.** The emulator does not enforce composite indexes, so those
   tests cover the *filter*, not the index entry. The index itself was checked against real Firestore
   on 2026-09-02 — see "Deploying Track C" — and inspection had got its field order wrong.

--- a/docs/plans/CLUE-645-ratings-to-summaries-implementation.md
+++ b/docs/plans/CLUE-645-ratings-to-summaries-implementation.md
@@ -7,9 +7,15 @@ record the departure (see DEVIATIONS at the end).
 **Verified against:** `master` at `c08e75c28` (2026-08-27), post-harness-merge. File and symbol
 references below were re-checked on that commit.
 
-**Status (2026-09-01).** Track A shipped in PR #2990. Track B — tasks 3 to 6 — is the branch this
-plan sits on. Track C has not started; it is gated on `CLUE-371-ai-feedback-text-and-images`, and
-tasks 7 to 11 are the only ones here that describe work still to do.
+**Status (2026-09-01).** Track A shipped in PR #2990. Track B — tasks 3 to 6 — is merged, and its
+functions are deployed to production, where `onCommentRated` runs but finds no summaries to record
+against. Track C's tasks 7 to 9 are implemented on `CLUE-645-track-c`, which is what makes the
+collection exist; task 11 is the only one here that describes work still to do.
+
+**The one thing in Track C with no equivalent in code is the index deploy.** The realm-scoped
+lookup needs `root` and `space` in the `summaries` composite index, so `firestore.indexes.json` must
+be deployed and the index built *before* the functions deploy that queries it. The full procedure,
+and what goes wrong in which order, is under "Deploying Track C" below.
 
 Tasks 1 to 6 describe work that is finished, and are kept at full detail as the record of what was
 asked. What is durable about them now lives where it is enforced: the reconcile and timestamp rules
@@ -405,6 +411,93 @@ is inert until summaries exist (its no-summary skip is the designed behavior, an
 means the trigger swap is already soaked). Track C (7 → 8 → 9 → 10) as a second PR once
 `CLUE-371-ai-feedback-text-and-images` merges, starting with the reconciliation pass.
 
+## Deploying Track C
+
+Written 2026-09-02, from a read-only probe run against both staging and production
+(`functions-v2/probe-vector-query.ts`, untracked; its header carries the findings). Everything here
+was measured, not assumed — inspection alone had the index field order wrong.
+
+**The order is index first, functions second.** Not because the wrong order breaks loudly, but
+because it does not: a query whose index is missing fails with `FAILED_PRECONDITION`, and
+`categorizeRepresentations` catches that and continues without related summaries. So deploying the
+functions first produces prompts quietly missing their agreement counts, one warning line per run,
+and nothing else. Easy to miss for a long time.
+
+### Step 1 — look before writing
+
+```
+npx firebase firestore:indexes --project <staging|production>
+```
+
+Diff that against `firestore.indexes.json`. Two things to learn from it: what the delete prompt in
+step 2 will offer to remove, and whether any *other* index in the file is missing from that project.
+The deploy sends the whole file — `docs`, `documents`, `messages` and `summaries` — so a project
+missing one of the first three would start building it over a real-sized collection. Staging already
+had all three; production has not been checked.
+
+### Step 2 — deploy the indexes
+
+```
+npx firebase deploy --only firestore:indexes --project <staging|production>
+```
+
+- **Rules are not deployed by this command.** `--only firestore:indexes` sets `firestoreRules` to
+  false in `deploy/firestore/prepare.js`. It does still *compile* `firestore.rules`, so a syntax
+  error there fails the command — harmlessly, and any warning it prints is pre-existing.
+- **A delete prompt will appear, and the answer is no.** Creation is additive and unconditional;
+  deletion only happens if you say yes or pass `--force`, and the default is no. In production the
+  list will include the **old `summaries` composite index** (the one without `root`/`space`) — and
+  that index is what serves the *currently deployed* function. Deleting it during the window
+  between this step and step 4 breaks the live lookup. It only becomes redundant once Track C is
+  live, and even then leaving it costs almost nothing.
+- **Never pass `--force` to this command.** Creating an index is cheap and reversible; deleting one
+  is cheap to do and expensive to undo, because recreating it means a rebuild during which every
+  query that needs it fails.
+
+### Step 3 — wait for the build, and check it
+
+"deployed indexes successfully" means the API accepted the request, not that anything is ready. The
+CLI logs index creation at `debug` level only, so the normal output never mentions it, and
+`firestore:indexes` does not print a state field. Index builds take minutes regardless of collection
+size.
+
+The reliable check is the probe: the production-query variant flips from `FAILED_PRECONDITION` to
+`OK`. While it is still building, Firestore says so in the error text — "That index is currently
+building" — which is a *different* answer from "missing", and means the shape is right. If it is
+still building after ~15 minutes, open the console link in the message: a failed build lands in
+`NEEDS_REPAIR` rather than retrying, and looks the same from outside.
+
+### Step 4 — deploy the functions
+
+Note that Track B's cutover (Task 5 step 3) also has to be honored if it has not already happened.
+
+### What to expect afterwards, so it is not read as a fault
+
+- **The lookup returns nothing at first.** Realm scoping needs `root` and `space`, which only the
+  pipeline writes. Every record that predates Track C is invisible until its document is analyzed
+  again. Measured: production holds exactly **one** summary record, a `cas` demo record with no
+  realm fields, which confirms the CLUE-371 spike's count; staging holds three, two of them real
+  artifacts of the retired pipeline and one a hand-made Track B fixture.
+- **Records also need agreements.** A newly written record has `numAiAgreements: 0` and so does not
+  qualify for the lookup until somebody rates one of its comments. So the ramp is: analyze, then
+  rate, then a *different* document in the same class, unit and problem sees the counts.
+- Taken together, expect the related-summaries feature to return nothing for a while after this
+  ships, and treat that as the designed migration behavior rather than a regression. The design
+  doc's Migration section makes the same point: this is the first time the feature runs end to end.
+
+### What was and was not verified
+
+Verified against real Firestore: inequality pre-filters are legal with `findNearest` (every probe
+variant returned `FAILED_PRECONDITION`, never `INVALID_ARGUMENT`); the index in
+`firestore.indexes.json` is field-for-field what Firestore asks for; and with realm scoping removed
+the query returns real records, so vector search, the context filters and both inequality filters
+all work over live data.
+
+Not verified: that `root` and `space` select correctly, because no record anywhere carries them
+until the pipeline writes one. That is two more equality filters through an index Firestore has
+already accepted the full query against, so the residual risk is small — but it is inference, and
+the first record the staging pipeline writes is what would settle it.
+
 ## Acceptance (done when…)
 
 1. Rules reject out-of-enum rating values and allow toggle-off, with tests in `firebase-test/src`.
@@ -514,3 +607,51 @@ departure and reason here (and in the design doc when it changes a decision).
   an agreeing stale event, and the two "no write" tests could not tell a skipped write from an
   identical one, because the emulator does not move `updateTime` when the data does not change.
   Both now assert on the log line instead.
+
+### Track C reconciliation (Tasks 7 to 9, as implemented)
+
+Tasks 7 to 9 were drafted against `CLUE-371-production-mixed-mode-implementation.md` before that
+work merged, so they describe what the pipeline was expected to look like. The reconciliation pass
+this track opens with found the following. Task 7's central claim held: the merged
+`categorizeRepresentations` did return `{completion, messageShape}` and did leave the imaged handler
+with nothing Task 8 needed.
+
+- **The function is `categorizeRepresentations`**, not `categorizeDocumentRepresentations`.
+- **Hoisting `getEmbeddings` forced two more entries into `CategorizeDeps`.** Until this change no
+  test reached OpenAI or Firestore from this module, because both calls sat *inside* the injected
+  `findRelatedSummaries`. Moving them to the entry point would have had the existing integration
+  tests issue real embedding calls, so `readDocumentMetadata` and `getEmbeddings` are injected too.
+- **The metadata read became `readDocumentMetadata`, which returns `undefined` rather than
+  throwing.** A missing document used to throw into the lookup's catch, which was fine when the
+  only consumer was enrichment. The summary write needs to tell "no metadata" apart from "the
+  lookup failed", so the three unusable cases — not a document path, no such document, incomplete
+  context — are one answer, given once.
+- **The summary-write gate is "the request carried a summary", not `queueDoc.sendSummary`.** Same
+  condition: `representationsOf` has already folded `sendSummary` into `summary !== null`, and the
+  handler never sees the raw field. One source, and it is the same one that decides whether related
+  summaries are looked up, which is what keeps a document from receiving agreement counts it can
+  never contribute to.
+- **`offeringId` is normalized to `""`.** It is optional on a metadata document, required on
+  `Summary`, and absent from the context guard, so it can genuinely be missing — and `undefined`
+  cannot be written to Firestore.
+- **`Summary.summaryEmbedding` was typed `FieldValue` and is now `VectorValue`.** `FieldValue.vector()`
+  returns the latter. The type had never had a writer, so nothing had caught it; Task 8 is the first.
+- **`adaCommentId` is written once, not written-then-updated.** `collection.doc()` generates an id
+  locally without writing anything, so the summary can name the comment *and* still be written
+  first. Task 8 step 2 offered this as the alternative; it is strictly better than the two-write
+  version, which would leave a window where the record named no comment.
+- **A summary write that fails is logged and the run continues to the comment.** Neither doc
+  settled this. The evaluation succeeded and the student is owed its feedback; a missing record
+  costs only ratings of that comment, which `onCommentRated` already logs and skips, and the next
+  analysis writes the record again. This matches how the surrounding code already treats this
+  collection ("enrichment, their absence costs the evaluation nothing").
+- **Task 9's last case is covered in Task 7's test file, not Task 8's.** "A record in another realm
+  is not returned by the lookup" is a fact about `findRelatedSummaries`, so it lives with the other
+  realm tests in `functions-v2/test/related-summaries-emulator.test.ts`.
+- **`findRelatedSummaries` and `readDocumentMetadata` are exported.** They were module-local,
+  reachable only through the injection seam. The realm filter is the kind of thing that has to be
+  checked against a real Firestore rather than against a recording of the calls it made, and the
+  emulator supports `findNearest`.
+- **What the realm tests do not prove.** The emulator does not enforce composite indexes, so those
+  tests cover the *filter*, not the index entry. The index itself was checked against real Firestore
+  on 2026-09-02 — see "Deploying Track C" — and inspection had got its field order wrong.

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -59,6 +59,14 @@
           "order": "ASCENDING"
         },
         {
+          "fieldPath": "root",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "space",
+          "order": "ASCENDING"
+        },
+        {
           "fieldPath": "unit",
           "order": "ASCENDING"
         },

--- a/functions-v2/README.md
+++ b/functions-v2/README.md
@@ -12,8 +12,8 @@ the `deploy:` scripts target, so `getAiContent` is called as `getAiContent_v2`.
 |--------|-------|
 |_onUserDocWritten_|Monitors Firestore user documents for changes and updates the Firestore class documents with the networks of all of the teachers in these classes|
 |_onAnalyzableTestDocWritten_, _onAnalyzableProdDocWritten_|Monitor Firestore user metadata for updates to documents that request AI analysis, and put them into the analysis queue. One each for the test and prod roots.|
-|_onAnalysisDocumentPending_|Monitors the queue for documents to analyze, and sends them to Shutterbug to create a screenshot of the document|
-|_onAnalysisDocumentImaged_|Sends new screenshots to ChatGPT for analysis and creates a comment on the original document|
+|_onAnalysisDocumentPending_|Monitors the queue for documents to analyze, summarizes their text, and sends them to Shutterbug to create a screenshot of the document|
+|_onAnalysisDocumentImaged_|Sends what the previous step produced to ChatGPT for analysis, records the summary it evaluated in `summaries/`, and creates a comment on the original document|
 |_atMidnight_|Clears old Firebase roots for dev and qa instances|
 |_onDocumentTagged_|Updates metadata documents with strategies as needed whenever a comment is made|
 |_onCommentRated_|Records what people said about a document's comments on that document's summary, whenever a comment's ratings change or a rated comment is deleted. Never creates or deletes a summary; the analysis pipeline owns those|

--- a/functions-v2/README.md
+++ b/functions-v2/README.md
@@ -136,6 +136,34 @@ Then run:
 $ npm run deploy                        # deploy all functions
 ```
 
+### Deploy Firestore indexes before the functions that query them
+
+A query whose composite index is missing fails with `FAILED_PRECONDITION`. Callers here catch that
+and carry on — the related-summaries lookup, for one, returns nothing and logs a warning — so
+deploying in the wrong order does not break anything visibly. It quietly drops whatever the query
+was for, one log line per run.
+
+So when a change adds or alters an index in `firestore.indexes.json`, deploy the index first, wait
+for it to finish building, and only then deploy the functions:
+
+```shell
+$ npm run deploy:firestore:indexes      # from the repo root
+```
+
+Two things about that command:
+
+- **It deploys the whole file**, not the index you changed. Run
+  `npx firebase firestore:indexes --project [project]` first and compare, so you know whether it is
+  about to build an index over a large collection.
+- **It asks whether to delete indexes that exist in the project but not in the file, and the answer
+  is normally no.** One of them is usually the index serving the functions that are still deployed.
+  Deleting an index is quick; rebuilding one is not, and every query needing it fails meanwhile.
+  Never pass `--force` to it without first reading what it would remove.
+
+"deployed indexes successfully" means the request was accepted, not that the index is ready —
+creation is asynchronous and is logged only at debug level. Check the Firebase console, or run a
+query that needs it: while it builds, Firestore says so in the error text.
+
 ## Differences with functions-v1
 
 - in `v2` the firebase-tools are a devDependency: it is not necessary to install them globally

--- a/functions-v2/lib/src/ai-categorize-document.ts
+++ b/functions-v2/lib/src/ai-categorize-document.ts
@@ -92,21 +92,32 @@ export interface DocumentMetadata {
 }
 
 /**
+ * Why a document yielded no metadata. The two are worth telling apart: a personal document has no
+ * class or problem and reports `no-context` on every run, where `no-metadata` means a document that
+ * should have been readable was not.
+ */
+export type MetadataGap = "no-context" | "no-metadata";
+
+/** The document's metadata, or why there is none. Exactly one of the two is set. */
+export type DocumentMetadataResult =
+  | {metadata: DocumentMetadata; gap?: never}
+  | {metadata?: never; gap: MetadataGap};
+
+/**
  * Reads the document's Firestore metadata.
  *
- * `undefined` means there is nothing here to look up related summaries with and nothing to write a
- * summary record from: a path that is not a document path, a missing document, or the incomplete
- * context that personal documents have.
+ * A gap means there is nothing here to look up related summaries with and nothing to write a
+ * summary record from.
  *
  * `offeringId` is normalized because it is optional on a metadata document while the `summaries`
  * record stores it unconditionally, and `undefined` cannot be written to Firestore.
  */
-export async function readDocumentMetadata(firestoreDocumentPath: string): Promise<DocumentMetadata | undefined> {
+export async function readDocumentMetadata(firestoreDocumentPath: string): Promise<DocumentMetadataResult> {
   // `{root}/{space}/documents/{docId}`, as built by on-analyzable-doc-written.
   const segments = firestoreDocumentPath.split("/");
   if (segments.length !== 4 || segments[2] !== "documents") {
     logger.warn(`Not a document path, skipping related summaries and the summary record: ${firestoreDocumentPath}`);
-    return undefined;
+    return {gap: "no-metadata"};
   }
   const [root, space] = segments;
 
@@ -114,7 +125,7 @@ export async function readDocumentMetadata(firestoreDocumentPath: string): Promi
   const document = await db.doc(firestoreDocumentPath).get();
   if (!document.exists) {
     logger.warn(`Document ${firestoreDocumentPath} does not exist`);
-    return undefined;
+    return {gap: "no-metadata"};
   }
   const { key, context_id, unit, problem, investigation, offeringId } = document.data()!;
   logger.info("Document data", { key, context_id, unit, problem, investigation });
@@ -124,17 +135,17 @@ export async function readDocumentMetadata(firestoreDocumentPath: string): Promi
   // open realms, and `onCommentRated` guards the same field the same way.
   if (typeof key !== "string" || !key) {
     logger.warn(`Document ${firestoreDocumentPath} has no usable key; skipping the summary record.`);
-    return undefined;
+    return {gap: "no-metadata"};
   }
 
   if (!context_id || !unit || !problem || !investigation) {
     logger.info("Skipping related summary lookup. " +
       "Document doesn't have a complete context for finding related summaries. " +
       "Personal documents don't have this context. ");
-    return undefined;
+    return {gap: "no-context"};
   }
 
-  return {
+  return {metadata: {
     root,
     space,
     key,
@@ -143,7 +154,7 @@ export async function readDocumentMetadata(firestoreDocumentPath: string): Promi
     problem,
     investigation,
     offeringId: typeof offeringId === "string" ? offeringId : "",
-  };
+  }};
 }
 
 /**
@@ -281,6 +292,8 @@ export interface CategorizeResult {
   messageShape: AnalysisMessageShape;
   summaryEmbedding: number[] | undefined;
   documentMetadata: DocumentMetadata | undefined;
+  /** Set when `documentMetadata` is not: why the read produced nothing. */
+  metadataGap: MetadataGap | undefined;
 }
 
 /**
@@ -318,6 +331,7 @@ export async function categorizeRepresentations(
 
   // Declared out here so both exits report them; an OpenAI failure is not a reason to lose them.
   let documentMetadata: DocumentMetadata | undefined;
+  let metadataGap: MetadataGap | undefined;
   let summaryEmbedding: number[] | undefined;
   let relatedSummaries: RelatedSummary[] = [];
 
@@ -333,7 +347,8 @@ export async function categorizeRepresentations(
     // ones after it.
     if (summary !== null) {
       try {
-        documentMetadata = await deps.readDocumentMetadata(firestoreDocumentPath);
+        ({metadata: documentMetadata, gap: metadataGap} =
+          await deps.readDocumentMetadata(firestoreDocumentPath));
         if (documentMetadata) {
           // getEmbeddings resolves undefined on any OpenAI error, and neither use may see it: a
           // query vector of undefined throws from findNearest, and a stored one would persist as a
@@ -369,10 +384,10 @@ export async function categorizeRepresentations(
       messages,
       response_format: categorizationResponseFormat(responseSchema),
     });
-    return { completion, messageShape, summaryEmbedding, documentMetadata };
+    return { completion, messageShape, summaryEmbedding, documentMetadata, metadataGap };
   } catch (error) {
     console.log("OpenAI error", error);
-    return { completion: undefined, messageShape, summaryEmbedding, documentMetadata };
+    return { completion: undefined, messageShape, summaryEmbedding, documentMetadata, metadataGap };
   }
 }
 

--- a/functions-v2/lib/src/ai-categorize-document.ts
+++ b/functions-v2/lib/src/ai-categorize-document.ts
@@ -72,28 +72,96 @@ export async function categorizeUrl(url: string, apiKey: string, aiPrompt = defa
   }
 }
 
-async function findRelatedSummaries(summary: string, apiKey: string, firestoreDocumentPath: string) {
-  // get the document to build the filters
+/**
+ * What the related-summaries lookup and the `summaries/` record are both built from.
+ *
+ * `root` and `space` name the realm — `demo/AI`, `authed/{portalId}` — and come from the document's
+ * path, since no field carries them. They confine the lookup to one realm: `summaries` is a flat
+ * collection, so without them a record written in one realm can be returned to a document analyzed
+ * in another whenever the context fields coincide.
+ */
+export interface DocumentMetadata {
+  root: string;
+  space: string;
+  key: string;
+  context_id: string;
+  unit: string;
+  investigation: string;
+  problem: string;
+  offeringId: string;
+}
+
+/**
+ * Reads the document's Firestore metadata.
+ *
+ * `undefined` means there is nothing here to look up related summaries with and nothing to write a
+ * summary record from: a path that is not a document path, a missing document, or the incomplete
+ * context that personal documents have.
+ *
+ * `offeringId` is normalized because it is optional on a metadata document while the `summaries`
+ * record stores it unconditionally, and `undefined` cannot be written to Firestore.
+ */
+export async function readDocumentMetadata(firestoreDocumentPath: string): Promise<DocumentMetadata | undefined> {
+  // `{root}/{space}/documents/{docId}`, as built by on-analyzable-doc-written.
+  const segments = firestoreDocumentPath.split("/");
+  if (segments.length !== 4 || segments[2] !== "documents") {
+    logger.warn(`Not a document path, skipping related summaries and the summary record: ${firestoreDocumentPath}`);
+    return undefined;
+  }
+  const [root, space] = segments;
+
   const db = new Firestore();
   const document = await db.doc(firestoreDocumentPath).get();
   if (!document.exists) {
-    throw new Error(`Document ${firestoreDocumentPath} does not exist`);
+    logger.warn(`Document ${firestoreDocumentPath} does not exist`);
+    return undefined;
   }
-  const { key, context_id, unit, problem, investigation } = document.data()!;
+  const { key, context_id, unit, problem, investigation, offeringId } = document.data()!;
   logger.info("Document data", { key, context_id, unit, problem, investigation });
+
+  // Typed, not just present: `getSummaryPath` escapes the key with a string method, so a non-string
+  // throws where every other bad value skips. Clients can write metadata documents directly in the
+  // open realms, and `onCommentRated` guards the same field the same way.
+  if (typeof key !== "string" || !key) {
+    logger.warn(`Document ${firestoreDocumentPath} has no usable key; skipping the summary record.`);
+    return undefined;
+  }
 
   if (!context_id || !unit || !problem || !investigation) {
     logger.info("Skipping related summary lookup. " +
       "Document doesn't have a complete context for finding related summaries. " +
       "Personal documents don't have this context. ");
-    return [];
+    return undefined;
   }
 
-  // get the embeddings for the summary
-  const embeddings = await getEmbeddings(summary, apiKey);
+  return {
+    root,
+    space,
+    key,
+    context_id,
+    unit,
+    problem,
+    investigation,
+    offeringId: typeof offeringId === "string" ? offeringId : "",
+  };
+}
+
+/**
+ * Finds summaries of similar documents that carry agreements, within the same realm.
+ *
+ * The caller supplies the query vector because the same embedding is stored on this document's own
+ * summary record, and one analysis run should pay OpenAI for it once.
+ */
+export async function findRelatedSummaries(
+  metadata: DocumentMetadata, queryVector: number[]
+): Promise<RelatedSummary[]> {
+  const db = new Firestore();
+  const { root, space, key, context_id, unit, problem, investigation } = metadata;
 
   // lookup related documents based on summary embedding that have ai agreements
   const query: VectorQuery = db.collection('summaries')
+    .where("root", "==", root)
+    .where("space", "==", space)
     .where("key", "!=", key)
     .where("numAiAgreements", ">", 0)
     .where("context_id", "==", context_id)
@@ -102,7 +170,7 @@ async function findRelatedSummaries(summary: string, apiKey: string, firestoreDo
     .where("investigation", "==", investigation)
     .findNearest({
       vectorField: "summaryEmbedding",
-      queryVector: FieldValue.vector(embeddings),
+      queryVector: FieldValue.vector(queryVector),
       limit: 5,
       distanceMeasure: "EUCLIDEAN",
     });
@@ -182,19 +250,38 @@ export interface DocumentRepresentations {
 /**
  * Test seam. Production callers pass nothing.
  *
- * `findRelatedSummaries` is called through a same-module binding, so exporting it and spying on
- * the export does not intercept the internal call once ts-jest has compiled the module. Injecting
- * it is the honest way to let a test stand in for it.
+ * These are called through same-module bindings, so exporting them and spying on the exports does
+ * not intercept the internal calls once ts-jest has compiled the module. Injecting them is the
+ * honest way to let a test stand in for them. Every dependency that would reach Firestore or the
+ * network needs an entry, or a test that replaces one of them still reaches out through another.
  */
 export interface CategorizeDeps {
+  readDocumentMetadata: typeof readDocumentMetadata;
+  getEmbeddings: typeof getEmbeddings;
   findRelatedSummaries: typeof findRelatedSummaries;
   createOpenAI: (apiKey: string) => OpenAI;
 }
 
 const defaultCategorizeDeps: CategorizeDeps = {
+  readDocumentMetadata,
+  getEmbeddings,
   findRelatedSummaries,
   createOpenAI: (apiKey: string) => new OpenAI({apiKey}),
 };
+
+/**
+ * What one categorization run produced.
+ *
+ * `summaryEmbedding` and `documentMetadata` serve the caller's summary write rather than the
+ * evaluation: the queue record carries a path, not the document's fields, so the caller has no
+ * metadata of its own. Both must be present for a record to be written.
+ */
+export interface CategorizeResult {
+  completion: ParsedCompletion | undefined;
+  messageShape: AnalysisMessageShape;
+  summaryEmbedding: number[] | undefined;
+  documentMetadata: DocumentMetadata | undefined;
+}
 
 /**
  * Sends one request carrying whatever representations the document produced.
@@ -211,7 +298,7 @@ export async function categorizeRepresentations(
   firestoreDocumentPath: string,
   aiPrompt = defaultAiPrompt,
   deps: CategorizeDeps = defaultCategorizeDeps
-): Promise<{ completion: ParsedCompletion | undefined; messageShape: AnalysisMessageShape }> {
+): Promise<CategorizeResult> {
   const { summary, imageUrl } = representations;
   if (summary === null && imageUrl === null) {
     // The producer will not write such a record and the consumer turns empty values into this
@@ -229,26 +316,42 @@ export async function categorizeRepresentations(
   const messageShape = request.shape;
   logger.info(`Categorizing ${messageShape} for: ${firestoreDocumentPath}`);
 
+  // Declared out here so both exits report them; an OpenAI failure is not a reason to lose them.
+  let documentMetadata: DocumentMetadata | undefined;
+  let summaryEmbedding: number[] | undefined;
+  let relatedSummaries: RelatedSummary[] = [];
+
   try {
     const responseSchema = buildZodResponseSchema(aiPrompt);
     if (Object.keys(responseSchema).length === 0) {
       throw new Error("aiPrompt must specify at least one response field for the schema.");
     }
 
-    // Related summaries are enrichment, and their absence costs the evaluation nothing. The whole
-    // lookup is inside the try, not just the embeddings call: getEmbeddings returns undefined on
-    // error and FieldValue.vector(undefined) then throws from inside findRelatedSummaries.
-    let relatedSummaries: RelatedSummary[] = [];
+    // Only when a summary is being sent, so a document that receives agreement counts is always one
+    // that can contribute them. Related summaries are enrichment and their absence costs the
+    // evaluation nothing, so the three steps share one catch, and each step's failure stops the
+    // ones after it.
     if (summary !== null) {
       try {
-        relatedSummaries = await deps.findRelatedSummaries(summary, apiKey, firestoreDocumentPath);
+        documentMetadata = await deps.readDocumentMetadata(firestoreDocumentPath);
+        if (documentMetadata) {
+          // getEmbeddings resolves undefined on any OpenAI error, and neither use may see it: a
+          // query vector of undefined throws from findNearest, and a stored one would persist as a
+          // zero-dimension vector no search can find.
+          summaryEmbedding = await deps.getEmbeddings(summary, apiKey);
+          if (summaryEmbedding?.length) {
+            relatedSummaries = await deps.findRelatedSummaries(documentMetadata, summaryEmbedding);
+          } else {
+            summaryEmbedding = undefined;
+            logger.warn("no embedding for this summary, continuing without related summaries");
+          }
+        }
       } catch (error) {
         logger.warn("related summaries unavailable, continuing without them", error);
       }
     }
 
-    // One builder per shape, over the shape decided above. The image-only case uses the mixed
-    // builder with a null summary, as this function's comment explains.
+    // One builder per shape, over the shape decided above.
     const buildMessages = () => {
       switch (request.shape) {
       case "mixed":
@@ -266,10 +369,10 @@ export async function categorizeRepresentations(
       messages,
       response_format: categorizationResponseFormat(responseSchema),
     });
-    return { completion, messageShape };
+    return { completion, messageShape, summaryEmbedding, documentMetadata };
   } catch (error) {
     console.log("OpenAI error", error);
-    return { completion: undefined, messageShape };
+    return { completion: undefined, messageShape, summaryEmbedding, documentMetadata };
   }
 }
 

--- a/functions-v2/lib/src/ai-categorize-document.ts
+++ b/functions-v2/lib/src/ai-categorize-document.ts
@@ -73,6 +73,21 @@ export async function categorizeUrl(url: string, apiKey: string, aiPrompt = defa
 }
 
 /**
+ * The module's Firestore client.
+ *
+ * Each `new Firestore()` opens its own gRPC channel and nothing closes it, and a warm container
+ * reuses this module across invocations — so one per call becomes one per call that never goes
+ * away. Created on first use rather than at import so that loading this module costs nothing.
+ *
+ * @return {Firestore} the shared client
+ */
+function firestoreClient(): Firestore {
+  sharedFirestore ??= new Firestore();
+  return sharedFirestore;
+}
+let sharedFirestore: Firestore | undefined;
+
+/**
  * What the related-summaries lookup and the `summaries/` record are both built from.
  *
  * `root` and `space` name the realm — `demo/AI`, `authed/{portalId}` — and come from the document's
@@ -121,7 +136,7 @@ export async function readDocumentMetadata(firestoreDocumentPath: string): Promi
   }
   const [root, space] = segments;
 
-  const db = new Firestore();
+  const db = firestoreClient();
   const document = await db.doc(firestoreDocumentPath).get();
   if (!document.exists) {
     logger.warn(`Document ${firestoreDocumentPath} does not exist`);
@@ -166,7 +181,7 @@ export async function readDocumentMetadata(firestoreDocumentPath: string): Promi
 export async function findRelatedSummaries(
   metadata: DocumentMetadata, queryVector: number[]
 ): Promise<RelatedSummary[]> {
-  const db = new Firestore();
+  const db = firestoreClient();
   const { root, space, key, context_id, unit, problem, investigation } = metadata;
 
   // lookup related documents based on summary embedding that have ai agreements
@@ -342,9 +357,8 @@ export async function categorizeRepresentations(
     }
 
     // Only when a summary is being sent, so a document that receives agreement counts is always one
-    // that can contribute them. Related summaries are enrichment and their absence costs the
-    // evaluation nothing, so the three steps share one catch, and each step's failure stops the
-    // ones after it.
+    // that can contribute them. Related summaries are enrichment: their absence costs the
+    // evaluation nothing.
     if (summary !== null) {
       try {
         ({metadata: documentMetadata, gap: metadataGap} =

--- a/functions-v2/src/on-analysis-document-imaged.ts
+++ b/functions-v2/src/on-analysis-document-imaged.ts
@@ -3,18 +3,19 @@ import * as logger from "firebase-functions/logger";
 import * as admin from "firebase-admin";
 // Modular import: admin.firestore.FieldValue is undefined in the functions emulator.
 import {FieldValue} from "firebase-admin/firestore";
-import {getAnalysisQueueFirestorePath} from "./utils";
+import {getAnalysisQueueFirestorePath, getSummaryPath} from "./utils";
 import {
-  type DocumentRepresentations, categorizeRepresentations,
+  type DocumentMetadata, type DocumentRepresentations, categorizeRepresentations,
 } from "../lib/src/ai-categorize-document";
+import {Summary} from "./summary-types";
 import {defineSecret} from "firebase-functions/params";
 import {kAnalyzerUserParams} from "../../shared/shared";
 
 // This is one of three functions for AI analysis of documents:
 // 1. Watch for changes to the lastUpdatedAt metadata field and write a queue of docs to process
 // 2. Summarize and screenshot those documents
-// 3. (This function) Send what was produced to the AI service for processing along with any custom AI prompt, and
-//    create comments with the results
+// 3. (This function) Send what was produced to the AI service for processing along with any custom AI prompt,
+//    record the summary that was evaluated in `summaries/`, and create comments with the results
 
 const openaiApiKey = defineSecret("OPENAI_API_KEY");
 
@@ -58,6 +59,72 @@ export function representationsOf(queueDoc: Record<string, unknown>): DocumentRe
   };
 }
 
+/**
+ * What became of this run's summary record, stored on the `done` queue entry so that "did this
+ * document get a summary, and if not why not" is a query rather than a log search.
+ *
+ * `no-summary-sent` is the ordinary shape of an image-only or mock run; `no-metadata` and
+ * `no-embedding` mean something was expected and did not arrive.
+ */
+export type SummaryOutcome =
+  "created" | "refreshed" | "failed" | "no-summary-sent" | "no-metadata" | "no-embedding";
+
+/**
+ * Records the summary this run evaluated, so ratings of the comments it produces have somewhere to
+ * land and later evaluations of similar documents can find it.
+ *
+ * Two paths, because a merge that never touches the agreements cannot also initialize them. A new
+ * record starts with no agreements and both counts at zero; an existing one has only its summary,
+ * vector, timestamp and comment id refreshed, since the agreements belong to the people who made
+ * them. A record written before `root` and `space` existed gains them here, which is what puts it
+ * back within reach of the realm-scoped lookup.
+ *
+ * The read and the write share a transaction because a rating can arrive at any moment.
+ *
+ * @param {admin.firestore.Firestore} firestore the admin Firestore instance
+ * @param {DocumentMetadata} metadata where the document lives and what class and problem it is for
+ * @param {string} summary the summary text that was sent to the AI service
+ * @param {number[]} summaryEmbedding the vector of that text, computed once for this run
+ * @param {string} adaCommentId the comment this run is about to create
+ * @return {Promise<SummaryOutcome>} whether the record was created or refreshed
+ */
+async function writeSummaryRecord(
+  firestore: admin.firestore.Firestore,
+  metadata: DocumentMetadata,
+  summary: string,
+  summaryEmbedding: number[],
+  adaCommentId: string
+): Promise<SummaryOutcome> {
+  const summaryRef = firestore.doc(getSummaryPath(metadata.root, metadata.space, metadata.key));
+  // Typed as a subset of Summary so a field this run has no business writing cannot be added here.
+  const analyzed: Omit<Summary, "aiAgreements" | "numAiAgreements" | "numAgreements"> = {
+    key: metadata.key,
+    root: metadata.root,
+    space: metadata.space,
+    context_id: metadata.context_id,
+    unit: metadata.unit,
+    investigation: metadata.investigation,
+    problem: metadata.problem,
+    offeringId: metadata.offeringId,
+    summary,
+    summaryEmbedding: FieldValue.vector(summaryEmbedding),
+    analyzedAt: Date.now(),
+    adaCommentId,
+  };
+
+  return firestore.runTransaction(async (transaction): Promise<SummaryOutcome> => {
+    const existing = await transaction.get(summaryRef);
+    if (existing.exists) {
+      transaction.update(summaryRef, analyzed);
+      logger.info("Refreshed summary", summaryRef.path);
+      return "refreshed";
+    }
+    transaction.set(summaryRef, {...analyzed, aiAgreements: {}, numAiAgreements: 0, numAgreements: 0});
+    logger.info("Created summary", summaryRef.path);
+    return "created";
+  });
+}
+
 async function error(error: string, event: FirestoreEvent<QueryDocumentSnapshot | undefined, Record<string, string>>) {
   logger.warn("Error processing document", event.document, error);
   const firestore = admin.firestore();
@@ -92,6 +159,11 @@ export const onAnalysisDocumentImaged =
       let completionTokens = 0;
       let fullResponse = "";
       let messageShape;
+      // All three are set together or not at all: a run that sends no summary reads no metadata and
+      // buys no embedding.
+      let sentSummary: string | null = null;
+      let summaryEmbedding: number[] | undefined;
+      let documentMetadata: DocumentMetadata | undefined;
 
       if (queueDoc.evaluator === "mock") {
         message = "Mock reply from AI analysis";
@@ -100,9 +172,10 @@ export const onAnalysisDocumentImaged =
         const firestoreDocumentPath = queueDoc.firestoreDocumentPath;
 
         const representations = representationsOf(queueDoc);
+        sentSummary = representations.summary;
         let completion;
         try {
-          ({completion, messageShape} = await categorizeRepresentations(
+          ({completion, messageShape, summaryEmbedding, documentMetadata} = await categorizeRepresentations(
             representations, openaiApiKey.value(), firestoreDocumentPath, aiPrompt));
         } catch (err) {
           await error(`${err}`, event);
@@ -130,9 +203,36 @@ export const onAnalysisDocumentImaged =
         return;
       }
 
+      // Generating the id writes nothing, so the summary record can name the comment and still be
+      // written first. It has to be first: a student can rate a comment the moment it appears, and
+      // onCommentRated drops a rating whose summary does not exist yet.
+      const commentRef = firestore.collection(commentsPath).doc();
+
+      let summaryRecorded: SummaryOutcome;
+
+      // `.length`, not truthiness: an empty array is truthy, and writing one would persist a
+      // zero-dimension vector no search can find. categorizeRepresentations also turns an empty
+      // result into undefined, so neither guard alone is load-bearing.
+      if (sentSummary && documentMetadata && summaryEmbedding?.length) {
+        try {
+          summaryRecorded =
+            await writeSummaryRecord(firestore, documentMetadata, sentSummary, summaryEmbedding, commentRef.id);
+        } catch (err) {
+          // The evaluation succeeded and the student is owed its feedback. A missing record only
+          // costs ratings of this comment, and the next analysis writes it again.
+          summaryRecorded = "failed";
+          logger.warn("Could not record the summary; continuing to the comment", event.document, err);
+        }
+      } else {
+        // Not logged: a line per image-only run would bury the cases that matter, and the two that
+        // are anomalies are already logged where they are detected.
+        summaryRecorded = !sentSummary ? "no-summary-sent" :
+          !documentMetadata ? "no-metadata" : "no-embedding";
+      }
+
       logger.info("Creating comment for", event.document);
       // NOTE we are leaving the "network" and "tileId" fields empty in the comment doc.
-      await firestore.collection(commentsPath).add({
+      await commentRef.set({
         tags,
         content: message,
         createdAt: FieldValue.serverTimestamp(),
@@ -148,6 +248,7 @@ export const onAnalysisDocumentImaged =
         promptTokens,
         completionTokens,
         fullResponse,
+        summaryRecorded,
         ...(messageShape ? {messageShape} : {}),
       });
 

--- a/functions-v2/src/on-analysis-document-imaged.ts
+++ b/functions-v2/src/on-analysis-document-imaged.ts
@@ -5,7 +5,7 @@ import * as admin from "firebase-admin";
 import {FieldValue} from "firebase-admin/firestore";
 import {getAnalysisQueueFirestorePath, getSummaryPath} from "./utils";
 import {
-  type DocumentMetadata, type DocumentRepresentations, categorizeRepresentations,
+  type DocumentMetadata, type DocumentRepresentations, type MetadataGap, categorizeRepresentations,
 } from "../lib/src/ai-categorize-document";
 import {Summary} from "./summary-types";
 import {defineSecret} from "firebase-functions/params";
@@ -63,11 +63,12 @@ export function representationsOf(queueDoc: Record<string, unknown>): DocumentRe
  * What became of this run's summary record, stored on the `done` queue entry so that "did this
  * document get a summary, and if not why not" is a query rather than a log search.
  *
- * `no-summary-sent` is the ordinary shape of an image-only or mock run; `no-metadata` and
- * `no-embedding` mean something was expected and did not arrive.
+ * `no-summary-sent` and `no-context` are ordinary: the first is an image-only or mock run, the
+ * second a document with no class or problem, which is what a personal document looks like.
+ * `no-metadata`, `no-embedding` and `failed` mean something was expected and did not arrive.
  */
 export type SummaryOutcome =
-  "created" | "refreshed" | "failed" | "no-summary-sent" | "no-metadata" | "no-embedding";
+  "created" | "refreshed" | "failed" | "no-summary-sent" | MetadataGap | "no-embedding";
 
 /**
  * Records the summary this run evaluated, so ratings of the comments it produces have somewhere to
@@ -76,8 +77,10 @@ export type SummaryOutcome =
  * Two paths, because a merge that never touches the agreements cannot also initialize them. A new
  * record starts with no agreements and both counts at zero; an existing one has only its summary,
  * vector, timestamp and comment id refreshed, since the agreements belong to the people who made
- * them. A record written before `root` and `space` existed gains them here, which is what puts it
- * back within reach of the realm-scoped lookup.
+ * them. A record written before `root` and `space` existed gains them here, but only if it sits at
+ * the id `getSummaryPath` derives: the retired trigger keyed records by the metadata document id,
+ * which differs from the key on older documents, and such a record is never found — re-analysis
+ * writes a fresh one beside it.
  *
  * The read and the write share a transaction because a rating can arrive at any moment.
  *
@@ -159,11 +162,12 @@ export const onAnalysisDocumentImaged =
       let completionTokens = 0;
       let fullResponse = "";
       let messageShape;
-      // All three are set together or not at all: a run that sends no summary reads no metadata and
-      // buys no embedding.
+      // None of these is set unless a summary was sent; the metadata and the embedding can still
+      // go missing individually, which is what the outcomes below tell apart.
       let sentSummary: string | null = null;
       let summaryEmbedding: number[] | undefined;
       let documentMetadata: DocumentMetadata | undefined;
+      let metadataGap: MetadataGap | undefined;
 
       if (queueDoc.evaluator === "mock") {
         message = "Mock reply from AI analysis";
@@ -175,8 +179,9 @@ export const onAnalysisDocumentImaged =
         sentSummary = representations.summary;
         let completion;
         try {
-          ({completion, messageShape, summaryEmbedding, documentMetadata} = await categorizeRepresentations(
-            representations, openaiApiKey.value(), firestoreDocumentPath, aiPrompt));
+          ({completion, messageShape, summaryEmbedding, documentMetadata, metadataGap} =
+            await categorizeRepresentations(
+              representations, openaiApiKey.value(), firestoreDocumentPath, aiPrompt));
         } catch (err) {
           await error(`${err}`, event);
           return;
@@ -211,8 +216,8 @@ export const onAnalysisDocumentImaged =
       let summaryRecorded: SummaryOutcome;
 
       // `.length`, not truthiness: an empty array is truthy, and writing one would persist a
-      // zero-dimension vector no search can find. categorizeRepresentations also turns an empty
-      // result into undefined, so neither guard alone is load-bearing.
+      // zero-dimension vector no search can find. Kept even though categorizeRepresentations
+      // normalizes an empty result too, so a change to either file alone cannot open this.
       if (sentSummary && documentMetadata && summaryEmbedding?.length) {
         try {
           summaryRecorded =
@@ -226,8 +231,8 @@ export const onAnalysisDocumentImaged =
       } else {
         // Not logged: a line per image-only run would bury the cases that matter, and the two that
         // are anomalies are already logged where they are detected.
-        summaryRecorded = !sentSummary ? "no-summary-sent" :
-          !documentMetadata ? "no-metadata" : "no-embedding";
+        // metadataGap is set exactly when the metadata is missing, so it answers for that case.
+        summaryRecorded = !sentSummary ? "no-summary-sent" : metadataGap ?? "no-embedding";
       }
 
       logger.info("Creating comment for", event.document);

--- a/functions-v2/src/on-analysis-document-pending.ts
+++ b/functions-v2/src/on-analysis-document-pending.ts
@@ -16,7 +16,8 @@ import {classifyDocument} from "../../shared/ai-analysis-classify";
 // This is one of three functions for AI analysis of documents:
 // 1. Watch for changes to the lastUpdatedAt metadata field and write into the queue of docs to process
 // 2. (This function) Summarize and screenshot those documents
-// 3. Send what was produced to the AI service for processing, and create document comments with the results
+// 3. Send what was produced to the AI service for processing, record the summary that was evaluated
+//    in `summaries/`, and create document comments with the results
 
 // The released CLUE build. The release workflow copies only a few entry points to the top level
 // (see .github/workflows/release.yml), and `iframe.html` is not one of them, so the document

--- a/functions-v2/src/on-analyzable-doc-written.ts
+++ b/functions-v2/src/on-analyzable-doc-written.ts
@@ -7,7 +7,8 @@ import {getAnalysisQueueFirestorePath} from "./utils";
 // This is one of three functions for AI analysis of documents:
 // 1. (This function) watch for changes to the evaluation metadata field and write into the queue of docs to process
 // 2. Summarize and screenshot those documents
-// 3. Send what was produced to the AI service for processing, and create document comments with the results
+// 3. Send what was produced to the AI service for processing, record the summary that was evaluated
+//    in `summaries/`, and create document comments with the results
 
 // We watch for changes in the Firebase metadata, but will eventually need to write results out to comments
 // on the document.

--- a/functions-v2/src/summary-types.ts
+++ b/functions-v2/src/summary-types.ts
@@ -1,4 +1,4 @@
-import type {FieldValue} from "firebase-admin/firestore";
+import type {VectorValue} from "@google-cloud/firestore";
 import {RatingValue} from "../../shared/shared";
 
 // The agreement entries stored in a summary's `aiAgreements` map.
@@ -55,15 +55,14 @@ export function isAiAgreement(entry: AiAgreement): boolean {
  * A `summaries/{summaryId}` record: the summary the AI evaluated for one document, the vector it
  * was found by, and what people said about the comments it produced.
  *
- * The analysis pipeline creates and refreshes the record, `root` and `space` included;
- * `onCommentRated` only ever adjusts `aiAgreements` and the two counts.
+ * The analysis pipeline creates and refreshes the record; `onCommentRated` only ever adjusts
+ * `aiAgreements` and the two counts.
  *
- * Three fields are optional on read, all because a stored record need not carry them — this type
- * describes what a reader may find, where the design doc's Data Model describes what the pipeline
- * writes. `numAgreements` postdates the records that exist today, and the recompute in
- * `onCommentRated` fills it in the first time a rating touches one. `root` and `space` are written
- * by nothing yet: they arrive with the pipeline write in Track C, which needs them to scope the
- * related-summaries lookup to a single realm, and an older record gains them on its next analysis.
+ * `root`, `space` and `numAgreements` are optional because this type describes what a reader may
+ * find, and records predating them are still stored. Each gains its missing fields when it is next
+ * written: the pipeline supplies the realm on the next analysis, `onCommentRated` recomputes
+ * `numAgreements` on the next rating. Note the compiler will not tell you if a write path forgets
+ * the realm, and a record without it cannot match the realm-scoped lookup.
  */
 export interface Summary {
   key: string;
@@ -75,7 +74,7 @@ export interface Summary {
   problem: string;
   offeringId: string;
   summary: string;
-  summaryEmbedding: FieldValue;
+  summaryEmbedding: VectorValue;
   analyzedAt: number;
   adaCommentId?: string;
   numAiAgreements: number;

--- a/functions-v2/test/ai-analysis-messages-integration.test.ts
+++ b/functions-v2/test/ai-analysis-messages-integration.test.ts
@@ -5,6 +5,7 @@
 import {ZodArray, ZodEnum, ZodString} from "zod";
 import {
   IAiPrompt,
+  RelatedSummary,
   buildImageMessages,
   buildMixedMessages,
   buildSummaryMessages,
@@ -81,6 +82,14 @@ describe("shared/ai-analysis-messages in functions-v2", () => {
       root: "demo", space: "AI", key: "testdoc1", context_id: "class1",
       unit: "vibe", investigation: "1", problem: "1.1", offeringId: "1234",
     };
+    const defaultEmbedding = [0.1, 0.2, 0.3];
+    // Non-empty by default, so an assertion that the built messages carry it is the difference
+    // between covering the builders and covering the wiring from the lookup to them. Every empty
+    // list below is then a claim about that path rather than an artifact of the fixture.
+    const relatedSummary: RelatedSummary = {
+      summary: "A peer's work, found by the lookup.",
+      agreements: {yes: [{content: "Ada said something.", tags: []}]},
+    };
 
     // A CategorizeDeps whose OpenAI client records the request instead of sending it. Everything
     // that would reach Firestore or the network has a default, so a test overrides only what it
@@ -89,8 +98,8 @@ describe("shared/ai-analysis-messages in functions-v2", () => {
       const sent: Record<string, any>[] = [];
       const deps: CategorizeDeps = {
         readDocumentMetadata: jest.fn().mockResolvedValue({metadata: documentMetadata}),
-        getEmbeddings: jest.fn().mockResolvedValue([0.1, 0.2, 0.3]),
-        findRelatedSummaries: jest.fn().mockResolvedValue([]),
+        getEmbeddings: jest.fn().mockResolvedValue(defaultEmbedding),
+        findRelatedSummaries: jest.fn().mockResolvedValue([relatedSummary]),
         createOpenAI: () => ({
           chat: {
             completions: {
@@ -113,7 +122,7 @@ describe("shared/ai-analysis-messages in functions-v2", () => {
         {summary, imageUrl}, "key", "demo/AI/documents/testdoc1", fullPrompt, deps);
 
       expect(result.messageShape).toBe("mixed");
-      expect(sent[0].messages).toEqual(buildMixedMessages(fullPrompt, summary, [], imageUrl));
+      expect(sent[0].messages).toEqual(buildMixedMessages(fullPrompt, summary, [relatedSummary], imageUrl));
       expect(sent[0].model).toBe("gpt-4o-mini");
     });
 
@@ -124,7 +133,7 @@ describe("shared/ai-analysis-messages in functions-v2", () => {
         {summary, imageUrl: null}, "key", "demo/AI/documents/testdoc1", fullPrompt, deps);
 
       expect(result.messageShape).toBe("summary-only");
-      expect(sent[0].messages).toEqual(buildSummaryMessages(fullPrompt, summary, []));
+      expect(sent[0].messages).toEqual(buildSummaryMessages(fullPrompt, summary, [relatedSummary]));
     });
 
     test("an image-only request is both builders at once", async () => {
@@ -251,7 +260,7 @@ describe("shared/ai-analysis-messages in functions-v2", () => {
         {summary, imageUrl}, "key", "demo/AI/documents/testdoc1", fullPrompt, deps);
 
       expect(result.documentMetadata).toEqual(documentMetadata);
-      expect(result.summaryEmbedding).toEqual([0.1, 0.2, 0.3]);
+      expect(result.summaryEmbedding).toEqual(defaultEmbedding);
     });
 
     test("a failed related-summaries lookup does not cost the evaluation", async () => {

--- a/functions-v2/test/ai-analysis-messages-integration.test.ts
+++ b/functions-v2/test/ai-analysis-messages-integration.test.ts
@@ -13,7 +13,7 @@ import {
   defaultAiPrompt,
 } from "../../shared/ai-analysis-messages";
 import * as categorizeDocumentModule from "../lib/src/ai-categorize-document";
-import {CategorizeDeps, categorizeRepresentations} from "../lib/src/ai-categorize-document";
+import {CategorizeDeps, DocumentMetadata, categorizeRepresentations} from "../lib/src/ai-categorize-document";
 
 const fullPrompt: IAiPrompt = {
   systemPrompt: "You are a master teacher.",
@@ -77,11 +77,19 @@ describe("shared/ai-analysis-messages in functions-v2", () => {
   describe("every request shape comes from the shared builders", () => {
     const summary = "A summary of the student's work.";
     const imageUrl = "https://example.com/image.png";
+    const documentMetadata: DocumentMetadata = {
+      root: "demo", space: "AI", key: "testdoc1", context_id: "class1",
+      unit: "vibe", investigation: "1", problem: "1.1", offeringId: "1234",
+    };
 
-    // A CategorizeDeps whose OpenAI client records the request instead of sending it.
+    // A CategorizeDeps whose OpenAI client records the request instead of sending it. Everything
+    // that would reach Firestore or the network has a default, so a test overrides only what it
+    // cares about.
     function recordingDeps(overrides: Partial<CategorizeDeps> = {}) {
       const sent: Record<string, any>[] = [];
       const deps: CategorizeDeps = {
+        readDocumentMetadata: jest.fn().mockResolvedValue(documentMetadata),
+        getEmbeddings: jest.fn().mockResolvedValue([0.1, 0.2, 0.3]),
         findRelatedSummaries: jest.fn().mockResolvedValue([]),
         createOpenAI: () => ({
           chat: {
@@ -135,15 +143,101 @@ describe("shared/ai-analysis-messages in functions-v2", () => {
     test("related summaries are looked up only when a summary is being sent", async () => {
       const {deps} = recordingDeps();
 
-      await categorizeRepresentations(
+      const result = await categorizeRepresentations(
         {summary: null, imageUrl}, "key", "demo/AI/documents/testdoc1", fullPrompt, deps);
 
       expect(deps.findRelatedSummaries).not.toHaveBeenCalled();
+      // An image-only run pays for no embedding and reads no metadata, so it also reports nothing
+      // for the caller to write a summary record from.
+      expect(deps.getEmbeddings).not.toHaveBeenCalled();
+      expect(deps.readDocumentMetadata).not.toHaveBeenCalled();
+      expect(result.summaryEmbedding).toBeUndefined();
+      expect(result.documentMetadata).toBeUndefined();
+    });
+
+    test("the summary is embedded once, and the vector is both searched with and reported", async () => {
+      const embedding = [0.4, 0.5, 0.6];
+      const {deps} = recordingDeps({getEmbeddings: jest.fn().mockResolvedValue(embedding)});
+
+      const result = await categorizeRepresentations(
+        {summary, imageUrl}, "key", "demo/AI/documents/testdoc1", fullPrompt, deps);
+
+      expect(deps.getEmbeddings).toHaveBeenCalledTimes(1);
+      expect(deps.getEmbeddings).toHaveBeenCalledWith(summary, "key");
+      expect(deps.findRelatedSummaries).toHaveBeenCalledWith(documentMetadata, embedding);
+      expect(result.summaryEmbedding).toBe(embedding);
+      expect(result.documentMetadata).toEqual(documentMetadata);
+    });
+
+    test("no embedding means no lookup and no vector to store, and the run still completes", async () => {
+      // getEmbeddings resolves undefined on any OpenAI error. A query vector of undefined throws
+      // from findNearest, and a stored one would persist as a zero-dimension vector.
+      const {deps, sent} = recordingDeps({getEmbeddings: jest.fn().mockResolvedValue(undefined)});
+
+      const result = await categorizeRepresentations(
+        {summary, imageUrl}, "key", "demo/AI/documents/testdoc1", fullPrompt, deps);
+
+      expect(deps.findRelatedSummaries).not.toHaveBeenCalled();
+      expect(result.summaryEmbedding).toBeUndefined();
+      expect(result.completion).toBeDefined();
+      expect(sent[0].messages).toEqual(buildMixedMessages(fullPrompt, summary, [], imageUrl));
+    });
+
+    test("an empty embedding is treated as no embedding", async () => {
+      const {deps} = recordingDeps({getEmbeddings: jest.fn().mockResolvedValue([])});
+
+      const result = await categorizeRepresentations(
+        {summary, imageUrl}, "key", "demo/AI/documents/testdoc1", fullPrompt, deps);
+
+      expect(deps.findRelatedSummaries).not.toHaveBeenCalled();
+      expect(result.summaryEmbedding).toBeUndefined();
+      expect(result.completion).toBeDefined();
+    });
+
+    test("a document with no usable metadata is neither looked up nor embedded", async () => {
+      const {deps, sent} = recordingDeps({readDocumentMetadata: jest.fn().mockResolvedValue(undefined)});
+
+      const result = await categorizeRepresentations(
+        {summary, imageUrl}, "key", "demo/AI/documents/testdoc1", fullPrompt, deps);
+
+      expect(deps.getEmbeddings).not.toHaveBeenCalled();
+      expect(deps.findRelatedSummaries).not.toHaveBeenCalled();
+      expect(result.documentMetadata).toBeUndefined();
+      expect(result.summaryEmbedding).toBeUndefined();
+      expect(result.completion).toBeDefined();
+      expect(sent[0].messages).toEqual(buildMixedMessages(fullPrompt, summary, [], imageUrl));
+    });
+
+    test("a failed metadata read does not cost the evaluation", async () => {
+      const {deps, sent} = recordingDeps({
+        readDocumentMetadata: jest.fn().mockRejectedValue(new Error("Firestore unavailable")),
+      });
+
+      const result = await categorizeRepresentations(
+        {summary, imageUrl}, "key", "demo/AI/documents/testdoc1", fullPrompt, deps);
+
+      expect(result.completion).toBeDefined();
+      expect(result.documentMetadata).toBeUndefined();
+      expect(sent[0].messages).toEqual(buildMixedMessages(fullPrompt, summary, [], imageUrl));
+    });
+
+    test("a failed lookup still reports the metadata and vector for the summary record", async () => {
+      // The record is worth writing even when the search that shares its vector fails: the two are
+      // separate jobs that happen to want the same embedding.
+      const {deps} = recordingDeps({
+        findRelatedSummaries: jest.fn().mockRejectedValue(new Error("vector search unavailable")),
+      });
+
+      const result = await categorizeRepresentations(
+        {summary, imageUrl}, "key", "demo/AI/documents/testdoc1", fullPrompt, deps);
+
+      expect(result.documentMetadata).toEqual(documentMetadata);
+      expect(result.summaryEmbedding).toEqual([0.1, 0.2, 0.3]);
     });
 
     test("a failed related-summaries lookup does not cost the evaluation", async () => {
-      // getEmbeddings resolves undefined on error and FieldValue.vector(undefined) then throws
-      // from inside the lookup, so the whole call can fail, not just the embeddings part.
+      // The vector search can fail on its own — an index that is not ready, Firestore unavailable —
+      // and related summaries are enrichment, so the request goes out without them.
       const {deps, sent} = recordingDeps({
         findRelatedSummaries: jest.fn().mockRejectedValue(new Error("vector search unavailable")),
       });

--- a/functions-v2/test/ai-analysis-messages-integration.test.ts
+++ b/functions-v2/test/ai-analysis-messages-integration.test.ts
@@ -88,7 +88,7 @@ describe("shared/ai-analysis-messages in functions-v2", () => {
     function recordingDeps(overrides: Partial<CategorizeDeps> = {}) {
       const sent: Record<string, any>[] = [];
       const deps: CategorizeDeps = {
-        readDocumentMetadata: jest.fn().mockResolvedValue(documentMetadata),
+        readDocumentMetadata: jest.fn().mockResolvedValue({metadata: documentMetadata}),
         getEmbeddings: jest.fn().mockResolvedValue([0.1, 0.2, 0.3]),
         findRelatedSummaries: jest.fn().mockResolvedValue([]),
         createOpenAI: () => ({
@@ -195,7 +195,9 @@ describe("shared/ai-analysis-messages in functions-v2", () => {
     });
 
     test("a document with no usable metadata is neither looked up nor embedded", async () => {
-      const {deps, sent} = recordingDeps({readDocumentMetadata: jest.fn().mockResolvedValue(undefined)});
+      const {deps, sent} = recordingDeps({
+        readDocumentMetadata: jest.fn().mockResolvedValue({gap: "no-metadata"}),
+      });
 
       const result = await categorizeRepresentations(
         {summary, imageUrl}, "key", "demo/AI/documents/testdoc1", fullPrompt, deps);
@@ -203,9 +205,26 @@ describe("shared/ai-analysis-messages in functions-v2", () => {
       expect(deps.getEmbeddings).not.toHaveBeenCalled();
       expect(deps.findRelatedSummaries).not.toHaveBeenCalled();
       expect(result.documentMetadata).toBeUndefined();
+      expect(result.metadataGap).toBe("no-metadata");
       expect(result.summaryEmbedding).toBeUndefined();
       expect(result.completion).toBeDefined();
       expect(sent[0].messages).toEqual(buildMixedMessages(fullPrompt, summary, [], imageUrl));
+    });
+
+    // A personal document has no class or problem. It is reported apart from an unreadable document
+    // so the run's record can say "nothing to summarize here" rather than "something went wrong".
+    test("a document with no context reports that, not a failure", async () => {
+      const {deps} = recordingDeps({
+        readDocumentMetadata: jest.fn().mockResolvedValue({gap: "no-context"}),
+      });
+
+      const result = await categorizeRepresentations(
+        {summary, imageUrl}, "key", "demo/AI/documents/testdoc1", fullPrompt, deps);
+
+      expect(deps.getEmbeddings).not.toHaveBeenCalled();
+      expect(result.documentMetadata).toBeUndefined();
+      expect(result.metadataGap).toBe("no-context");
+      expect(result.completion).toBeDefined();
     });
 
     test("a failed metadata read does not cost the evaluation", async () => {

--- a/functions-v2/test/on-analysis-document-imaged.test.ts
+++ b/functions-v2/test/on-analysis-document-imaged.test.ts
@@ -5,10 +5,13 @@ import {
 import * as logger from "firebase-functions/logger";
 import {getDatabase} from "firebase-admin/database";
 import * as admin from "firebase-admin";
+import {DocumentReference, FieldValue} from "@google-cloud/firestore";
 import * as dotenv from "dotenv";
 import * as path from "path";
 import {initialize, projectConfig} from "./initialize";
 import {onAnalysisDocumentImaged, representationsOf} from "../src/on-analysis-document-imaged";
+import {onCommentRated} from "../src/on-comment-rated";
+import {getSummaryPath} from "../src/utils";
 import {buildZodResponseSchema, buildImageMessages} from "../lib/src/ai-categorize-document";
 import {ZodArray, ZodEnum, ZodString} from "zod";
 
@@ -44,18 +47,38 @@ const sampleDoc = {
   evaluator: "categorize-design",
 };
 
+// `key` is deliberately not the queue record's `docId`: an older document's metadata id carries a
+// uid or network prefix, and both writers derive the summary's path from `key` instead.
+const documentMetadata = {
+  root: "demo",
+  space: "AI",
+  key: "doc-key-1",
+  context_id: "class1",
+  unit: "vibe",
+  investigation: "1",
+  problem: "1.1",
+  offeringId: "offering-1",
+};
+
 function mockCategorizeResponse({
   parsed,
   usage = {prompt_tokens: 1, completion_tokens: 2},
   refusal,
   messageShape = "image-only",
+  // Absent by default, which is what an image-only run reports.
+  summaryEmbedding,
+  metadata,
 }: {
   parsed?: { category: string, discussion: string, keyIndicators: string[] },
   usage?: { prompt_tokens: number, completion_tokens: number },
   refusal?: string,
   messageShape?: string,
+  summaryEmbedding?: number[],
+  metadata?: typeof documentMetadata,
 }) {
   categorizeRepresentations.mockResolvedValueOnce({
+    summaryEmbedding,
+    documentMetadata: metadata,
     completion: {
       choices: [{
         message: {
@@ -233,6 +256,7 @@ describe("functions", () => {
             promptTokens: 0,
             completionTokens: 0,
             fullResponse: "",
+            summaryRecorded: "no-summary-sent",
           });
         });
       });
@@ -313,6 +337,7 @@ describe("functions", () => {
             promptTokens: 1,
             completionTokens: 2,
             fullResponse: "{\"choices\":[{\"message\":{\"parsed\":{\"category\":\"category\",\"discussion\":\"Discussion.\",\"keyIndicators\":[\"key1\",\"key2\"]}}}],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":2}}",
+            summaryRecorded: "no-summary-sent",
             messageShape: "image-only",
             aiPrompt: {
               mainPrompt: "Main prompt",
@@ -394,6 +419,7 @@ describe("functions", () => {
             promptTokens: 1,
             completionTokens: 2,
             fullResponse: "{\"choices\":[{\"message\":{\"parsed\":{\"category\":\"category\",\"discussion\":\"Discussion.\",\"keyIndicators\":[\"key1\",\"key2\"]}}}],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":2}}",
+            summaryRecorded: "no-summary-sent",
             messageShape: "image-only",
           });
         });
@@ -468,6 +494,7 @@ describe("functions", () => {
             promptTokens: 1,
             completionTokens: 2,
             fullResponse: "{\"choices\":[{\"message\":{\"parsed\":{\"category\":\"unknown\",\"discussion\":\"Discussion.\",\"keyIndicators\":[]}}}],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":2}}",
+            summaryRecorded: "no-summary-sent",
             messageShape: "image-only",
           });
         });
@@ -704,6 +731,297 @@ describe("functions", () => {
         "analysis/queue/imaged/testdoc1", "No response from AI");
       expect(await admin.firestore().collection("analysis/queue/failedAnalyzing").count().get()
         .then((result) => result.data().count)).toEqual(1);
+    });
+  });
+
+  describe("the summary record the run leaves behind", () => {
+    const parsed = {category: "category", discussion: "Discussion.", keyIndicators: []};
+    const embedding = [0.1, 0.2, 0.3];
+    const summaryPath = getSummaryPath(documentMetadata.root, documentMetadata.space, documentMetadata.key);
+    const commentsPath = "demo/AI/documents/testdoc1/comments";
+
+    // The only case that records anything.
+    const summarySent = () => versionTwoDoc({
+      sendSummary: true, docSummary: "The student's work.",
+      sendImage: false, docImageUrl: undefined,
+    });
+
+    async function runImaged(doc: Record<string, unknown>) {
+      await fft.wrap(onAnalysisDocumentImaged)({
+        data: makeDocumentSnapshot(doc, "analysis/queue/imaged/testdoc1"),
+        params: {docId: "testdoc1"},
+      });
+    }
+
+    const readSummary = () => admin.firestore().doc(summaryPath).get();
+
+    const doneRecord = () => admin.firestore().collection("analysis/queue/done").get()
+      .then((snapshot) => snapshot.docs[0]?.data());
+
+    // An agreement of the shape onCommentRated writes.
+    const anAgreement = () => ({
+      "comment-0_student-1": {
+        version: 2, value: "yes", raterUid: "student-1", commentId: "comment-0",
+        commentUid: "ada_insight_1", isAiComment: true, content: "Ada said something.",
+        tags: [], updatedAt: 1_700_000_000_000,
+      },
+    });
+
+    test("a first analysis creates the record with no agreements and both counts at zero", async () => {
+      mockCategorizeResponse({parsed, messageShape: "summary-only", summaryEmbedding: embedding, metadata: documentMetadata});
+
+      await runImaged(summarySent());
+
+      const record = await readSummary();
+      expect(record.exists).toBe(true);
+      expect(record.data()).toEqual({
+        ...documentMetadata,
+        summary: "The student's work.",
+        summaryEmbedding: FieldValue.vector(embedding),
+        analyzedAt: expect.any(Number),
+        adaCommentId: expect.any(String),
+        aiAgreements: {},
+        numAiAgreements: 0,
+        numAgreements: 0,
+      });
+    });
+
+    // `root` and `space` are optional on the Summary type, so nothing in the compiler notices if a
+    // write path drops them. These two tests are the only thing that does.
+    test("the created record says which realm it belongs to", async () => {
+      mockCategorizeResponse({parsed, messageShape: "summary-only", summaryEmbedding: embedding, metadata: documentMetadata});
+
+      await runImaged(summarySent());
+
+      expect(await readSummary().then((record) => record.data())).toMatchObject({root: "demo", space: "AI"});
+    });
+
+    test("a re-analysis adds the realm to a record that predates it", async () => {
+      // A record written before root and space existed, which the realm-scoped lookup cannot match
+      // until an analysis rewrites it.
+      await admin.firestore().doc(summaryPath).set({
+        key: documentMetadata.key, context_id: "class1", unit: "vibe", investigation: "1", problem: "1.1",
+        summary: "An older summary.", numAiAgreements: 1, aiAgreements: anAgreement(),
+      });
+      mockCategorizeResponse({parsed, messageShape: "summary-only", summaryEmbedding: embedding, metadata: documentMetadata});
+
+      await runImaged(summarySent());
+
+      expect(await readSummary().then((record) => record.data())).toMatchObject({root: "demo", space: "AI"});
+    });
+
+    test("a re-analysis refreshes the summary and leaves the agreements alone", async () => {
+      await admin.firestore().doc(summaryPath).set({
+        ...documentMetadata,
+        summary: "An older summary.",
+        summaryEmbedding: FieldValue.vector([0.9, 0.9, 0.9]),
+        analyzedAt: 1_700_000_000_000,
+        adaCommentId: "comment-0",
+        aiAgreements: anAgreement(),
+        numAiAgreements: 1,
+        numAgreements: 1,
+      });
+      mockCategorizeResponse({parsed, messageShape: "summary-only", summaryEmbedding: embedding, metadata: documentMetadata});
+
+      await runImaged(summarySent());
+
+      const data = await readSummary().then((record) => record.data());
+      // Refreshed by this run.
+      expect(data?.summary).toBe("The student's work.");
+      expect(data?.summaryEmbedding).toEqual(FieldValue.vector(embedding));
+      expect(data?.analyzedAt).toBeGreaterThan(1_700_000_000_000);
+      expect(data?.adaCommentId).not.toBe("comment-0");
+      // Left to the people who made them. An older agreement stays attached to the newer summary
+      // text; that drift is accepted, and argued in the design doc.
+      expect(data?.aiAgreements).toEqual(anAgreement());
+      expect(data?.numAiAgreements).toBe(1);
+      expect(data?.numAgreements).toBe(1);
+    });
+
+    test("the summary exists before the comment does", async () => {
+      // Checked at the instant the comment becomes readable, since that is when a rating could
+      // arrive and onCommentRated drops one with no summary. The comment is the only write that
+      // goes through DocumentReference.set — the summary goes through the transaction — so the spy
+      // intercepts the comment and nothing else.
+      mockCategorizeResponse({parsed, messageShape: "summary-only", summaryEmbedding: embedding, metadata: documentMetadata});
+      let summaryExistedWhenCommentWasWritten: boolean | undefined;
+      const realSet = DocumentReference.prototype.set;
+      const spy = jest.spyOn(DocumentReference.prototype, "set")
+        .mockImplementation(async function(this: DocumentReference, ...args: any[]) {
+          // eslint-disable-next-line no-invalid-this, @typescript-eslint/no-this-alias
+          const ref = this; // a method spy is invoked as a method, so `this` is the reference
+          if (ref.path.startsWith(commentsPath)) {
+            summaryExistedWhenCommentWasWritten = (await readSummary()).exists;
+          }
+          return realSet.apply(ref, args as any);
+        });
+
+      try {
+        await runImaged(summarySent());
+      } finally {
+        spy.mockRestore();
+      }
+
+      expect(summaryExistedWhenCommentWasWritten).toBe(true);
+    });
+
+    test("the record names the comment this run created", async () => {
+      mockCategorizeResponse({parsed, messageShape: "summary-only", summaryEmbedding: embedding, metadata: documentMetadata});
+
+      await runImaged(summarySent());
+
+      const comments = await admin.firestore().collection(commentsPath).get();
+      expect(comments.size).toBe(1);
+      expect(await readSummary().then((record) => record.data()?.adaCommentId)).toBe(comments.docs[0].id);
+    });
+
+    // Runs the two writers against each other rather than comparing the helper with itself: the
+    // metadata id is "testdoc1" and the key is "doc-key-1", so either one reaching for a path
+    // segment would miss.
+    test("a rating lands on the record the pipeline wrote", async () => {
+      await admin.firestore().doc("demo/AI/documents/testdoc1").set({key: documentMetadata.key});
+      mockCategorizeResponse({parsed, messageShape: "summary-only", summaryEmbedding: embedding, metadata: documentMetadata});
+
+      await runImaged(summarySent());
+
+      const comment = (await admin.firestore().collection(commentsPath).get()).docs[0];
+      const rated = {...comment.data(), ratings: {"student-1": "yes"}};
+      await comment.ref.set(rated);
+      await fft.wrap(onCommentRated)({
+        data: {before: comment.data(), after: rated},
+        params: {root: "demo", space: "AI", documentId: "testdoc1", commentId: comment.id},
+        time: "2026-09-01T12:00:00.000Z",
+      });
+
+      const data = await readSummary().then((record) => record.data());
+      expect(data?.numAiAgreements).toBe(1);
+      expect(data?.aiAgreements[`${comment.id}_student-1`]).toMatchObject({value: "yes", isAiComment: true});
+    });
+
+    test("a mock run records nothing", async () => {
+      await runImaged({...sampleDoc, evaluator: "mock"});
+
+      expect((await readSummary()).exists).toBe(false);
+      // The student still got their comment.
+      expect(await admin.firestore().collection(commentsPath).count().get()
+        .then((result) => result.data().count)).toBe(1);
+    });
+
+    test("a run that sent no summary records nothing", async () => {
+      // What categorizeRepresentations reports for an image-only run, pinned by its own tests.
+      mockCategorizeResponse({parsed, messageShape: "image-only"});
+
+      await runImaged(versionTwoDoc({
+        sendSummary: false, docSummary: "The student's work.",
+        summaryOmittedReason: "no-student-work-in-summary",
+        sendImage: true, docImageUrl: "https://x/y.png",
+      }));
+
+      expect((await readSummary()).exists).toBe(false);
+      expect(await admin.firestore().collection(commentsPath).count().get()
+        .then((result) => result.data().count)).toBe(1);
+    });
+
+    // An empty array is truthy, so a gate written as `if (summaryEmbedding)` would store a
+    // zero-dimension vector no search can find.
+    test("an empty embedding is not mistaken for a usable one", async () => {
+      mockCategorizeResponse({
+        parsed, messageShape: "summary-only", summaryEmbedding: [], metadata: documentMetadata,
+      });
+
+      await runImaged(summarySent());
+
+      expect((await readSummary()).exists).toBe(false);
+      expect(await doneRecord()).toMatchObject({summaryRecorded: "no-embedding"});
+    });
+
+    test.each([
+      ["created on a first analysis", "created"],
+      ["failed", "failed"],
+    ])("the done record says the summary was %s", async (_label, expected) => {
+      mockCategorizeResponse({
+        parsed, messageShape: "summary-only", summaryEmbedding: embedding, metadata: documentMetadata,
+      });
+      const spy = expected === "failed" ?
+        jest.spyOn(admin.firestore.Firestore.prototype, "runTransaction")
+          .mockRejectedValueOnce(new Error("Firestore unavailable")) :
+        undefined;
+
+      try {
+        await runImaged(summarySent());
+      } finally {
+        spy?.mockRestore();
+      }
+
+      expect(await doneRecord()).toMatchObject({summaryRecorded: expected});
+    });
+
+    test("the done record says a re-analysis refreshed the record", async () => {
+      await admin.firestore().doc(summaryPath).set({
+        ...documentMetadata, summary: "An older summary.",
+        summaryEmbedding: FieldValue.vector([0.9, 0.9, 0.9]), analyzedAt: 1_700_000_000_000,
+        aiAgreements: {}, numAiAgreements: 0, numAgreements: 0,
+      });
+      mockCategorizeResponse({
+        parsed, messageShape: "summary-only", summaryEmbedding: embedding, metadata: documentMetadata,
+      });
+
+      await runImaged(summarySent());
+
+      expect(await doneRecord()).toMatchObject({summaryRecorded: "refreshed"});
+    });
+
+    test("the done record distinguishes a run that sent no summary from one that failed", async () => {
+      mockCategorizeResponse({parsed, messageShape: "image-only"});
+
+      await runImaged(versionTwoDoc({
+        sendSummary: false, docSummary: "The student's work.",
+        summaryOmittedReason: "no-student-work-in-summary",
+        sendImage: true, docImageUrl: "https://x/y.png",
+      }));
+
+      expect(await doneRecord()).toMatchObject({summaryRecorded: "no-summary-sent"});
+    });
+
+    test("the done record names a missing metadata read", async () => {
+      mockCategorizeResponse({parsed, messageShape: "summary-only", summaryEmbedding: embedding});
+
+      await runImaged(summarySent());
+
+      expect((await readSummary()).exists).toBe(false);
+      expect(await doneRecord()).toMatchObject({summaryRecorded: "no-metadata"});
+    });
+
+    test("a run whose summary could not be embedded records nothing", async () => {
+      // getEmbeddings resolves undefined on any OpenAI error.
+      mockCategorizeResponse({parsed, messageShape: "summary-only", metadata: documentMetadata});
+
+      await runImaged(summarySent());
+
+      expect((await readSummary()).exists).toBe(false);
+      expect(await admin.firestore().collection(commentsPath).count().get()
+        .then((result) => result.data().count)).toBe(1);
+    });
+
+    test("a record that cannot be written does not cost the student their comment", async () => {
+      mockCategorizeResponse({parsed, messageShape: "summary-only", summaryEmbedding: embedding, metadata: documentMetadata});
+      const spy = jest.spyOn(admin.firestore.Firestore.prototype, "runTransaction")
+        .mockRejectedValueOnce(new Error("Firestore unavailable"));
+
+      try {
+        await runImaged(summarySent());
+      } finally {
+        spy.mockRestore();
+      }
+
+      expect((await readSummary()).exists).toBe(false);
+      expect(logger.warn).toHaveBeenCalledWith("Could not record the summary; continuing to the comment",
+        "analysis/queue/imaged/testdoc1", expect.any(Error));
+      expect(await admin.firestore().collection(commentsPath).count().get()
+        .then((result) => result.data().count)).toBe(1);
+      // And the run finished: the queue record moved on rather than being left to retry.
+      expect(await admin.firestore().collection("analysis/queue/done").count().get()
+        .then((result) => result.data().count)).toBe(1);
     });
   });
 

--- a/functions-v2/test/on-analysis-document-imaged.test.ts
+++ b/functions-v2/test/on-analysis-document-imaged.test.ts
@@ -789,16 +789,9 @@ describe("functions", () => {
       });
     });
 
-    // `root` and `space` are optional on the Summary type, so nothing in the compiler notices if a
-    // write path drops them. These two tests are the only thing that does.
-    test("the created record says which realm it belongs to", async () => {
-      mockCategorizeResponse({parsed, messageShape: "summary-only", summaryEmbedding: embedding, metadata: documentMetadata});
-
-      await runImaged(summarySent());
-
-      expect(await readSummary().then((record) => record.data())).toMatchObject({root: "demo", space: "AI"});
-    });
-
+    // `root` and `space` are optional on the Summary type, so nothing in the compiler notices if the
+    // update path drops them. This is the only test that does; the create path is covered by the
+    // exact-match assertion above.
     test("a re-analysis adds the realm to a record that predates it", async () => {
       // A record written before root and space existed, which the realm-scoped lookup cannot match
       // until an analysis rewrites it.
@@ -921,6 +914,7 @@ describe("functions", () => {
       }));
 
       expect((await readSummary()).exists).toBe(false);
+      expect(await doneRecord()).toMatchObject({summaryRecorded: "no-summary-sent"});
       expect(await admin.firestore().collection(commentsPath).count().get()
         .then((result) => result.data().count)).toBe(1);
     });
@@ -938,25 +932,14 @@ describe("functions", () => {
       expect(await doneRecord()).toMatchObject({summaryRecorded: "no-embedding"});
     });
 
-    test.each([
-      ["created on a first analysis", "created"],
-      ["failed", "failed"],
-    ])("the done record says the summary was %s", async (_label, expected) => {
+    test("the done record says a first analysis created the record", async () => {
       mockCategorizeResponse({
         parsed, messageShape: "summary-only", summaryEmbedding: embedding, metadata: documentMetadata,
       });
-      const spy = expected === "failed" ?
-        jest.spyOn(admin.firestore.Firestore.prototype, "runTransaction")
-          .mockRejectedValueOnce(new Error("Firestore unavailable")) :
-        undefined;
 
-      try {
-        await runImaged(summarySent());
-      } finally {
-        spy?.mockRestore();
-      }
+      await runImaged(summarySent());
 
-      expect(await doneRecord()).toMatchObject({summaryRecorded: expected});
+      expect(await doneRecord()).toMatchObject({summaryRecorded: "created"});
     });
 
     test("the done record says a re-analysis refreshed the record", async () => {
@@ -972,18 +955,6 @@ describe("functions", () => {
       await runImaged(summarySent());
 
       expect(await doneRecord()).toMatchObject({summaryRecorded: "refreshed"});
-    });
-
-    test("the done record distinguishes a run that sent no summary from one that failed", async () => {
-      mockCategorizeResponse({parsed, messageShape: "image-only"});
-
-      await runImaged(versionTwoDoc({
-        sendSummary: false, docSummary: "The student's work.",
-        summaryOmittedReason: "no-student-work-in-summary",
-        sendImage: true, docImageUrl: "https://x/y.png",
-      }));
-
-      expect(await doneRecord()).toMatchObject({summaryRecorded: "no-summary-sent"});
     });
 
     test("the done record names a missing metadata read", async () => {
@@ -1036,6 +1007,7 @@ describe("functions", () => {
       }
 
       expect((await readSummary()).exists).toBe(false);
+      expect(await doneRecord()).toMatchObject({summaryRecorded: "failed"});
       expect(logger.warn).toHaveBeenCalledWith("Could not record the summary; continuing to the comment",
         "analysis/queue/imaged/testdoc1", expect.any(Error));
       expect(await admin.firestore().collection(commentsPath).count().get()

--- a/functions-v2/test/on-analysis-document-imaged.test.ts
+++ b/functions-v2/test/on-analysis-document-imaged.test.ts
@@ -68,6 +68,7 @@ function mockCategorizeResponse({
   // Absent by default, which is what an image-only run reports.
   summaryEmbedding,
   metadata,
+  metadataGap,
 }: {
   parsed?: { category: string, discussion: string, keyIndicators: string[] },
   usage?: { prompt_tokens: number, completion_tokens: number },
@@ -75,10 +76,12 @@ function mockCategorizeResponse({
   messageShape?: string,
   summaryEmbedding?: number[],
   metadata?: typeof documentMetadata,
+  metadataGap?: string,
 }) {
   categorizeRepresentations.mockResolvedValueOnce({
     summaryEmbedding,
     documentMetadata: metadata,
+    metadataGap,
     completion: {
       choices: [{
         message: {
@@ -984,12 +987,30 @@ describe("functions", () => {
     });
 
     test("the done record names a missing metadata read", async () => {
-      mockCategorizeResponse({parsed, messageShape: "summary-only", summaryEmbedding: embedding});
+      mockCategorizeResponse({
+        parsed, messageShape: "summary-only", summaryEmbedding: embedding, metadataGap: "no-metadata",
+      });
 
       await runImaged(summarySent());
 
       expect((await readSummary()).exists).toBe(false);
       expect(await doneRecord()).toMatchObject({summaryRecorded: "no-metadata"});
+    });
+
+    // A personal document has no class or problem, so it records nothing on every run. Recording
+    // that apart from an unreadable document is what keeps the field worth querying: the ordinary
+    // case does not drown the one worth looking at.
+    test("a document with no context is recorded apart from an unreadable one", async () => {
+      mockCategorizeResponse({
+        parsed, messageShape: "summary-only", summaryEmbedding: embedding, metadataGap: "no-context",
+      });
+
+      await runImaged(summarySent());
+
+      expect((await readSummary()).exists).toBe(false);
+      expect(await doneRecord()).toMatchObject({summaryRecorded: "no-context"});
+      expect(await admin.firestore().collection(commentsPath).count().get()
+        .then((result) => result.data().count)).toBe(1);
     });
 
     test("a run whose summary could not be embedded records nothing", async () => {

--- a/functions-v2/test/related-summaries-emulator.test.ts
+++ b/functions-v2/test/related-summaries-emulator.test.ts
@@ -148,22 +148,23 @@ describe("the related-summaries lookup", () => {
         offeringId: "1234", title: "Not a field the lookup uses",
       });
 
-      expect(await readDocumentMetadata(documentPath)).toEqual(demoMetadata);
+      expect(await readDocumentMetadata(documentPath)).toEqual({metadata: demoMetadata});
     });
 
-    it("returns nothing for a document with incomplete context", async () => {
-      // What a personal document looks like: no class, no problem.
+    // A personal document: no class, no problem. Reported apart from the unreadable cases, because
+    // it is the ordinary state of a whole class of documents rather than something going wrong.
+    it("reports no-context for a document with incomplete context", async () => {
       await writeMetadataDocument({key: "thisdoc", unit: "vibe"});
 
-      expect(await readDocumentMetadata(documentPath)).toBeUndefined();
+      expect(await readDocumentMetadata(documentPath)).toEqual({gap: "no-context"});
     });
 
-    it("returns nothing for a document with no key", async () => {
+    it("reports no-metadata for a document with no key", async () => {
       await writeMetadataDocument({
         context_id: "class1", unit: "vibe", investigation: "1", problem: "1.1",
       });
 
-      expect(await readDocumentMetadata(documentPath)).toBeUndefined();
+      expect(await readDocumentMetadata(documentPath)).toEqual({gap: "no-metadata"});
     });
 
     // `getSummaryPath` escapes the key with a string method, so a non-string throws rather than
@@ -173,23 +174,23 @@ describe("the related-summaries lookup", () => {
       ["an object", {oops: true}],
       ["an array", ["a", "b"]],
       ["a boolean", true],
-    ])("returns nothing when key is %s rather than a string", async (_label, key) => {
+    ])("reports no-metadata when key is %s rather than a string", async (_label, key) => {
       await writeMetadataDocument({
         key, context_id: "class1", unit: "vibe", investigation: "1", problem: "1.1",
       });
 
-      expect(await readDocumentMetadata(documentPath)).toBeUndefined();
+      expect(await readDocumentMetadata(documentPath)).toEqual({gap: "no-metadata"});
       expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("no usable key"));
     });
 
-    it("returns nothing when the document does not exist", async () => {
-      expect(await readDocumentMetadata(documentPath)).toBeUndefined();
+    it("reports no-metadata when the document does not exist", async () => {
+      expect(await readDocumentMetadata(documentPath)).toEqual({gap: "no-metadata"});
       expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("does not exist"));
     });
 
-    it("returns nothing for a path that is not a document path", async () => {
-      expect(await readDocumentMetadata("demo/AI/curriculum/vibe%2F1%2F1%2Fintro")).toBeUndefined();
-      expect(await readDocumentMetadata("demo/AI/documents/testdoc1/comments/c1")).toBeUndefined();
+    it("reports no-metadata for a path that is not a document path", async () => {
+      expect(await readDocumentMetadata("demo/AI/curriculum/vibe%2F1%2F1%2Fintro")).toEqual({gap: "no-metadata"});
+      expect(await readDocumentMetadata("demo/AI/documents/testdoc1/comments/c1")).toEqual({gap: "no-metadata"});
       expect(logger.warn).toHaveBeenCalledTimes(2);
     });
 
@@ -200,7 +201,7 @@ describe("the related-summaries lookup", () => {
         key: "thisdoc", context_id: "class1", unit: "vibe", investigation: "1", problem: "1.1",
       });
 
-      expect(await readDocumentMetadata(documentPath)).toEqual({...demoMetadata, offeringId: ""});
+      expect(await readDocumentMetadata(documentPath)).toEqual({metadata: {...demoMetadata, offeringId: ""}});
     });
   });
 });

--- a/functions-v2/test/related-summaries-emulator.test.ts
+++ b/functions-v2/test/related-summaries-emulator.test.ts
@@ -1,0 +1,206 @@
+import {clearFirestoreData} from "firebase-functions-test/lib/providers/firestore";
+import {FieldValue, Firestore} from "@google-cloud/firestore";
+import * as logger from "firebase-functions/logger";
+import {initialize, projectConfig} from "./initialize";
+import {
+  DocumentMetadata, findRelatedSummaries, readDocumentMetadata,
+} from "../lib/src/ai-categorize-document";
+import {AiAgreementV2} from "../src/summary-types";
+
+jest.mock("firebase-functions/logger");
+
+const {cleanup} = initialize();
+
+const db = new Firestore(projectConfig);
+
+const demoMetadata: DocumentMetadata = {
+  root: "demo",
+  space: "AI",
+  key: "thisdoc",
+  context_id: "class1",
+  unit: "vibe",
+  investigation: "1",
+  problem: "1.1",
+  offeringId: "1234",
+};
+
+function aiRating(): AiAgreementV2 {
+  return {
+    version: 2,
+    value: "yes",
+    raterUid: "student-1",
+    commentId: "comment-1",
+    commentUid: "ada_insight_1",
+    isAiComment: true,
+    content: "Ada said something.",
+    tags: [],
+    updatedAt: 1_700_000_000_000,
+  };
+}
+
+// A stored summary record, with only the fields the lookup filters or reads.
+async function writeSummary(id: string, fields: Partial<DocumentMetadata> & {summary: string}) {
+  await db.doc(`summaries/${id}`).set({
+    ...demoMetadata,
+    ...fields,
+    summaryEmbedding: FieldValue.vector([0.1, 0.2, 0.3]),
+    numAiAgreements: 1,
+    numAgreements: 1,
+    aiAgreements: {"comment-1_student-1": aiRating()},
+    analyzedAt: 1_700_000_000_000,
+  });
+}
+
+function summaryTexts(found: {summary: string}[]) {
+  return found.map((related) => related.summary).sort();
+}
+
+describe("the related-summaries lookup", () => {
+  beforeEach(async () => {
+    await clearFirestoreData(projectConfig);
+    jest.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  describe("findRelatedSummaries", () => {
+    it("returns a record from the same realm with matching context", async () => {
+      await writeSummary("demo-AI-otherdoc", {key: "otherdoc", summary: "A peer's work."});
+
+      const found = await findRelatedSummaries(demoMetadata, [0.1, 0.2, 0.3]);
+
+      expect(summaryTexts(found)).toEqual(["A peer's work."]);
+    });
+
+    // Why realm scoping exists: `summaries` is one flat collection, and the open realms let a
+    // signed-in user author both the context fields and the agreement counts, so without this
+    // filter a record written for testing can reach a production document's prompt.
+    it("does not return a record from another realm whose context fields all match", async () => {
+      await writeSummary("qa-AI-otherdoc", {key: "otherdoc", root: "qa", summary: "A qa realm record."});
+
+      const found = await findRelatedSummaries(demoMetadata, [0.1, 0.2, 0.3]);
+
+      expect(found).toEqual([]);
+    });
+
+    it("does not return a record from another space within the same root", async () => {
+      await writeSummary("demo-OTHER-otherdoc", {key: "otherdoc", space: "OTHER", summary: "Another demo space."});
+
+      const found = await findRelatedSummaries(demoMetadata, [0.1, 0.2, 0.3]);
+
+      expect(found).toEqual([]);
+    });
+
+    // A record predating the realm fields is dropped rather than shared across realms. Its next
+    // analysis rewrites it.
+    it("does not return a record written before root and space existed", async () => {
+      await db.doc("summaries/demo-AI-legacydoc").set({
+        key: "legacydoc",
+        context_id: demoMetadata.context_id,
+        unit: demoMetadata.unit,
+        investigation: demoMetadata.investigation,
+        problem: demoMetadata.problem,
+        summary: "A record with no realm.",
+        summaryEmbedding: FieldValue.vector([0.1, 0.2, 0.3]),
+        numAiAgreements: 1,
+        aiAgreements: {"comment-1_student-1": aiRating()},
+      });
+
+      const found = await findRelatedSummaries(demoMetadata, [0.1, 0.2, 0.3]);
+
+      expect(found).toEqual([]);
+    });
+
+    it("keeps the filters it already had, alongside the realm ones", async () => {
+      await writeSummary("demo-AI-thisdoc", {summary: "This document's own summary."});
+      await writeSummary("demo-AI-otherunit", {key: "otherunit", unit: "mods", summary: "Another unit."});
+      await writeSummary("demo-AI-otherclass", {key: "otherclass", context_id: "class2", summary: "Another class."});
+      await db.doc("summaries/demo-AI-unrated").set({
+        ...demoMetadata,
+        key: "unrated",
+        summary: "Nobody rated this one.",
+        summaryEmbedding: FieldValue.vector([0.1, 0.2, 0.3]),
+        numAiAgreements: 0,
+        numAgreements: 0,
+        aiAgreements: {},
+        analyzedAt: 1_700_000_000_000,
+      });
+      await writeSummary("demo-AI-keeper", {key: "keeper", summary: "The one that qualifies."});
+
+      const found = await findRelatedSummaries(demoMetadata, [0.1, 0.2, 0.3]);
+
+      expect(summaryTexts(found)).toEqual(["The one that qualifies."]);
+    });
+  });
+
+  describe("readDocumentMetadata", () => {
+    const documentPath = "demo/AI/documents/testdoc1";
+
+    async function writeMetadataDocument(fields: Record<string, unknown>) {
+      await db.doc(documentPath).set(fields);
+    }
+
+    it("reads the context fields and takes the realm from the path", async () => {
+      await writeMetadataDocument({
+        key: "thisdoc", context_id: "class1", unit: "vibe", investigation: "1", problem: "1.1",
+        offeringId: "1234", title: "Not a field the lookup uses",
+      });
+
+      expect(await readDocumentMetadata(documentPath)).toEqual(demoMetadata);
+    });
+
+    it("returns nothing for a document with incomplete context", async () => {
+      // What a personal document looks like: no class, no problem.
+      await writeMetadataDocument({key: "thisdoc", unit: "vibe"});
+
+      expect(await readDocumentMetadata(documentPath)).toBeUndefined();
+    });
+
+    it("returns nothing for a document with no key", async () => {
+      await writeMetadataDocument({
+        context_id: "class1", unit: "vibe", investigation: "1", problem: "1.1",
+      });
+
+      expect(await readDocumentMetadata(documentPath)).toBeUndefined();
+    });
+
+    // `getSummaryPath` escapes the key with a string method, so a non-string throws rather than
+    // skips. Clients can write metadata documents directly in the open realms.
+    it.each([
+      ["a number", 12345],
+      ["an object", {oops: true}],
+      ["an array", ["a", "b"]],
+      ["a boolean", true],
+    ])("returns nothing when key is %s rather than a string", async (_label, key) => {
+      await writeMetadataDocument({
+        key, context_id: "class1", unit: "vibe", investigation: "1", problem: "1.1",
+      });
+
+      expect(await readDocumentMetadata(documentPath)).toBeUndefined();
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("no usable key"));
+    });
+
+    it("returns nothing when the document does not exist", async () => {
+      expect(await readDocumentMetadata(documentPath)).toBeUndefined();
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("does not exist"));
+    });
+
+    it("returns nothing for a path that is not a document path", async () => {
+      expect(await readDocumentMetadata("demo/AI/curriculum/vibe%2F1%2F1%2Fintro")).toBeUndefined();
+      expect(await readDocumentMetadata("demo/AI/documents/testdoc1/comments/c1")).toBeUndefined();
+      expect(logger.warn).toHaveBeenCalledTimes(2);
+    });
+
+    // Optional on a metadata document, stored unconditionally on a summary record, and undefined
+    // cannot be written to Firestore.
+    it("substitutes an empty string for a missing offeringId", async () => {
+      await writeMetadataDocument({
+        key: "thisdoc", context_id: "class1", unit: "vibe", investigation: "1", problem: "1.1",
+      });
+
+      expect(await readDocumentMetadata(documentPath)).toEqual({...demoMetadata, offeringId: ""});
+    });
+  });
+});

--- a/functions-v2/test/related-summaries-emulator.test.ts
+++ b/functions-v2/test/related-summaries-emulator.test.ts
@@ -117,6 +117,8 @@ describe("the related-summaries lookup", () => {
       await writeSummary("demo-AI-thisdoc", {summary: "This document's own summary."});
       await writeSummary("demo-AI-otherunit", {key: "otherunit", unit: "mods", summary: "Another unit."});
       await writeSummary("demo-AI-otherclass", {key: "otherclass", context_id: "class2", summary: "Another class."});
+      await writeSummary("demo-AI-otherproblem", {key: "otherproblem", problem: "1.2", summary: "Another problem."});
+      await writeSummary("demo-AI-otherinv", {key: "otherinv", investigation: "2", summary: "Another investigation."});
       await db.doc("summaries/demo-AI-unrated").set({
         ...demoMetadata,
         key: "unrated",

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "clean": "rimraf dist",
     "deploy:database:rules": "firebase deploy --only database",
     "deploy:firestore:rules": "firebase deploy --only firestore:rules",
+    "deploy:firestore:indexes": "firebase deploy --only firestore:indexes",
     "lint": "eslint \"./src/**/*.{js,json,jsx,ts,tsx}\" \"./shared/**/*.{js,json,jsx,ts,tsx}\" \"./cypress/**/*.{js,json,jsx,ts,tsx}\"",
     "lint:build:src": "eslint -c \".eslintrc.build.js\" \"./src/**/*.{js,json,jsx,ts,tsx}\"",
     "lint:build:shared": "eslint -c \".eslintrc.build.js\" \"./shared/**/*.{js,json,jsx,ts,tsx}\"",

--- a/shared/shared.ts
+++ b/shared/shared.ts
@@ -237,6 +237,10 @@ export const kRatingValues = ["yes", "no", "notSure"] as const;
 
 export type RatingValue = typeof kRatingValues[number];
 
+/**
+ * The retired "do you agree with the AI?" flag. Nothing writes it any more; it describes comments
+ * already stored, which `onCommentRated` reads when such a comment is deleted.
+ */
 export interface IAgreeWithAi {
   version: 1;
   value: RatingValue;
@@ -247,7 +251,6 @@ export interface IClientCommentParams {
   content: string;    // plain text for now; potentially html if we need rich text
   tags?: string[];    // list of tags to apply to the comment
   linkedDocumentKey?: string; // Key of the document that this comment should link to
-  agreeWithAi?: IAgreeWithAi; // Whether the comment agrees with the AI's suggestion
 }
 
 export interface IFirestoreMetadataDocumentParams extends IFirebaseFunctionBaseParams {

--- a/src/components/chat/chat-panel.tsx
+++ b/src/components/chat/chat-panel.tsx
@@ -29,7 +29,6 @@ import "./chat-panel.scss";
 interface IPostCommentOptions {
   comment: IClientCommentParams["content"];
   tags?: IClientCommentParams["tags"];
-  agreeWithAi?: IClientCommentParams["agreeWithAi"];
 }
 export type PostCommentFn = (options: IPostCommentOptions) => void;
 
@@ -85,7 +84,7 @@ export const ChatPanel: React.FC<IProps> = observer(({ user, activeNavTab, focus
   const postCommentMutation = usePostDocumentComment();
   const firestore = useFirestore();
 
-  const postComment = useCallback(({ comment, tags, agreeWithAi }: IPostCommentOptions) => {
+  const postComment = useCallback(({ comment, tags }: IPostCommentOptions) => {
     if (focusDocument) {
       const numComments = postedComments ? postedComments.length : 0;
       const focusDocumentId = focusDocument;
@@ -95,14 +94,13 @@ export const ChatPanel: React.FC<IProps> = observer(({ user, activeNavTab, focus
         isFirst: (numComments < 1),
         commentText: comment,
         action: "add",
-        tags,
-        agreeWithAi
+        tags
       };
       logCommentEvent(eventPayload);
     }
     return documentMetadata
       ? postCommentMutation.mutate(
-        { document: documentMetadata, comment: { content: comment, tileId: validFocusTileId, tags, agreeWithAi } })
+        { document: documentMetadata, comment: { content: comment, tileId: validFocusTileId, tags } })
       : undefined;
   }, [documentMetadata, focusDocument, validFocusTileId, postCommentMutation, postedComments]);
 

--- a/src/hooks/document-comment-hooks.ts
+++ b/src/hooks/document-comment-hooks.ts
@@ -145,7 +145,6 @@ export const usePostDocumentComment = (options?: PostDocumentCommentUseMutationO
         createdAt: new Date(),
         tileId: comment.tileId,
         content: comment.content,
-        agreeWithAi: comment.agreeWithAi,
         tags: comment.tags
       };
       // optimistically add the new comment (https://react-query.tanstack.com/guides/optimistic-updates)


### PR DESCRIPTION
[CLUE-645](https://concord-consortium.atlassian.net/browse/CLUE-645)

Track C of `docs/plans/CLUE-645-ratings-to-summaries-implementation.md` — tasks 7 to 11.

## Why

Students rate the AI's comments on their documents, and those ratings are meant to reach later evaluations of similar work. The trigger that records them, `onCommentRated`, is deployed and running in production today — but it only ever adds to an existing `summaries/` record, and nothing created one. Every rating in production has been logged and dropped.

This is the change that creates the records those ratings attach to. It is the last piece of the loop; with it, the related-summaries feature runs end to end.

Depends on `CLUE-371-ai-feedback-text-and-images` (merged) and Track B (merged).

## What changed

**The analysis pipeline writes the summary it evaluated**, in `on-analysis-document-imaged.ts`, **before** it posts the comment. The order is load-bearing: a student can rate a comment the moment it appears, and `onCommentRated` discards a rating whose summary does not exist yet. The comment's id is generated locally without writing anything, so the record can name the comment and still be written first.

The write has two paths, in one transaction:

- **Create** — the full record, with `aiAgreements: {}` and both counts at zero.
- **Update** — only the summary, vector, timestamp and comment id. Agreements and counts are never touched; they belong to the people who made them.

**The related-summaries lookup is confined to one realm.** `summaries` is a single flat collection filtered only on class, unit, problem and investigation, so without `root` and `space` a record written for testing could be returned to a real document whenever those fields coincided. Closing that belongs in this PR because this is what first populates the collection.

**The summary embedding is computed once per run.** It was built inside the lookup and discarded; the record stores the same vector, and asking OpenAI for it twice would be paying twice. The metadata read moved alongside it, since the write needs the fields the lookup was already reading.

**Each run records what became of its summary** on the `done` queue entry — `created`, `refreshed`, `failed`, or which of three reasons it was skipped for — so "did this document get a summary, and if not why not" is a query rather than a log search.

**The client's dead `agreeWithAi` parameter is removed.** Nothing has supplied it since the agree buttons became rating buttons, and no backend reads it now. This is type-only; the type describing stored comments stays, because comments already carry the field.

### Files

| File | Change |
|------|--------|
| `functions-v2/src/on-analysis-document-imaged.ts` | Writes the summary record before the comment; records the outcome |
| `functions-v2/lib/src/ai-categorize-document.ts` | Metadata read and embedding hoisted out of the lookup; realm scoping; widened return |
| `functions-v2/src/summary-types.ts` | `summaryEmbedding` corrected to `VectorValue` |
| `firestore.indexes.json` | `root` and `space` added to the `summaries` composite index |
| `functions-v2/test/…` | 11 pipeline-write cases, 15 lookup cases, 6 categorize cases |
| `src/components/chat/chat-panel.tsx`, `src/hooks/document-comment-hooks.ts`, `shared/shared.ts` | Dead `agreeWithAi` parameter removed |
| `docs/plans/…` | Reconciliation against the merged CLUE-371 code; deployment procedure |

## ⚠️ Deployment — order matters

Full procedure in the plan's **"Deploying Track C"** section. The short version:

1. **List and diff first:** `npx firebase firestore:indexes --project production`. The deploy sends the whole file, not just `summaries`, so check nothing large is about to be built.
2. **Deploy the index and let it build**, before the functions. `npx firebase deploy --only firestore:indexes --project production`
   - **Decline the delete prompt.** It will offer to remove the old `summaries` composite index, which is what serves the *currently deployed* function. Deleting it during the gap between the index deploy and the function deploy breaks the live lookup.
   - **Never `--force`.** Creating an index is cheap and reversible; deleting one is cheap to do and expensive to undo.
3. **Wait for the build.** "deployed indexes successfully" means the request was accepted, not that anything is ready — creation is logged at debug level only.
4. **Then deploy the functions.**

Getting the order wrong **fails quietly, not loudly**: the query returns `FAILED_PRECONDITION`, which the caller catches and continues past, so prompts silently lose their agreement counts. That is easier to miss than a hard failure, which is why the ordering is called out here.

### After deploy, expect the lookup to return nothing for a while

Not a regression. A record needs `root`/`space`, which only this pipeline writes, so every record predating this change is invisible until its document is analyzed again. Then somebody has to rate one of its comments before it qualifies at all. Production holds exactly one summary record today, so nothing meaningful is stranded.

## Testing

| Suite | Before | After |
|---|---|---|
| `functions-v2` | 202 passed / 1 skipped / 21 suites | **240 passed / 1 skipped / 22 suites** |
| root Jest | 4050 passed / 5 skipped / 360 suites | unchanged |

`npm run check:types`, `npx tsc -p functions-v2/tsconfig.json`, and eslint over `functions-v2/src test` are all clean. Chat Cypress specs pass (run locally by the author; Cypress could not start in the dev environment).

Coverage includes: first analysis initializes the counts; re-analysis refreshes the summary and preserves agreements; the summary exists before the comment does; `mock` / `sendSummary: false` / missing embedding each record nothing while the comment is still posted; a failed write costs the student nothing; and a record in another realm is not returned.

Every new guard was checked by breaking the code and confirming the intended test — and only that test — failed: the realm filters, the embedding guard, `root`/`space` on the update path, merge-not-overwrite on re-analysis, and the write ordering.

### Verified against real Firestore

The vector query had never demonstrably run in production, and neither the emulator nor the SDK can say whether its two inequality pre-filters are legal — the emulator does not enforce index requirements, the SDK does no client-side validation, and the docs do not address it. A read-only probe against staging and production settled it:

- **Inequality pre-filters are legal** with `findNearest`. No fallback design is needed.
- **The index in this PR is field-for-field what Firestore asks for.** My hand-written field order was wrong and has been corrected.
- **With the index built, the query runs**, and with realm scoping removed it returns real records — so the vector search, the context filters and both inequality filters all work over live data.

**Not verified:** that `root` and `space` select correctly, because no record anywhere carries them until this pipeline writes one. That is two more equality filters through an index Firestore has already accepted the full query against, so the residual risk is small — but it is inference, not a test, and the first record the pipeline writes is what would settle it.

The realm tests prove the *filter*, not the index entry, since the emulator ignores index definitions.

## Accepted trade-offs

- **Summary drift on re-analysis.** An agreement made against an earlier summary stays attached to the refreshed text. Only per-value counts reach the prompt, never the pairing. Argued in the design doc.
- **No retention or deletion path.** A summary and its 1536-dimension vector persist indefinitely per analyzed document. Deferred deliberately; the schema already stores what either cleanup approach would need.
- **A failed summary write does not fail the run.** The evaluation succeeded and the student is owed its feedback; the outcome is recorded on the `done` entry and the next analysis writes the record again.
- **Records predating this change are excluded** from the lookup until re-analysis.

## Known gaps, deliberately left

- The five context fields other than `key` are not type-checked. Validating them could *lose* matches for a document storing a numeric `problem`, so guessing seemed worse than leaving it.
- A crash between the summary write and the comment write leaves a record naming a comment that was never created.

[CLUE-645]: https://concord-consortium.atlassian.net/browse/CLUE-645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ