### PR TITLE
feat: switch S3 deployment to OIDC authentication (DEV-185)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,19 +183,25 @@ jobs:
       - jest
       - cypress
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      deployments: write
     steps:
       - uses: actions/download-artifact@v4
         with:
           name: build
           path: dist
+      - uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::612297603577:role/collaborative-learning
+          aws-region: us-east-1
       - uses: concord-consortium/s3-deploy-action@v1
         id: s3-deploy
         with:
           build: echo no build
           bucket: models-resources
           prefix: collaborative-learning
-          awsAccessKeyId: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          awsSecretAccessKey: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           deployRunUrl: https://collaborative-learning.concord.org/__deployPath__/?demo
           # Parameters to GHActions have to be strings, so a regular yaml array cannot

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -7,6 +7,12 @@ on:
         required: true
 jobs:
   release:
+    # These permissions are passed through to the called workflow, which cannot have
+    # more than its caller. `id-token: write` is never granted by default.
+    permissions:
+      id-token: write
+      contents: read
+      deployments: write
     uses: ./.github/workflows/release.yml
     with:
       version: ${{ inputs.version }}

--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -7,6 +7,12 @@ on:
         required: true
 jobs:
   release:
+    # These permissions are passed through to the called workflow, which cannot have
+    # more than its caller. `id-token: write` is never granted by default.
+    permissions:
+      id-token: write
+      contents: read
+      deployments: write
     uses: ./.github/workflows/release.yml
     with:
       version: ${{ inputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,10 +26,10 @@ env:
 jobs:
   release:
     runs-on: ubuntu-latest
-    env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_DEFAULT_REGION: us-east-1
+    permissions:
+      id-token: write
+      contents: read
+      deployments: write
     steps:
       - uses: chrnorm/deployment-action@v2
         name: Create GitHub deployment
@@ -39,6 +39,10 @@ jobs:
           environment-url: ${{ inputs.url }}
           environment: ${{ inputs.environment }}
           ref: ${{ inputs.version }}
+      - uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::612297603577:role/collaborative-learning
+          aws-region: us-east-1
       - run: >
           aws s3 cp
           s3://${{ env.BUCKET }}/${{ env.PREFIX }}/version/${{ inputs.version }}/${{ env.SRC_FILE }}

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ For information on how to add a new tile type to the CLUE codebase, see the [Add
 
 Deployments are based on the contents of the /dist folder and are built automatically by GitHub Actions for each branch and tag pushed to GitHub.
 
+S3 deployment is handled by GitHub Actions using OIDC for AWS authentication. See [deploy-setup.md in starter-projects](https://github.com/concord-consortium/starter-projects/blob/main/doc/deploy-setup.md) for how the AWS side is set up, and [docs/deploy.md](docs/deploy.md) for how deploys work in this repo.
+
 Branches are deployed to `https://collaborative-learning.concord.org/branch/<name>/`, where
 `<name>` is the branch name **with any issue-tracker prefix or suffix stripped** — so
 `CLUE-123-my-feature` is served at `/branch/my-feature/`. See [docs/deploy.md](docs/deploy.md)

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -4,6 +4,16 @@ This project is configured to automatically deploy branches and tags to S3. Thes
 
 Deploying to S3 is handled by the [S3 Deploy Action](https://github.com/concord-consortium/s3-deploy-action). Building the `index-top.html` is done by webpack when it receives a `DEPLOY_PATH` environment variable from the S3 Deploy Action.
 
+Pushes are deployed to `models-resources/collaborative-learning/` by the `s3-deploy` job in [`ci.yml`](../.github/workflows/ci.yml). A released version is promoted to the top-level `index.html` (production) or `staging.html` (staging) by [`release.yml`](../.github/workflows/release.yml), which is started by [`release-production.yml`](../.github/workflows/release-production.yml) or [`release-staging.yml`](../.github/workflows/release-staging.yml) via `workflow_dispatch`.
+
+## AWS Access
+
+The GitHub actions in this project are allowed to update files in S3 using OIDC. An IAM role has been created in AWS with a trust policy that allows GitHub actions in this specific repository to assume this IAM role. The IAM role has a `RepoName` tag and a managed policy that uses this tag to give the role's users permission to update files in `models-resources/[RepoName]`.
+
+See [deploy-setup.md in starter-projects](https://github.com/concord-consortium/starter-projects/blob/main/doc/deploy-setup.md) for how the AWS side is set up.
+
+`release.yml` is a reusable workflow, so `release-production.yml` and `release-staging.yml` must each grant `id-token: write`. A called workflow can never have more token permissions than its caller, and GitHub does not grant `id-token: write` by default.
+
 ## Where to find builds
 
 - **branch builds**: when a developer pushes a branch, GitHub actions will build and deploy it to `https://collaborative-learning.concord.org/branch/[branch-name]/`. An issue-tracker prefix or suffix is stripped off and not included in the folder name, so the deployed name is often not the branch's git name. `concord-consortium/s3-deploy-action` (`src/deploy-props.ts`) strips the first of these that matches:


### PR DESCRIPTION
[DEV-185](https://concord-consortium.atlassian.net/browse/DEV-185)

Migrates collaborative-learning's S3 deploy and release workflows off static AWS access keys to OIDC role assumption, per DEV-185.

**Changes:**

- **`ci.yml` (`s3-deploy`)** — added `id-token: write` / `contents: read` / `deployments: write` permissions, added `configure-aws-credentials@v6`, removed the `awsAccessKeyId`/`awsSecretAccessKey` inputs.
- **`release.yml`** — removed the job `env:` block holding `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_DEFAULT_REGION`; added the same three permissions and `configure-aws-credentials@v6` before the `aws s3 cp` steps. `deployments: write` is included because this job also uses `chrnorm/deployment-action`, and adding a `permissions:` block sets every scope not listed to none.
- **`release-production.yml` / `release-staging.yml`** — added the same three permissions to the job that calls `release.yml`. This is the one change beyond the standard migration: `release.yml` is a reusable workflow, a called workflow can never hold more token permissions than its caller, and GitHub never grants `id-token: write` by default. Without this the release job cannot get an OIDC token.
- **docs** — added an "AWS Access" section to the existing `docs/deploy.md` and a deployment note to the README. 

**Follow-up:**

Leave the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` secrets in place until both a CI deploy and a release run have succeeded. Check that no other repository sharing those organization secrets still needs them before removing anything.

[DEV-185]: https://concord-consortium.atlassian.net/browse/DEV-185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ